### PR TITLE
chore(workspace): add Japanese issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.ja.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.ja.yml
@@ -1,0 +1,91 @@
+name: 🐛 バグ報告
+description: chirimen-device-dashboard の不具合報告
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ありがとうございます！再現可能な情報があると調査が速くなります。
+
+  - type: input
+    id: environment
+    attributes:
+      label: 環境（Nx / Node / pnpm など）
+      description: "例: Nx 22.x, Node 20.x, pnpm 10.x"
+      placeholder: "Nx x.x / Node x.x / pnpm x.x"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: 対象アプリ
+      options:
+        - web (Angular)
+        - api (NestJS)
+        - functions (Firebase)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: ブラウザ / バージョン（web の場合）
+      description: "例: Chrome 120 / Edge 120"
+      placeholder: "Chrome xx / Edge xx / 該当なし"
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "macOS / Windows / Linux"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 何が起きましたか？
+      description: 実際に起きたこと（エラー内容や挙動）
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 再現手順（番号付きで）
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待される動作
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: ログ / エラースタック
+      description: コンソールログ、スタックトレース、スクリーンショット（あれば）を貼ってください
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: チェックリスト
+      options:
+        - label: README の Quick Start を確認しました
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 質問 / Q&A (Discussions)
+    url: https://github.com/gurezo/chirimen-device-dashboard/discussions
+    about: バグ報告・機能要望以外（質問、使い方相談）は Discussions へお願いします
+  - name: 📖 README / ドキュメント
+    url: https://github.com/gurezo/chirimen-device-dashboard#readme
+    about: まずは README（使い方、前提条件）をご確認ください

--- a/.github/ISSUE_TEMPLATE/feature_request.ja.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.ja.yml
@@ -1,0 +1,46 @@
+name: ✨ 機能要望
+description: 機能追加・改善の提案
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        提案ありがとうございます！「何の課題を解決したいか → どうしたいか」を書いてもらえると助かります。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 課題 / 背景
+      description: 解決したい課題・背景（なぜ必要か）
+      placeholder: "今は〜が難しい / 〜ができない、など"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案する解決策
+      description: どういう挙動・API になってほしいか（例コード歓迎）
+      placeholder: |
+        例:
+        - xxx に ○○ オプションを追加したい
+        - xx の戻り値を ○○ にしたい
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 検討した代替案
+      description: 他の代替案（回避策）や既存ライブラリ比較があれば
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: 追加情報
+      description: 参考リンク、ユースケース、実装イメージなど
+    validations:
+      required: false


### PR DESCRIPTION
### 概要:

- 目的: Issue #30 に従い、ISSUE_TEMPLATE を追加する。

### 変更内容:

- .github/ISSUE_TEMPLATE/config.yml を追加（chirimen-device-dashboard 用 URL）
- .github/ISSUE_TEMPLATE/bug_report.ja.yml を追加（日本語・バグ報告）
- .github/ISSUE_TEMPLATE/feature_request.ja.yml を追加（日本語・機能要望）


Fixes #30 

