### PR TITLE
feat(workspace): add Nx dev target with emulators and web proxy

### DIFF
--- a/apps/web/proxy.conf.json
+++ b/apps/web/proxy.conf.json
@@ -1,0 +1,10 @@
+{
+  "/api": {
+    "target": "http://127.0.0.1:5101",
+    "secure": false,
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api": "/chirimen-device-dashboard/us-central1/api/api"
+    }
+  }
+}

--- a/project.json
+++ b/project.json
@@ -6,6 +6,30 @@
       "options": {
         "command": "echo 'Build complete'"
       }
+    },
+    "emulators:start": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "firebase emulators:start --only functions,firestore,storage",
+        "cwd": "."
+      }
+    },
+    "web:serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "nx serve web --proxy-config apps/web/proxy.conf.json",
+        "cwd": "."
+      }
+    },
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "parallel": true,
+        "commands": [
+          { "command": "nx run chirimen-device-dashboard:emulators:start" },
+          { "command": "nx run chirimen-device-dashboard:web:serve" }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Nx コマンドだけで開発環境を起動できるようにする。\`nx run chirimen-device-dashboard:dev\` で 
web（Angular）と Firebase エミュレータ（functions, firestore, storage）を並列起動し、
web から \`/api/**\` を Functions エミュレータへプロキシする。

## Type of change

- [x] New feature

## Related issues

- Fixes #8

## What changed?

- ルート \`project.json\` に \`emulators:start\` / \`web:serve\` / \`dev\` ターゲットを追加（\`nx:run-commands\` 使用）
- \`apps/web/proxy.conf.json\` を追加（\`/api\` → Functions エミュレータ 5101 へプロキシ）

## API / Compatibility

- [x] This change is backward compatible

## How to test

1. \`nx run chirimen-device-dashboard:dev\` を実行
2. web が http://localhost:4200 で起動し、エミュレータが並列で起動することを確認
3. ブラウザで \`http://localhost:4200/api/health\` 等にアクセスし、Functions エミュレータ経由で応答があることを確認

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

---

## 起動フロー（イメージ）

```mermaid
sequenceDiagram
  participant User
  participant Nx as nx run chirimen-device-dashboard:dev
  participant Emulators as firebase emulators
  participant Web as nx serve web (proxy付き)
  participant Browser

  User->>Nx: 起動
  Nx->>Emulators: emulators:start (並列)
  Nx->>Web: web:serve (並列)
  Web->>Browser: http://localhost:4200
  Browser->>Web: GET /api/...
  Web->>Emulators: proxy to :5101/.../api/api/...
  Emulators->>Web: response
  Web->>Browser: response
```

