### PR TITLE
feat(shared-types): add shared-types library with device type definitions

### DIFF
--- a/libs/shared-types/project.json
+++ b/libs/shared-types/project.json
@@ -1,0 +1,23 @@
+{
+  "name": "shared-types",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared-types/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/shared-types",
+        "main": "libs/shared-types/src/index.ts",
+        "tsConfig": "libs/shared-types/tsconfig.lib.json",
+        "assets": []
+      },
+      "configurations": {
+        "production": {},
+        "development": {}
+      }
+    }
+  }
+}

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/device';

--- a/libs/shared-types/src/lib/device.ts
+++ b/libs/shared-types/src/lib/device.ts
@@ -1,0 +1,26 @@
+export interface ExampleInfo {
+  hardware: string;
+  code: string;
+}
+
+export interface ProductInfo {
+  url: string;
+  example: ExampleInfo[];
+  circuit?: string;
+  datasheet?: string;
+  reference?: string;
+  note?: string;
+  spec?: string;
+  instructions?: string;
+  guide?: string;
+}
+
+export interface DeviceInfo {
+  id: string;
+  deviceName: string;
+  tag: 'GPIO' | 'I2C' | 'Other';
+  category: string;
+  description: string;
+  image: string;
+  product: ProductInfo;
+}

--- a/libs/shared-types/tsconfig.json
+++ b/libs/shared-types/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/shared-types/tsconfig.lib.json
+++ b/libs/shared-types/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,9 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
-    "paths": {}
+    "paths": {
+      "@chirimen-device-dashboard/shared-types": ["libs/shared-types/src/index.ts"]
+    }
   },
   "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## Summary

共有型ライブラリ（libs/shared-types）を追加し、フロントエンド・バックエンド間で型を共有できるようにしました。

## Changes

- @nx/js 相当の buildable な shared-types ライブラリを追加
- DeviceInfo, ProductInfo, ExampleInfo インターフェースを定義
- import { DeviceInfo } from '@chirimen-device-dashboard/shared-types' でのインポートを可能に

## Acceptance Criteria

- [x] import { DeviceInfo } from '@chirimen-device-dashboard/shared-types' が可能

Closes #4