### PR TITLE
fix(libs-device-detail): render spec and instructions as links when URL

### DIFF
--- a/libs/devices/device-detail/src/lib/product-info/product-info.component.html
+++ b/libs/devices/device-detail/src/lib/product-info/product-info.component.html
@@ -49,14 +49,26 @@
   @if (product().spec) {
     <div class="product-info__section">
       <h3 class="product-info__heading">仕様</h3>
-      <p class="product-info__text">{{ product().spec }}</p>
+      @if (isUrl(product().spec!)) {
+        <a [href]="product().spec" target="_blank" rel="noopener noreferrer" class="product-info__link">
+          {{ product().spec }}
+        </a>
+      } @else {
+        <p class="product-info__text">{{ product().spec }}</p>
+      }
     </div>
   }
 
   @if (product().instructions) {
     <div class="product-info__section">
       <h3 class="product-info__heading">使用方法</h3>
-      <p class="product-info__text">{{ product().instructions }}</p>
+      @if (isUrl(product().instructions!)) {
+        <a [href]="product().instructions" target="_blank" rel="noopener noreferrer" class="product-info__link">
+          {{ product().instructions }}
+        </a>
+      } @else {
+        <p class="product-info__text">{{ product().instructions }}</p>
+      }
     </div>
   }
 

--- a/libs/devices/device-detail/src/lib/product-info/product-info.component.ts
+++ b/libs/devices/device-detail/src/lib/product-info/product-info.component.ts
@@ -18,4 +18,8 @@ import { ExampleInfoComponent } from '../example-info/example-info.component';
 })
 export class ProductInfoComponent {
   readonly product = input.required<ProductInfo>();
+
+  protected isUrl(value: string): boolean {
+    return value.startsWith('http://') || value.startsWith('https://');
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #93. chirimen-product-info 内の「仕様」「使用方法」フィールドに PDF URL が含まれる場合、プレーンテキストではなくクリック可能なリンクとして表示し、別タブで開くようにしました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #93

## What changed?

- product-info コンポーネントに `isUrl()` ヘルパーメソッドを追加
- spec / instructions が URL（http:// または https:// で始まる）の場合、`<a>` タグでリンクとして表示
- URL でない場合は従来通り `<p>` でプレーンテキスト表示（後方互換）

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. https://chirimen-device-dashboard.web.app にアクセス
2. 任意のデバイスをクリック（例: i2c-mpu9250）
3. 「仕様」「使用方法」セクションの PDF URL がリンクとして表示され、クリックで別タブで開くことを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant
