### PR TITLE
fix(libs-feature-list): prevent header text wrap in image column

### DIFF
--- a/apps/web/src/styles.scss
+++ b/apps/web/src/styles.scss
@@ -33,6 +33,30 @@ body {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
+/* 列幅とヘッダ折り返し防止 */
+.device-list-table {
+  .mat-mdc-header-cell,
+  .mat-header-cell {
+    white-space: nowrap;
+  }
+  .mat-column-image {
+    width: 4rem; /* 画像 w-12 (48px) 用 */
+    min-width: 4rem;
+  }
+  .mat-column-deviceName {
+    min-width: 8rem;
+  }
+  .mat-column-tag {
+    min-width: 6rem;
+  }
+  .mat-column-category {
+    min-width: 6rem;
+  }
+  .mat-column-description {
+    min-width: 10rem;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   .device-list-table tr.mat-mdc-row:hover,
   .device-list-table tr.mat-row:hover {


### PR DESCRIPTION
## Summary

デバイスリストのヘッダ「イメージ」の文字が折り返すバグを修正しました。列幅と min-width を指定し、ヘッダセルに white-space: nowrap を適用しています。

## Type of change

- [x] Bug fix

## Related issues

- Fixes #106

## What changed?

- apps/web/src/styles.scss に .device-list-table の列幅スタイルを追加
- ヘッダセルに white-space: nowrap を適用して折り返しを防止

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. pnpm nx serve web でアプリを起動
2. デバイスリスト画面を表示
3. ヘッダ「イメージ」が1行で表示されることを確認

## Environment (if relevant)

- Browser:
- OS: macOS
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant

Made with [Cursor](https://cursor.com)