### PR TITLE
docs: update README with workspace structure and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,155 @@
 # chirimen-device-dashboard
 
-This project was generated using [Nx](https://nx.dev).
+CHIRIMEN デバイス一覧のダッシュボード。Nx モノレポで構成されています。
+
+## chirimen-device-dashboard Nx ワークスペース構造
+
+### ディレクトリ構造
+
+```mermaid
+flowchart TB
+    subgraph root["chirimen-device-dashboard (root)"]
+        direction TB
+    end
+
+    subgraph apps["apps/"]
+        web["web (Angular SPA)"]
+        api["api (NestJS API)"]
+        webE2e["web-e2e (Playwright E2E)"]
+        apiE2e["api-e2e (Jest E2E)"]
+    end
+
+    subgraph libs["libs/"]
+        sharedTypes["shared-types (共有型定義)"]
+        subgraph devices["devices/"]
+            dataAccess["data-access (データアクセス層)"]
+            stateLib["state (状態管理)"]
+            featureList["feature-list (デバイス一覧)"]
+            cardList["card-list (カード一覧)"]
+            deviceDetail["device-detail (デバイス詳細)"]
+        end
+    end
+
+    subgraph other["その他"]
+        functionsNode["functions (Firebase Cloud Functions)"]
+    end
+
+    root --> apps
+    root --> libs
+    root --> other
+```
+
+### プロジェクト依存関係グラフ
+
+```mermaid
+flowchart LR
+    subgraph apps["Applications"]
+        web["web"]
+        api["api"]
+        webE2e["web-e2e"]
+        apiE2e["api-e2e"]
+    end
+
+    subgraph libs["Libraries"]
+        sharedTypes["shared-types"]
+        dataAccess["libs-data-access"]
+        stateLib["libs-state"]
+        featureList["libs-feature-list"]
+        cardList["libs-card-list"]
+        deviceDetail["libs-device-detail"]
+    end
+
+    subgraph funcs["Functions"]
+        functionsNode["functions"]
+    end
+
+    sharedTypes --> dataAccess
+    sharedTypes --> stateLib
+    sharedTypes --> api
+    sharedTypes --> deviceDetail
+
+    dataAccess --> stateLib
+
+    stateLib --> featureList
+    stateLib --> cardList
+    dataAccess --> cardList
+    dataAccess --> deviceDetail
+
+    web --> dataAccess
+    web --> stateLib
+    web --> featureList
+    web --> cardList
+    web --> deviceDetail
+
+    webE2e -.->|implicit| web
+    apiE2e -.->|implicit| api
+
+    functionsNode --> api
+```
+
+### レイヤー別アーキテクチャ
+
+```mermaid
+flowchart TB
+    subgraph presentation["Presentation Layer"]
+        web["web (Angular)"]
+    end
+
+    subgraph feature["Feature Layer"]
+        featureList["libs-feature-list"]
+        cardList["libs-card-list"]
+        deviceDetail["libs-device-detail"]
+    end
+
+    subgraph stateLayer["State Layer"]
+        stateLib["libs-state"]
+    end
+
+    subgraph data["Data Layer"]
+        dataAccess["libs-data-access"]
+    end
+
+    subgraph shared["Shared Layer"]
+        sharedTypes["shared-types"]
+    end
+
+    subgraph backend["Backend"]
+        api["api (NestJS)"]
+        functionsNode["functions (Firebase)"]
+    end
+
+    web --> featureList
+    web --> cardList
+    web --> deviceDetail
+
+    featureList --> stateLib
+    cardList --> stateLib
+    deviceDetail --> dataAccess
+
+    stateLib --> dataAccess
+    stateLib --> sharedTypes
+    dataAccess --> sharedTypes
+    deviceDetail --> sharedTypes
+
+    api --> sharedTypes
+    functionsNode --> api
+```
+
+### プロジェクト一覧
+
+| プロジェクト | パス | 種別 | 説明 |
+| --- | --- | --- | --- |
+| web | apps/web | Application | Angular フロントエンド (ポート 4200) |
+| api | apps/api | Application | NestJS REST API |
+| web-e2e | apps/web-e2e | E2E | Playwright による Web E2E テスト |
+| api-e2e | apps/api-e2e | E2E | Jest による API E2E テスト |
+| shared-types | libs/shared-types | Library | DeviceInfo, ProductInfo 等の共有型 |
+| libs-data-access | libs/devices/data-access | Library | デバイスリポジトリ・データアクセス |
+| libs-state | libs/devices/state | Library | DeviceListStore 等の状態管理 |
+| libs-feature-list | libs/devices/feature-list | Library | デバイス一覧 UI コンポーネント |
+| libs-card-list | libs/devices/card-list | Library | デバイスカード一覧 UI |
+| libs-device-detail | libs/devices/device-detail | Library | デバイス詳細 UI |
+| functions | functions | Library | Firebase Cloud Functions |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Nx デフォルトの README を、ワークスペース固有の情報に更新しました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #104

## What changed?

- ディレクトリ構造の Mermaid 図を追加
- プロジェクト依存関係グラフの Mermaid 図を追加
- レイヤー別アーキテクチャの Mermaid 図を追加
- プロジェクト一覧テーブルを追加
- Quick Start / Running Tests セクションは維持

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. README.md を GitHub 上でプレビューし、Mermaid 図が正しく表示されることを確認
2. 記載内容が実際のプロジェクト構成と一致することを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [ ] I considered error handling where relevant

### ディレクトリ構造

```mermaid
flowchart TB
    subgraph root["chirimen-device-dashboard (root)"]
        direction TB
    end

    subgraph apps["apps/"]
        web["web (Angular SPA)"]
        api["api (NestJS API)"]
        webE2e["web-e2e (Playwright E2E)"]
        apiE2e["api-e2e (Jest E2E)"]
    end

    subgraph libs["libs/"]
        sharedTypes["shared-types (共有型定義)"]
        subgraph devices["devices/"]
            dataAccess["data-access (データアクセス層)"]
            stateLib["state (状態管理)"]
            featureList["feature-list (デバイス一覧)"]
            cardList["card-list (カード一覧)"]
            deviceDetail["device-detail (デバイス詳細)"]
        end
    end

    subgraph other["その他"]
        functionsNode["functions (Firebase Cloud Functions)"]
    end

    root --> apps
    root --> libs
    root --> other
```

### プロジェクト依存関係グラフ

```mermaid
flowchart LR
    subgraph apps["Applications"]
        web["web"]
        api["api"]
        webE2e["web-e2e"]
        apiE2e["api-e2e"]
    end

    subgraph libs["Libraries"]
        sharedTypes["shared-types"]
        dataAccess["libs-data-access"]
        stateLib["libs-state"]
        featureList["libs-feature-list"]
        cardList["libs-card-list"]
        deviceDetail["libs-device-detail"]
    end

    subgraph funcs["Functions"]
        functionsNode["functions"]
    end

    sharedTypes --> dataAccess
    sharedTypes --> stateLib
    sharedTypes --> api
    sharedTypes --> deviceDetail

    dataAccess --> stateLib

    stateLib --> featureList
    stateLib --> cardList
    dataAccess --> cardList
    dataAccess --> deviceDetail

    web --> dataAccess
    web --> stateLib
    web --> featureList
    web --> cardList
    web --> deviceDetail

    webE2e -.->|implicit| web
    apiE2e -.->|implicit| api

    functionsNode --> api
```

### レイヤー別アーキテクチャ

```mermaid
flowchart TB
    subgraph presentation["Presentation Layer"]
        web["web (Angular)"]
    end

    subgraph feature["Feature Layer"]
        featureList["libs-feature-list"]
        cardList["libs-card-list"]
        deviceDetail["libs-device-detail"]
    end

    subgraph stateLayer["State Layer"]
        stateLib["libs-state"]
    end

    subgraph data["Data Layer"]
        dataAccess["libs-data-access"]
    end

    subgraph shared["Shared Layer"]
        sharedTypes["shared-types"]
    end

    subgraph backend["Backend"]
        api["api (NestJS)"]
        functionsNode["functions (Firebase)"]
    end

    web --> featureList
    web --> cardList
    web --> deviceDetail

    featureList --> stateLib
    cardList --> stateLib
    deviceDetail --> dataAccess

    stateLib --> dataAccess
    stateLib --> sharedTypes
    dataAccess --> sharedTypes
    deviceDetail --> sharedTypes

    api --> sharedTypes
    functionsNode --> api
```

### プロジェクト一覧

| プロジェクト | パス | 種別 | 説明 |
| --- | --- | --- | --- |
| web | apps/web | Application | Angular フロントエンド (ポート 4200) |
| api | apps/api | Application | NestJS REST API |
| web-e2e | apps/web-e2e | E2E | Playwright による Web E2E テスト |
| api-e2e | apps/api-e2e | E2E | Jest による API E2E テスト |
| shared-types | libs/shared-types | Library | DeviceInfo, ProductInfo 等の共有型 |
| libs-data-access | libs/devices/data-access | Library | デバイスリポジトリ・データアクセス |
| libs-state | libs/devices/state | Library | DeviceListStore 等の状態管理 |
| libs-feature-list | libs/devices/feature-list | Library | デバイス一覧 UI コンポーネント |
| libs-card-list | libs/devices/card-list | Library | デバイスカード一覧 UI |
| libs-device-detail | libs/devices/device-detail | Library | デバイス詳細 UI |
| functions | functions | Library | Firebase Cloud Functions |

