### PR TITLE
fix(web): タブタイトルを CHIRIMEN デバイス一覧に変更

### DIFF
--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>web</title>
+    <title>CHIRIMEN デバイス一覧</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico?v=2" />


### PR DESCRIPTION
## Summary

ブラウザタブのタイトルを「CHIRIMEN デバイス一覧」に変更

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #71

## What changed?

- index.html の title タグを web から CHIRIMEN デバイス一覧に変更

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. localhost:4200 にアクセス
2. タブタイトルが「CHIRIMEN デバイス一覧」であることを確認

## Environment (if relevant)

- Browser:
- OS: macOS
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant