### PR TITLE
build(workspace): add npm minimum release age safeguard

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
## Summary

Apply npm package-install hardening by adding a minimum package release age policy.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #155 

## What changed?

- Added `.npmrc` at repository root.
- Set `min-release-age=3` so installs avoid packages published in the last 3 minutes.

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. Run `pnpm install` from repository root.
2. Confirm `.npmrc` includes `min-release-age=3`.
3. Verify dependency installation still succeeds in the local environment.

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version: see `.nvmrc`
- pnpm version: local installed version

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)