### PR TITLE
feat(devices): add libs-feature-detail for device detail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ functions/lib
 .firebase/
 firebase-debug.log
 firebase-debug.*.log
+
+vitest.config.*.timestamp*

--- a/apps/web/src/app/app.routes.ts
+++ b/apps/web/src/app/app.routes.ts
@@ -8,4 +8,11 @@ export const appRoutes: Route[] = [
         (m) => m.DeviceListPageComponent
       ),
   },
+  {
+    path: "devices/:id",
+    loadComponent: () =>
+      import("./pages/device-detail-page/device-detail-page.component").then(
+        (m) => m.DeviceDetailPageComponent
+      ),
+  },
 ];

--- a/apps/web/src/app/pages/device-detail-page/device-detail-page.component.html
+++ b/apps/web/src/app/pages/device-detail-page/device-detail-page.component.html
@@ -1,0 +1,8 @@
+<div class="device-detail-page">
+  <div class="device-detail-page__back">
+    <a mat-button routerLink="/">一覧に戻る</a>
+  </div>
+  @if (deviceId$ | async; as deviceId) {
+    <chirimen-device-detail [deviceId]="deviceId" />
+  }
+</div>

--- a/apps/web/src/app/pages/device-detail-page/device-detail-page.component.scss
+++ b/apps/web/src/app/pages/device-detail-page/device-detail-page.component.scss
@@ -1,0 +1,5 @@
+.device-detail-page {
+  &__back {
+    margin-bottom: 1rem;
+  }
+}

