### PR TITLE
feat(workspace): migrate release-age policy to pnpm workspace

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-min-release-age=7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,5 @@
 packages: []
+
+# 悪意のあるリリースは1週間以内に発見され、レジストリから削除される為
+# config = 7 day x 24h x 60 min
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Issue #159 の対応として、リリース年齢ポリシーの定義場所を `.npmrc` から `pnpm-workspace.yaml` へ移行しました。
レジストリの安全性担保のため、`minimumReleaseAge` を 7 日相当 (`10080`) に設定しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #159

## What changed?

- `.npmrc` を削除し、`min-release-age` の旧設定を廃止
- `pnpm-workspace.yaml` に `minimumReleaseAge: 10080` を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `git checkout chore/issue-159-move-release-age-policy`
2. `.npmrc` が存在しないことを確認する
3. `pnpm-workspace.yaml` に `minimumReleaseAge: 10080` が存在することを確認する

## Environment (if relevant)

- Browser:
- OS: macOS
- Node version: (local)
- pnpm version: (local)

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)