### PR TITLE
fix: add root tsconfig.json for libs-state module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    { "path": "apps/api" },
+    { "path": "apps/web" },
+    { "path": "apps/web-e2e" },
+    { "path": "libs/devices/state" },
+    { "path": "libs/devices/data-access" },
+    { "path": "libs/devices/ui" },
+    { "path": "libs/devices/card-list" },
+    { "path": "libs/devices/feature-list" },
+    { "path": "libs/devices/feature-create" },
+    { "path": "libs/devices/feature-edit" },
+    { "path": "libs/devices/feature-delete-confirm-dialog" },
+    { "path": "libs/shared-types" }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #78. ルート `tsconfig.json` を追加し、エディタ（Cursor）が `@chirimen-device-dashboard/libs-state` モジュールを正しく解決できるようにする。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #78

## What changed?

- ワークスペースルートに `tsconfig.json` を新規作成
- `tsconfig.base.json` を継承し、全プロジェクトへの `references` を設定
- エディタツールがプロジェクト構造を正しく認識できるようにした

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. Cursor でプロジェクトを開く
2. `@chirimen-device-dashboard/libs-state` をインポートしているファイルでエラーが表示されないことを確認
3. `pnpm run build` でビルドが成功することを確認

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: v24.x
- pnpm version: 10.28.0

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant

Made with [Cursor](https://cursor.com)