--- a/apps/web/src/app/pages/device-detail-page/device-detail-page.component.ts
+++ b/apps/web/src/app/pages/device-detail-page/device-detail-page.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { map } from "rxjs";
+import { AsyncPipe } from "@angular/common";
+import { DeviceDetailComponent } from "@chirimen-device-dashboard/libs-feature-detail";
+import { MatButtonModule } from "@angular/material/button";
+import { RouterLink } from "@angular/router";
+
+@Component({
+  selector: "app-device-detail-page",
+  standalone: true,
+  imports: [AsyncPipe, DeviceDetailComponent, MatButtonModule, RouterLink],
+  templateUrl: "./device-detail-page.component.html",
+  styleUrl: "./device-detail-page.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DeviceDetailPageComponent {
+  private readonly route = inject(ActivatedRoute);
+
+  readonly deviceId$ = this.route.paramMap.pipe(
+    map((params) => params.get("id") ?? "")
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,12 @@ export default [
   ...nx.configs["flat/typescript"],
   ...nx.configs["flat/javascript"],
   {
-    ignores: ["**/dist", "**/out-tsc", "**/functions/lib"],
+    ignores: [
+      "**/dist",
+      "**/out-tsc",
+      "**/functions/lib",
+      "**/vitest.config.*.timestamp*",
+    ],
   },
   {
     files: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],

--- a/libs/devices/card-list/src/lib/device-card-list/device-card-list.component.html
+++ b/libs/devices/card-list/src/lib/device-card-list/device-card-list.component.html
@@ -10,7 +10,10 @@
   } @else {
     <div class="device-card-list__grid">
       @for (device of filteredDevices$ | async; track device.id) {
-        <div class="device-card-list__card-wrapper">
+        <a
+          class="device-card-list__card-wrapper"
+          [routerLink]="['/devices', device.id]"
+        >
         <mat-card class="device-card-list__card">
           <img
             mat-card-image
@@ -31,7 +34,7 @@
             </p>
           </mat-card-content>
         </mat-card>
-        </div>
+        </a>
       } @empty {
         <div class="device-card-list__empty">デバイスがありません。</div>
       }

--- a/libs/devices/card-list/src/lib/device-card-list/device-card-list.component.scss
+++ b/libs/devices/card-list/src/lib/device-card-list/device-card-list.component.scss
@@ -39,9 +39,12 @@
   }
 
   &__card-wrapper {
+    display: block;
     position: relative;
     height: 100%;
     border-radius: 12px;
+    text-decoration: none;
+    color: inherit;
     overflow: hidden;
     box-shadow:
       0 2px 4px rgba(0, 0, 0, 0.06),

--- a/libs/devices/card-list/src/lib/device-card-list/device-card-list.component.ts
+++ b/libs/devices/card-list/src/lib/device-card-list/device-card-list.component.ts
@@ -4,6 +4,7 @@ import {
   Component,
   inject,
 } from "@angular/core";
+import { RouterLink } from "@angular/router";
 import { MatCardModule } from "@angular/material/card";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { DeviceListStore } from "@chirimen-device-dashboard/libs-state";
@@ -14,6 +15,7 @@ import { TruncatePipe } from "../truncate.pipe";
   standalone: true,
   imports: [
     AsyncPipe,
+    RouterLink,
     MatCardModule,
     MatProgressSpinnerModule,
     TruncatePipe,

--- a/libs/devices/feature-detail/README.md
+++ b/libs/devices/feature-detail/README.md
@@ -1,0 +1,7 @@
+# feature-detail
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test feature-detail` to execute the unit tests.

--- a/libs/devices/feature-detail/eslint.config.mjs
+++ b/libs/devices/feature-detail/eslint.config.mjs
@@ -1,0 +1,34 @@
+import nx from "@nx/eslint-plugin";
+import baseConfig from "../../../eslint.config.mjs";
+
+export default [
+  ...baseConfig,
+  ...nx.configs["flat/angular"],
+  ...nx.configs["flat/angular-template"],
+  {
+    files: ["**/*.ts"],
+    rules: {
+      "@angular-eslint/directive-selector": [
+        "error",
+        {
+          type: "attribute",
+          prefix: "lib",
+          style: "camelCase",
+        },
+      ],
+      "@angular-eslint/component-selector": [
+        "error",
+        {
+          type: "element",
+          prefix: "lib",
+          style: "kebab-case",
+        },
+      ],
+    },
+  },
+  {
+    files: ["**/*.html"],
+    // Override or add rules here
+    rules: {},
+  },
+];

--- a/libs/devices/feature-detail/project.json
+++ b/libs/devices/feature-detail/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "feature-detail",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/devices/feature-detail/src",
+  "prefix": "lib",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "../../../coverage/libs/devices/feature-detail"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/devices/feature-detail/src/index.ts
+++ b/libs/devices/feature-detail/src/index.ts
@@ -1,0 +1,1 @@
+export { DeviceDetailComponent } from "./lib/device-detail/device-detail.component";

--- a/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.html
+++ b/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.html
@@ -1,0 +1,100 @@
+<div class="device-detail">
+  @switch ((device$ | async) ?? undefined) {
+    @case (undefined) {
+      <div class="device-detail__loading">
+        <mat-spinner diameter="40"></mat-spinner>
+        <p class="device-detail__loading-text">読み込み中...</p>
+      </div>
+    }
+    @case (null) {
+      <div class="device-detail__not-found">
+        <p>デバイスが見つかりませんでした。</p>
+      </div>
+    }
+    @default {
+      @let device = $value;
+      <div class="device-detail__content">
+      <div class="device-detail__image-section">
+        <img
+          [src]="device.image"
+          [alt]="device.deviceName"
+          class="device-detail__image"
+        />
+      </div>
+      <div class="device-detail__info-section">
+        <h1 class="device-detail__title">{{ device.deviceName }}</h1>
+        <div class="device-detail__meta">
+          <span class="device-detail__tag">{{ device.tag }}</span>
+          <span class="device-detail__category">{{ device.category }}</span>
+        </div>
+        <p class="device-detail__description">{{ device.description }}</p>
+
+        @if (device.product) {
+          <div class="device-detail__product">
+            <h2 class="device-detail__product-title">製品情報</h2>
+            <ul class="device-detail__links">
+              @if (device.product.url) {
+                <li>
+                  <a [href]="device.product.url" target="_blank" rel="noopener noreferrer">
+                    購入リンク
+                  </a>
+                </li>
+              }
+              @if (device.product.circuit) {
+                <li>
+                  <a [href]="device.product.circuit" target="_blank" rel="noopener noreferrer">
+                    回路図
+                  </a>
+                </li>
+              }
+              @if (device.product.datasheet) {
+                <li>
+                  <a [href]="device.product.datasheet" target="_blank" rel="noopener noreferrer">
+                    データシート
+                  </a>
+                </li>
+              }
+              @if (device.product.reference) {
+                <li>
+                  <a [href]="device.product.reference" target="_blank" rel="noopener noreferrer">
+                    リファレンス
+                  </a>
+                </li>
+              }
+              @if (device.product.guide) {
+                <li>
+                  <a [href]="device.product.guide" target="_blank" rel="noopener noreferrer">
+                    ガイド
+                  </a>
+                </li>
+              }
+            </ul>
+            @if (device.product.note) {
+              <p class="device-detail__note">{{ device.product.note }}</p>
+            }
+            @if (device.product.spec) {
+              <p class="device-detail__spec">{{ device.product.spec }}</p>
+            }
+            @if (device.product.instructions) {
+              <p class="device-detail__instructions">{{ device.product.instructions }}</p>
+            }
+            @if (device.product.example?.length) {
+              <div class="device-detail__examples">
+                <h3 class="device-detail__examples-title">使用例</h3>
+                @for (ex of device.product.example; track ex.hardware) {
+                  <div class="device-detail__example">
+                    <span class="device-detail__example-hardware">{{ ex.hardware }}</span>
+                    @if (ex.code) {
+                      <pre class="device-detail__example-code">{{ ex.code }}</pre>
+                    }
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+    }
+  }
+</div>

--- a/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.scss
+++ b/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.scss
@@ -1,0 +1,183 @@
+:host {
+  display: block;
+}
+
+.device-detail {
+  padding: 1.5rem;
+  max-width: 960px;
+  margin: 0 auto;
+
+  &__content {
+    display: grid;
+    grid-template-columns: 1fr 1.5fr;
+    gap: 2rem;
+    align-items: start;
+
+    @media (max-width: 768px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &__image-section {
+    position: sticky;
+    top: 1rem;
+  }
+
+  &__image {
+    width: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  &__info-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+  }
+
+  &__meta {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+  }
+
+  &__tag {
+    display: inline-block;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    background-color: rgba(0, 0, 0, 0.08);
+    border-radius: 4px;
+
+    @media (prefers-color-scheme: dark) {
+      background-color: rgba(255, 255, 255, 0.12);
+    }
+  }
+
+  &__category {
+    font-size: 0.875rem;
+    color: rgba(0, 0, 0, 0.6);
+
+    @media (prefers-color-scheme: dark) {
+      color: rgba(255, 255, 255, 0.6);
+    }
+  }
+
+  &__description {
+    margin: 0;
+    line-height: 1.6;
+  }
+
+  &__product {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+
+    @media (prefers-color-scheme: dark) {
+      border-top-color: rgba(255, 255, 255, 0.12);
+    }
+  }
+
+  &__product-title {
+    margin: 0 0 0.75rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+  }
+
+  &__links {
+    margin: 0 0 1rem;
+    padding-left: 1.25rem;
+
+    li {
+      margin-bottom: 0.5rem;
+    }
+
+    a {
+      color: var(--mat-primary-default, #1976d2);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  &__note,
+  &__spec,
+  &__instructions {
+    margin: 0 0 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+  }
+
+  &__examples {
+    margin-top: 1rem;
+  }
+
+  &__examples-title {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  &__example {
+    margin-bottom: 1rem;
+    padding: 0.75rem;
+    background-color: rgba(0, 0, 0, 0.04);
+    border-radius: 4px;
+
+    @media (prefers-color-scheme: dark) {
+      background-color: rgba(255, 255, 255, 0.08);
+    }
+  }
+
+  &__example-hardware {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+  }
+
+  &__example-code {
+    margin: 0;
+    font-size: 0.8125rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  &__loading,
+  &__not-found {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    gap: 1rem;
+  }
+
+  &__loading-text {
+    margin: 0;
+    color: rgba(0, 0, 0, 0.6);
+
+    @media (prefers-color-scheme: dark) {
+      color: rgba(255, 255, 255, 0.6);
+    }
+  }
+
+  &__not-found p {
+    margin: 0;
+    color: rgba(0, 0, 0, 0.6);
+
+    @media (prefers-color-scheme: dark) {
+      color: rgba(255, 255, 255, 0.6);
+    }
+  }
+}

--- a/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.spec.ts
+++ b/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { provideNoopAnimations } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
+import { provideDeviceRepository } from "@chirimen-device-dashboard/libs-data-access";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DeviceDetailComponent } from "./device-detail.component";
+
+describe("DeviceDetailComponent", () => {
+  let fixture: ComponentFixture<DeviceDetailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeviceDetailComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        provideDeviceRepository(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeviceDetailComponent);
+    fixture.componentRef.setInput("deviceId", "test-device-1");
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});

--- a/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.ts
+++ b/libs/devices/feature-detail/src/lib/device-detail/device-detail.component.ts
@@ -1,0 +1,36 @@
+import { AsyncPipe } from "@angular/common";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  input,
+} from "@angular/core";
+import { toObservable } from "@angular/core/rxjs-interop";
+import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { RouterLink } from "@angular/router";
+import { switchMap, of, catchError, startWith } from "rxjs";
+import type { DeviceInfo } from "@chirimen-device-dashboard/shared-types";
+import { DEVICE_REPOSITORY } from "@chirimen-device-dashboard/libs-data-access";
+
+@Component({
+  selector: "chirimen-device-detail",
+  standalone: true,
+  imports: [AsyncPipe, MatProgressSpinnerModule, RouterLink],
+  templateUrl: "./device-detail.component.html",
+  styleUrl: "./device-detail.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DeviceDetailComponent {
+  private readonly repository = inject(DEVICE_REPOSITORY);
+
+  readonly deviceId = input.required<string>();
+
+  readonly device$ = toObservable(this.deviceId).pipe(
+    switchMap((id) =>
+      this.repository.get(id).pipe(
+        startWith(undefined as DeviceInfo | null | undefined),
+        catchError(() => of(null))
+      )
+    )
+  );
+}

--- a/libs/devices/feature-detail/src/test-setup.ts
+++ b/libs/devices/feature-detail/src/test-setup.ts
@@ -1,0 +1,5 @@
+import "@angular/compiler";
+import "@analogjs/vitest-angular/setup-snapshots";
+import { setupTestBed } from "@analogjs/vitest-angular/setup-testbed";
+
+setupTestBed();

--- a/libs/devices/feature-detail/tsconfig.json
+++ b/libs/devices/feature-detail/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "emitDecoratorMetadata": false,
+    "module": "preserve"
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/devices/feature-detail/tsconfig.lib.json
+++ b/libs/devices/feature-detail/tsconfig.lib.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/test-setup.ts"
+  ]
+}

--- a/libs/devices/feature-detail/tsconfig.spec.json
+++ b/libs/devices/feature-detail/tsconfig.spec.json
@@ -1,0 +1,29 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ],
+  "files": ["src/test-setup.ts"]
+}

--- a/libs/devices/feature-detail/vite.config.mts
+++ b/libs/devices/feature-detail/vite.config.mts
@@ -1,0 +1,28 @@
+/// <reference types='vitest' />
+import { defineConfig } from "vite";
+import angular from "@analogjs/vite-plugin-angular";
+import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
+import { nxCopyAssetsPlugin } from "@nx/vite/plugins/nx-copy-assets.plugin";
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: "../../../node_modules/.vite/libs/devices/feature-detail",
+  plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(["*.md"])],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //   plugins: () => [ nxViteTsPaths() ],
+  // },
+  test: {
+    name: "feature-detail",
+    watch: false,
+    globals: true,
+    environment: "jsdom",
+    include: ["{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+    setupFiles: ["src/test-setup.ts"],
+    reporters: ["default"],
+    coverage: {
+      reportsDirectory: "../../../coverage/libs/devices/feature-detail",
+      provider: "v8" as const,
+    },
+  },
+}));

--- a/libs/devices/feature-list/src/lib/device-list/device-list.component.html
+++ b/libs/devices/feature-list/src/lib/device-list/device-list.component.html
@@ -42,7 +42,12 @@
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: displayedColumns"
+          [routerLink]="['/devices', row.id]"
+          class="device-list__row-link"
+        ></tr>
 
         <tr class="mat-row" *matNoDataRow>
           <td class="mat-cell" [attr.colspan]="displayedColumns.length">

--- a/libs/devices/feature-list/src/lib/device-list/device-list.component.scss
+++ b/libs/devices/feature-list/src/lib/device-list/device-list.component.scss
@@ -54,4 +54,8 @@
     object-fit: cover;
     border-radius: 4px;
   }
+
+  &__row-link {
+    cursor: pointer;
+  }
 }

--- a/libs/devices/feature-list/src/lib/device-list/device-list.component.ts
+++ b/libs/devices/feature-list/src/lib/device-list/device-list.component.ts
@@ -5,6 +5,7 @@ import {
   inject,
 } from "@angular/core";
 import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
+import { RouterLink } from "@angular/router";
 import { MatTableModule } from "@angular/material/table";
 import { DeviceListStore } from "@chirimen-device-dashboard/libs-state";
 
@@ -14,6 +15,7 @@ import { DeviceListStore } from "@chirimen-device-dashboard/libs-state";
   imports: [
     AsyncPipe,
     MatProgressSpinnerModule,
+    RouterLink,
     MatTableModule,
   ],
   templateUrl: "./device-list.component.html",

--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,9 @@
     "production": [
       "default",
       "!{projectRoot}/.eslintrc.json",
-      "!{projectRoot}/eslint.config.mjs"
+      "!{projectRoot}/eslint.config.mjs",
+      "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
+      "!{projectRoot}/tsconfig.spec.json"
     ],
     "sharedGlobals": []
   },
@@ -28,11 +30,22 @@
     "@angular/build:unit-test": {
       "cache": true,
       "inputs": ["default", "^production"],
-      "options": { "watch": false }
+      "options": {
+        "watch": false
+      }
+    },
+    "@nx/vitest:test": {
+      "cache": true,
+      "inputs": ["default", "^production"]
     }
   },
   "plugins": [
-    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    },
     {
       "plugin": "@nx/webpack/plugin",
       "options": {
@@ -51,6 +64,13 @@
       "linter": "eslint",
       "style": "scss",
       "unitTestRunner": "vitest-angular"
+    },
+    "@nx/angular:library": {
+      "linter": "eslint",
+      "unitTestRunner": "vitest-analog"
+    },
+    "@nx/angular:component": {
+      "style": "scss"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "packageManager": "pnpm@10.28.0",
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^2.2.3",
+    "@analogjs/vitest-angular": "~2.1.2",
     "@angular-devkit/core": "~21.1.0",
     "@angular-devkit/schematics": "~21.1.0",
     "@angular/build": "~21.1.0",
@@ -38,6 +39,8 @@
     "@nx/nest": "22.5.1",
     "@nx/node": "22.5.1",
     "@nx/playwright": "22.5.1",
+    "@nx/vite": "22.5.1",
+    "@nx/vitest": "22.5.1",
     "@nx/web": "22.5.1",
     "@nx/webpack": "22.5.1",
     "@nx/workspace": "22.5.1",
@@ -48,6 +51,8 @@
     "@swc/helpers": "0.5.18",
     "@types/node": "20.19.9",
     "@typescript-eslint/utils": "^8.40.0",
+    "@vitest/coverage-v8": "^4.0.0",
+    "@vitest/ui": "^4.0.8",
     "angular-eslint": "^21.0.1",
     "autoprefixer": "^10.4.0",
     "eslint": "^9.8.0",
@@ -63,6 +68,7 @@
     "tslib": "^2.3.0",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.40.0",
+    "vite": "^7.0.0",
     "vitest": "^4.0.8",
     "webpack-cli": "^5.1.4"
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,9 @@
       "@chirimen-device-dashboard/api/*": ["apps/api/src/*"],
       "@chirimen-device-dashboard/libs-card-list": [
         "libs/devices/card-list/src/index.ts"
+      ],
+      "@chirimen-device-dashboard/libs-feature-detail": [
+        "libs/devices/feature-detail/src/index.ts"
       ]
     }
   },

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,4 @@
+export default [
+  "**/vite.config.{mjs,js,ts,mts}",
+  "**/vitest.config.{mjs,js,ts,mts}",
+];


### PR DESCRIPTION
## Summary

Add libs-feature-detail library for Device detail screen as specified in #90. Implements the Device detail view from #85 with DeviceInfo and ProductInfo display.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #90
- Relates to #85

## What changed?

- Added `libs/devices/feature-detail` library with `DeviceDetailComponent`
- `DeviceDetailComponent` displays DeviceInfo (name, tag, category, description, image) and ProductInfo (url, circuit, datasheet, reference, guide, note, spec, instructions, examples)
- Added `device-detail-page` and route `/devices/:id`
- Added navigation links from card list and table list to detail view

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. Run `pnpm install` and `pnpm run serve`
2. Navigate to the device list
3. Click a device card or table row to open the detail view
4. Verify DeviceInfo and ProductInfo are displayed correctly

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)