### PR TITLE
fix(web): add cache busting for favicon

### DIFF
--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -5,7 +5,7 @@
     <title>web</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico?v=2" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary

favicon にキャッシュバスティング（`?v=2`）を追加し、ブラウザが新しい favicon を確実に取得するようにしました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #68

## What changed?

- `apps/web/src/index.html` の favicon リンクに `?v=2` を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. アプリケーションを起動する
2. ブラウザで http://localhost:4200/ にアクセスする
3. タブに新しい favicon が表示されることを確認する（キャッシュがある場合はハードリロード: Cmd+Shift+R / Ctrl+Shift+R）

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant
