### PR TITLE
feat(workspace): extend min-release-age from 3 to 7

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-min-release-age=3
+min-release-age=7


### PR DESCRIPTION
## Summary
- Extend `.npmrc` `min-release-age` from `3` to `7` to increase safety margin for newly released packages.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #157

## What changed?
- Updated `.npmrc` from `min-release-age=3` to `min-release-age=7`.

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. Checkout this branch.
2. Confirm `.npmrc` contains `min-release-age=7`.
3. Run dependency install/update flow as needed and confirm no regressions.

## Environment (if relevant)
- Browser: N/A
- OS: macOS
- Node version: N/A
- pnpm version: N/A

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)