### PR TITLE
feat(libs-feature-list): add hover background color for table rows

### DIFF
--- a/libs/devices/feature-list/src/lib/device-list/device-list.component.scss
+++ b/libs/devices/feature-list/src/lib/device-list/device-list.component.scss
@@ -44,6 +44,18 @@
 
   &__table {
     width: 100%;
+
+    tr.mat-mdc-row:hover,
+    tr.mat-row:hover {
+      background-color: rgba(0, 0, 0, 0.04);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      tr.mat-mdc-row:hover,
+      tr.mat-row:hover {
+        background-color: rgba(255, 255, 255, 0.08);
+      }
+    }
   }
 
   &__thumbnail {


### PR DESCRIPTION
## Summary

デバイスリストのテーブル行にマウスホバー時の背景色を追加する。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #75

## What changed?

- デバイスリストのテーブル行にホバー時の背景色を追加
- ライトモード: rgba(0, 0, 0, 0.04)
- ダークモード: rgba(255, 255, 255, 0.08)

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. nx serve web でアプリを起動
2. デバイスリスト画面でテーブル行にマウスをホバー
3. 背景色が変化することを確認
4. ブラウザの開発者ツールでダークモードを切り替え、両方のテーマで表示を確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)