### PR TITLE
feat(libs-feature-delete-confirm-dialog): add device image to delete confirmation dialog

### DIFF
--- a/libs/devices/feature-delete-confirm-dialog/src/lib/delete-confirm-dialog/delete-confirm-dialog.component.html
+++ b/libs/devices/feature-delete-confirm-dialog/src/lib/delete-confirm-dialog/delete-confirm-dialog.component.html
@@ -1,6 +1,8 @@
 <chirimen-confirm-dialog
   title="削除の確認"
   [message]="message"
+  [imageUrl]="deviceImage"
+  [imageAlt]="deviceName"
   confirmLabel="削除"
   cancelLabel="キャンセル"
   (confirmed)="onConfirm()"

--- a/libs/devices/feature-delete-confirm-dialog/src/lib/delete-confirm-dialog/delete-confirm-dialog.component.spec.ts
+++ b/libs/devices/feature-delete-confirm-dialog/src/lib/delete-confirm-dialog/delete-confirm-dialog.component.spec.ts
@@ -1,9 +1,10 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { DeleteConfirmDialogComponent } from './delete-confirm-dialog.component';
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { provideNoopAnimations } from "@angular/platform-browser/animations";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DeleteConfirmDialogComponent } from "./delete-confirm-dialog.component";
 
-describe('DeleteConfirmDialogComponent', () => {
+describe("DeleteConfirmDialogComponent", () => {
   let component: DeleteConfirmDialogComponent;
   let fixture: ComponentFixture<DeleteConfirmDialogComponent>;
 
@@ -14,11 +15,19 @@ describe('DeleteConfirmDialogComponent', () => {
         provideNoopAnimations(),
         {
           provide: MatDialogRef,
-          useValue: { close: (): void => { return; } },
+          useValue: {
+            close: (): void => {
+              return;
+            },
+          },
         },
         {
           provide: MAT_DIALOG_DATA,
-          useValue: { deviceName: 'Test Device', deviceId: 'test-1' },
+          useValue: {
+            deviceName: "Test Device",
+            deviceId: "test-1",
+            deviceImage: "https://example.com/device.png",
+          },
         },
       ],
     }).compileComponents();
@@ -28,7 +37,14 @@ describe('DeleteConfirmDialogComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should display device image when deviceImage is provided", () => {
+    const img = fixture.nativeElement.querySelector(".confirm-dialog__image");
+    expect(img).toBeTruthy();
+    expect(img.getAttribute("src")).toBe("https://example.com/device.png");
+    expect(img.getAttribute("alt")).toBe("Test Device");
   });
 });

--- a/libs/devices/feature-delete-confirm-dialog/src/lib/delete-confirm-dialog/delete-confirm-dialog.component.ts
+++ b/libs/devices/feature-delete-confirm-dialog/src/lib/delete-confirm-dialog/delete-confirm-dialog.component.ts
@@ -3,41 +3,49 @@ import {
   Component,
   inject,
   Inject,
-} from '@angular/core';
+} from "@angular/core";
 import {
   MAT_DIALOG_DATA,
   MatDialogModule,
   MatDialogRef,
-} from '@angular/material/dialog';
-import { ConfirmDialogComponent } from '@chirimen-device-dashboard/libs-ui';
+} from "@angular/material/dialog";
+import { ConfirmDialogComponent } from "@chirimen-device-dashboard/libs-ui";
 
 export interface DeleteConfirmDialogData {
   deviceName: string;
   deviceId: string;
+  deviceImage?: string;
 }
 
 @Component({
-  selector: 'chirimen-delete-confirm-dialog',
+  selector: "chirimen-delete-confirm-dialog",
   standalone: true,
   imports: [MatDialogModule, ConfirmDialogComponent],
-  templateUrl: './delete-confirm-dialog.component.html',
-  styleUrl: './delete-confirm-dialog.component.scss',
+  templateUrl: "./delete-confirm-dialog.component.html",
+  styleUrl: "./delete-confirm-dialog.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DeleteConfirmDialogComponent {
   private readonly dialogRef = inject(
-    MatDialogRef<DeleteConfirmDialogComponent>
+    MatDialogRef<DeleteConfirmDialogComponent>,
   );
 
   readonly message: string;
+  readonly deviceImage: string | null;
+  readonly deviceName: string;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) data: DeleteConfirmDialogData | undefined
+    @Inject(MAT_DIALOG_DATA) data: DeleteConfirmDialogData | undefined,
   ) {
+    this.deviceName = data?.deviceName ?? "";
     this.message =
       data?.deviceName != null
         ? `「${data.deviceName}」を削除してもよろしいですか？`
-        : '削除してもよろしいですか？';
+        : "削除してもよろしいですか？";
+    this.deviceImage =
+      data?.deviceImage != null && data.deviceImage !== ""
+        ? data.deviceImage
+        : null;
   }
 
   onConfirm(): void {

--- a/libs/devices/feature-list/src/lib/device-list/device-list.component.ts
+++ b/libs/devices/feature-list/src/lib/device-list/device-list.component.ts
@@ -1,28 +1,28 @@
+import { AsyncPipe } from "@angular/common";
 import {
   ChangeDetectionStrategy,
   Component,
   inject,
   OnInit,
   signal,
-} from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTableModule } from '@angular/material/table';
-import { AsyncPipe } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+} from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatDialog, MatDialogModule } from "@angular/material/dialog";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { MatTableModule } from "@angular/material/table";
+import { DeleteConfirmDialogComponent } from "@chirimen-device-dashboard/libs-feature-delete-confirm-dialog";
 import {
   DeviceListStore,
   provideDeviceListStore,
-} from '@chirimen-device-dashboard/libs-state';
-import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
-import { DeleteConfirmDialogComponent } from '@chirimen-device-dashboard/libs-feature-delete-confirm-dialog';
+} from "@chirimen-device-dashboard/libs-state";
+import type { DeviceInfo } from "@chirimen-device-dashboard/shared-types";
 
 @Component({
-  selector: 'chirimen-device-list',
+  selector: "chirimen-device-list",
   standalone: true,
   providers: [provideDeviceListStore()],
   imports: [
@@ -36,8 +36,8 @@ import { DeleteConfirmDialogComponent } from '@chirimen-device-dashboard/libs-fe
     MatProgressSpinnerModule,
     MatTableModule,
   ],
-  templateUrl: './device-list.component.html',
-  styleUrl: './device-list.component.scss',
+  templateUrl: "./device-list.component.html",
+  styleUrl: "./device-list.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DeviceListComponent implements OnInit {
@@ -45,12 +45,12 @@ export class DeviceListComponent implements OnInit {
   private readonly dialog = inject(MatDialog);
 
   readonly displayedColumns: string[] = [
-    'image',
-    'deviceName',
-    'tag',
-    'category',
-    'description',
-    'actions',
+    "image",
+    "deviceName",
+    "tag",
+    "category",
+    "description",
+    "actions",
   ];
 
   readonly filteredDevices$ = this.store.filteredDevices$;
@@ -58,7 +58,7 @@ export class DeviceListComponent implements OnInit {
   readonly error$ = this.store.error$;
 
   /** Two-way binding target for search query (template uses ngModel) */
-  readonly query = signal('');
+  readonly query = signal("");
 
   ngOnInit(): void {
     this.store.loadDevices(undefined as never);
@@ -71,8 +71,12 @@ export class DeviceListComponent implements OnInit {
 
   confirmDelete(device: DeviceInfo): void {
     const dialogRef = this.dialog.open(DeleteConfirmDialogComponent, {
-      data: { deviceName: device.deviceName, deviceId: device.id },
-      width: '400px',
+      data: {
+        deviceName: device.deviceName,
+        deviceId: device.id,
+        deviceImage: device.image,
+      },
+      width: "400px",
     });
     dialogRef.afterClosed().subscribe((confirmed) => {
       if (confirmed) {

--- a/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.html
+++ b/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.html
@@ -1,5 +1,12 @@
 <h2 mat-dialog-title>{{ title() }}</h2>
 <mat-dialog-content>
+  @if (imageUrl()) {
+    <img
+      [src]="imageUrl()"
+      [alt]="imageAlt()"
+      class="confirm-dialog__image"
+    />
+  }
   <p>{{ message() }}</p>
 </mat-dialog-content>
 <mat-dialog-actions align="end">

--- a/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
+++ b/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.scss
@@ -1,3 +1,17 @@
-mat-dialog-content p {
-  margin: 0;
+mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  p {
+    margin: 0;
+  }
+}
+
+.confirm-dialog__image {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 4px;
+  align-self: flex-start;
 }

--- a/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { MatDialogRef } from '@angular/material/dialog';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { ConfirmDialogComponent } from './confirm-dialog.component';
 
 describe('ConfirmDialogComponent', () => {
@@ -26,5 +27,24 @@ describe('ConfirmDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show image when imageUrl is provided', () => {
+    fixture.componentRef.setInput('imageUrl', 'https://example.com/image.png');
+    fixture.componentRef.setInput('imageAlt', 'Test image');
+    fixture.detectChanges();
+
+    const img = fixture.nativeElement.querySelector('.confirm-dialog__image');
+    expect(img).toBeTruthy();
+    expect(img.getAttribute('src')).toBe('https://example.com/image.png');
+    expect(img.getAttribute('alt')).toBe('Test image');
+  });
+
+  it('should not show image when imageUrl is null', () => {
+    fixture.componentRef.setInput('imageUrl', null);
+    fixture.detectChanges();
+
+    const img = fixture.nativeElement.querySelector('.confirm-dialog__image');
+    expect(img).toBeFalsy();
   });
 });

--- a/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/devices/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
@@ -12,6 +12,8 @@ import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 export class ConfirmDialogComponent {
   readonly title = input<string>('確認');
   readonly message = input<string>('実行してもよろしいですか？');
+  readonly imageUrl = input<string | null>(null);
+  readonly imageAlt = input<string>('');
   readonly confirmLabel = input<string>('OK');
   readonly cancelLabel = input<string>('キャンセル');
 


### PR DESCRIPTION
## Summary

削除確認ダイアログにデバイス画像を表示する機能を追加しました。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #63

## What changed?

- \`chirimen-confirm-dialog\` にオプショナルな \`imageUrl\` / \`imageAlt\` 入力を追加
- \`delete-confirm-dialog\` に \`deviceImage\` を渡してデバイス画像を表示
- \`device-list\` の \`confirmDelete\` で \`device.image\` をダイアログに渡す
- spec ファイルに Vitest の明示的インポートを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. アプリを起動してデバイス一覧を表示
2. 任意のデバイスの削除ボタンをクリック
3. 削除確認ダイアログにデバイス画像が表示されることを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant
