### PR TITLE
docs(shared-types): add comments to device interfaces

### DIFF
--- a/libs/shared-types/src/lib/device.ts
+++ b/libs/shared-types/src/lib/device.ts
@@ -1,26 +1,26 @@
 export interface ExampleInfo {
-  hardware: string;
-  code: string;
+  hardware: string; // Raspbery Pi 3/4/5, Pi Zero, microbit
+  code: string; // サンプルコードURL
 }
 
 export interface ProductInfo {
-  url: string;
-  example: ExampleInfo[];
-  circuit?: string;
-  datasheet?: string;
-  reference?: string;
-  note?: string;
-  spec?: string;
-  instructions?: string;
-  guide?: string;
+  url: string; // 商品URL
+  example: ExampleInfo[]; // サンプルコード情報配列
+  circuit?: string; // 回路図URL
+  datasheet?: string; // データシートURL
+  reference?: string; // 製造元資料URL
+  note?: string; // アプリケーションノートURL
+  spec?: string; // 仕様書URL
+  instructions?: string; // 説明書URL
+  guide?: string; // 説明書URL
 }
 
 export interface DeviceInfo {
   id: string;
-  deviceName: string;
+  deviceName: string; // 型番 ADS1015
   tag: 'GPIO' | 'I2C' | 'Analog' | 'Actuator' | 'Other' | 'BoardComputer';
-  category: string;
-  description: string;
-  image: string;
-  product: ProductInfo;
+  category: string; // ADC(アナログ電圧測定) / サーモグラフィ / Other
+  description: string; // 説明
+  image: string; // 画像URL
+  product: ProductInfo; // 商品情報
 }


### PR DESCRIPTION
## Summary

libs/shared-types/src/lib/device.ts の ExampleInfo、ProductInfo、DeviceInfo インターフェースに各プロパティの説明コメントを追加しました。

## Type of change

- [x] Documentation

## Related issues

- Fixes #108

## What changed?

- ExampleInfo の hardware, code にコメントを追加
- ProductInfo の url, example, circuit, datasheet, reference, note, spec, instructions, guide にコメントを追加
- DeviceInfo の deviceName, tag, category, description, image, product にコメントを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible

## How to test

1. libs/shared-types のビルドが成功することを確認
2. 型定義を参照している箇所で型エラーが発生しないことを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant
