### PR TITLE
fix(ci): resolve pnpm version conflict in Firebase deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #130

## What changed?

- deploy.yml から pnpm/action-setup の \`version: latest\` を削除
- package.json の packageManager (pnpm@10.28.0) を自動使用するように変更

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. main にマージ後、Firebase Deploy ワークフローが成功することを確認
2. GitHub Actions の実行ログで pnpm 10.28.0 が使用されていることを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version: 22.x
- pnpm version: 10.28.0

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)"