### PR TITLE
feat(workspace): introduce cursor angular and nx skills and rules

### DIFF
--- a/.agents/skills/angular-developer/SKILL.md
+++ b/.agents/skills/angular-developer/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: angular-developer
+description: Generates Angular code and provides architectural guidance. Trigger when creating projects, components, or services, or for best practices on reactivity (signals, linkedSignal, resource), forms, dependency injection, routing, SSR, accessibility (ARIA), animations, styling (component styles, Tailwind CSS), testing, or CLI tooling.
+license: MIT
+metadata:
+  author: Copyright 2026 Google LLC
+  version: '1.0'
+---
+
+# Angular Developer Guidelines
+
+1. Always analyze the project's Angular version before providing guidance, as best practices and available features can vary significantly between versions. If creating a new project with Angular CLI, do not specify a version unless prompted by the user.
+
+2. When generating code, follow Angular's style guide and best practices for maintainability and performance. Use the Angular CLI for scaffolding components, services, directives, pipes, and routes to ensure consistency.
+
+3. Once you finish generating code, run `ng build` to ensure there are no build errors. If there are errors, analyze the error messages and fix them before proceeding. Do not skip this step, as it is critical for ensuring the generated code is correct and functional.
+
+## Creating New Projects
+
+If no guidelines are provided by the user, here are same default rules to follow when creating a new Angular project:
+
+1. Use the latest stable version of Angular unless the user specifies otherwise.
+2. Use Signals Forms for form management in new projects (available in Angular v21 and newer) [Find out more](references/signal-forms.md).
+
+**Execution Rules for `ng new`:**
+When asked to create a new Angular project, you must determine the correct execution command by following these strict steps:
+
+**Step 1: Check for an explicit user version.**
+
+- **IF** the user requests a specific version (e.g., Angular 15), bypass local installations and strictly use `npx`.
+- **Command:** `npx @angular/cli@<requested_version> new <project-name>`
+
+**Step 2: Check for an existing Angular installation.**
+
+- **IF** no specific version is requested, run `ng version` in the terminal to check if the Angular CLI is already installed on the system.
+- **IF** the command succeeds and returns an installed version, use the local/global installation directly.
+- **Command:** `ng new <project-name>`
+
+**Step 3: Fallback to Latest.**
+
+- **IF** no specific version is requested AND the `ng version` command fails (indicating no Angular installation exists), you must use `npx` to fetch the latest version.
+- **Command:** `npx @angular/cli@latest new <project-name>`
+
+## Components
+
+When working with Angular components, consult the following references based on the task:
+
+- **Fundamentals**: Anatomy, metadata, core concepts, and template control flow (@if, @for, @switch). Read [components.md](references/components.md)
+- **Inputs**: Signal-based inputs, transforms, and model inputs. Read [inputs.md](references/inputs.md)
+- **Outputs**: Signal-based outputs and custom event best practices. Read [outputs.md](references/outputs.md)
+- **Host Elements**: Host bindings and attribute injection. Read [host-elements.md](references/host-elements.md)
+
+If you require deeper documentation not found in the references above, read the documentation at `https://angular.dev/guide/components`.
+
+## Reactivity and Data Management
+
+When managing state and data reactivity, use Angular Signals and consult the following references:
+
+- **Signals Overview**: Core signal concepts (`signal`, `computed`), reactive contexts, and `untracked`. Read [signals-overview.md](references/signals-overview.md)
+- **Dependent State (`linkedSignal`)**: Creating writable state linked to source signals. Read [linked-signal.md](references/linked-signal.md)
+- **Async Reactivity (`resource`)**: Fetching asynchronous data directly into signal state. Read [resource.md](references/resource.md)
+- **Side Effects (`effect`)**: Logging, third-party DOM manipulation (`afterRenderEffect`), and when NOT to use effects. Read [effects.md](references/effects.md)
+
+## Forms
+
+In most cases for new apps, **prefer signal forms**. When making a forms decision, analyze the project and consider the following guidelines:
+
+- if the application is using v21 or newer and this is a new form, **prefer signal forms**.
+  -For older applications or when working with existing forms, use the appropriate form type that matches the applications current form strategy.
+
+- **Signal Forms**: Use signals for form state management. Read [signal-forms.md](references/signal-forms.md)
+- **Template-driven forms**: Use for simple forms. Read [template-driven-forms.md](references/template-driven-forms.md)
+- **Reactive forms**: Use for complex forms. Read [reactive-forms.md](references/reactive-forms.md)
+
+## Dependency Injection
+
+When implementing dependency injection in Angular, follow these guidelines:
+
+- **Fundamentals**: Overview of Dependency Injection, services, and the `inject()` function. Read [di-fundamentals.md](references/di-fundamentals.md)
+- **Creating and Using Services**: Creating services, the `providedIn: 'root'` option, and injecting into components or other services. Read [creating-services.md](references/creating-services.md)
+- **Defining Dependency Providers**: Automatic vs manual provision, `InjectionToken`, `useClass`, `useValue`, `useFactory`, and scopes. Read [defining-providers.md](references/defining-providers.md)
+- **Injection Context**: Where `inject()` is allowed, `runInInjectionContext`, and `assertInInjectionContext`. Read [injection-context.md](references/injection-context.md)
+- **Hierarchical Injectors**: The `EnvironmentInjector` vs `ElementInjector`, resolution rules, modifiers (`optional`, `skipSelf`), and `providers` vs `viewProviders`. Read [hierarchical-injectors.md](references/hierarchical-injectors.md)
+
+## Angular Aria
+
+When building accessible custom components for any of the following patterns: Accordion, Listbox, Combobox, Menu, Tabs, Toolbar, Tree, Grid, consult the following reference:
+
+- **Angular Aria Components**: Building headless, accessible components (Accordion, Listbox, Combobox, Menu, Tabs, Toolbar, Tree, Grid) and styling ARIA attributes. Read [angular-aria.md](references/angular-aria.md)
+
+## Routing
+
+When implementing navigation in Angular, consult the following references:
+
+- **Define Routes**: URL paths, static vs dynamic segments, wildcards, and redirects. Read [define-routes.md](references/define-routes.md)
+- **Route Loading Strategies**: Eager vs lazy loading, and context-aware loading. Read [loading-strategies.md](references/loading-strategies.md)
+- **Show Routes with Outlets**: Using `<router-outlet>`, nested outlets, and named outlets. Read [show-routes-with-outlets.md](references/show-routes-with-outlets.md)
+- **Navigate to Routes**: Declarative navigation with `RouterLink` and programmatic navigation with `Router`. Read [navigate-to-routes.md](references/navigate-to-routes.md)
+- **Control Route Access with Guards**: Implementing `CanActivate`, `CanMatch`, and other guards for security. Read [route-guards.md](references/route-guards.md)
+- **Data Resolvers**: Pre-fetching data before route activation with `ResolveFn`. Read [data-resolvers.md](references/data-resolvers.md)
+- **Router Lifecycle and Events**: Chronological order of navigation events and debugging. Read [router-lifecycle.md](references/router-lifecycle.md)
+- **Rendering Strategies**: CSR, SSG (Prerendering), and SSR with hydration. Read [rendering-strategies.md](references/rendering-strategies.md)
+- **Route Transition Animations**: Enabling and customizing the View Transitions API. Read [route-animations.md](references/route-animations.md)
+
+If you require deeper documentation or more context, visit the [official Angular Routing guide](https://angular.dev/guide/routing).
+
+## Styling and Animations
+
+When implementing styling and animations in Angular, consult the following references:
+
+- **Using Tailwind CSS with Angular**: Integrating Tailwind CSS into Angular projects. Read [tailwind-css.md](references/tailwind-css.md)
+- **Angular Animations**: Using native CSS (recommended) or the legacy DSL for dynamic effects. Read [angular-animations.md](references/angular-animations.md)
+- **Styling components**: Best practices for component styles and encapsulation. Read [component-styling.md](references/component-styling.md)
+
+## Testing
+
+When writing or updating tests, consult the following references based on the task:
+
+- **Fundamentals**: Best practices for unit testing (Vitest), async patterns, and `TestBed`. Read [testing-fundamentals.md](references/testing-fundamentals.md)
+- **Component Harnesses**: Standard patterns for robust component interaction. Read [component-harnesses.md](references/component-harnesses.md)
+- **Router Testing**: Using `RouterTestingHarness` for reliable navigation tests. Read [router-testing.md](references/router-testing.md)
+- **End-to-End (E2E) Testing**: Best practices for E2E tests with Cypress. Read [e2e-testing.md](references/e2e-testing.md)
+
+## Tooling
+
+When working with Angular tooling, consult the following references:
+
+- **Angular CLI**: Creating applications, generating code (components, routes, services), serving, and building. Read [cli.md](references/cli.md)
+- **Code Modernization**: Automatically refactoring to modern standards using migrations. Read [migrations.md](references/migrations.md)
+- **Angular MCP Server**: Available tools, configuration, and experimental features. Read [mcp.md](references/mcp.md)

--- a/.agents/skills/angular-developer/references/angular-animations.md
+++ b/.agents/skills/angular-developer/references/angular-animations.md
@@ -1,0 +1,160 @@
+# Angular Animations
+
+When animating elements in Angular, **first analyze the project's Angular version** in `package.json`.
+For modern applications (**Angular v20.2 and above**), prefer using native CSS with `animate.enter` and `animate.leave`. For older applications, you may need to use the deprecated `@angular/animations` package.
+
+## 1. Native CSS Animations (v20.2+ Recommended)
+
+Modern Angular provides `animate.enter` and `animate.leave` to animate elements as they enter or leave the DOM. They apply CSS classes at the appropriate times.
+
+### `animate.enter` and `animate.leave`
+
+Use these directly on elements to apply CSS classes during the enter or leave phase. Angular automatically removes the enter classes when the animation completes. For `animate.leave`, Angular waits for the animation to finish before removing the element from the DOM.
+
+`animate.enter` example:
+
+```html
+@if (isShown()) {
+<div class="enter-container" animate.enter="enter-animation">
+  <p>The box is entering.</p>
+</div>
+}
+```
+
+```css
+/* Ensure you have a starting style if using transitions instead of keyframes */
+.enter-container {
+  border: 1px solid #dddddd;
+  margin-top: 1em;
+  padding: 20px;
+  font-weight: bold;
+  font-size: 20px;
+}
+.enter-container p {
+  margin: 0;
+}
+.enter-animation {
+  animation: slide-fade 1s;
+}
+@keyframes slide-fade {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+```
+
+_Note: `animate.leave` may be added to child elements being removed._
+
+### Event Bindings and Third-party Libraries
+
+You can bind to `(animate.enter)` and `(animate.leave)` to call functions or use JS libraries like GSAP.
+
+```html
+@if(show()) {
+<div (animate.leave)="onLeave($event)">...</div>
+}
+```
+
+```ts
+import { AnimationCallbackEvent } from '@angular/core';
+
+onLeave(event: AnimationCallbackEvent) {
+  // Custom animation logic here
+  // CRITICAL: You MUST call animationComplete() when done so Angular removes the element!
+  event.animationComplete();
+}
+```
+
+## 2. Advanced CSS Animations
+
+CSS offers robust tools for advanced animation sequences.
+
+### Animating State and Styles
+
+Toggle CSS classes on elements using property binding to trigger transitions.
+
+```html
+<div [class.open]="isOpen">...</div>
+```
+
+```css
+div {
+  transition: height 0.3s ease-out;
+  height: 100px;
+}
+div.open {
+  height: 200px;
+}
+```
+
+### Animating Auto Height
+
+You can use `css-grid` to animate to auto height.
+
+```css
+.container {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s;
+}
+.container.open {
+  grid-template-rows: 1fr;
+}
+.container > div {
+  overflow: hidden;
+}
+```
+
+### Staggering and Parallel Animations
+
+- **Staggering**: Use `animation-delay` or `transition-delay` with different values for items in a list.
+- **Parallel**: Apply multiple animations in the `animation` shorthand (e.g., `animation: rotate 3s, fade-in 2s;`).
+
+### Programmatic Control
+
+Retrieve animations directly using standard Web APIs:
+
+```ts
+const animations = element.getAnimations();
+animations.forEach((anim) => anim.pause());
+```
+
+## 3. Legacy Animations DSL (Deprecated)
+
+For older projects (pre v20.2 or where `@angular/animations` is already heavily used), you use the component metadata DSL.
+
+**Important:** Do not mix legacy animations and `animate.enter`/`leave` in the same component.
+
+### Setup
+
+```ts
+bootstrapApplication(App, {
+  providers: [provideAnimationsAsync()],
+});
+```
+
+### Defining Transitions
+
+```ts
+import {signal} from '@angular/core';
+import {trigger, state, style, animate, transition} from '@angular/animations';
+
+@Component({
+  animations: [
+    trigger('openClose', [
+      state('open', style({opacity: 1})),
+      state('closed', style({opacity: 0})),
+      transition('open <=> closed', [animate('0.5s')]),
+    ]),
+  ],
+  template: `<div [@openClose]="isOpen() ? 'open' : 'closed'">...</div>`,
+})
+export class OpenClose {
+  isOpen = signal(true);
+}
+```

--- a/.agents/skills/angular-developer/references/angular-aria.md
+++ b/.agents/skills/angular-developer/references/angular-aria.md
@@ -1,0 +1,410 @@
+# Angular Aria
+
+Angular Aria (`@angular/aria`) is a collection of headless, accessible directives that implement common WAI-ARIA patterns. These directives handle keyboard interactions, ARIA attributes, focus management, and screen reader support.
+
+**As an AI Agent, your role is to provide the HTML structure and CSS styling**, while the directives handle the complex accessibility logic.
+
+## Styling Headless Components
+
+Because Angular Aria components are headless, they do not come with default styles. You **must** use CSS to style different states based on the ARIA attributes or structural classes the directives automatically apply.
+
+Common ARIA attributes to target in CSS:
+
+- `[aria-expanded="true"]` / `[aria-expanded="false"]`
+- `[aria-selected="true"]`
+- `[aria-disabled="true"]`
+- `[aria-current="page"]` (for navigation)
+
+---
+
+**CRITICAL**: Before using this package, it must be installed via the package manager. Confirm that it has been installed in the project. Use `npm install @angular/aria` to install if necessary.
+
+## 1. Accordion
+
+Organizes related content into expandable/collapsible sections.
+
+**Usage:** The Accordion is a layout component designed to organize content into logical groups that users can expand one at a time to reduce scrolling on content-heavy pages. Use it for FAQs, long forms, or progressive disclosure of information, but avoid it for primary navigation or scenarios where users must view multiple sections of content simultaneously.
+
+**Imports:** `import { AccordionContent, AccordionGroup, AccordionPanel, AccordionTrigger } from '@angular/aria/accordion';`
+
+**Directives:** `ngAccordionGroup`, `ngAccordionTrigger`, `ngAccordionPanel`, `ngAccordionContent` (for lazy loading).
+
+```ts
+@Component({
+  selector: 'app-cmp',
+  imports: [AccordionContent, AccordionGroup, AccordionPanel, AccordionTrigger],
+  template: `...`,
+  styles: [],
+})
+export class App {
+  protected readonly title = signal('angular-app');
+}
+```
+
+```html
+<div ngAccordionGroup [multiExpandable]="false">
+  <div class="accordion-item">
+    <button ngAccordionTrigger panelId="panel-1" class="accordion-header">
+      Section 1
+      <span class="icon">▼</span>
+    </button>
+    <div ngAccordionPanel panelId="panel-1" class="accordion-panel">
+      <ng-template ngAccordionContent>
+        <p>Lazy loaded content here.</p>
+      </ng-template>
+    </div>
+  </div>
+</div>
+```
+
+**Styling Strategy:**
+Target the `[aria-expanded]` attribute on the trigger to rotate icons, and style the panel visibility.
+
+```css
+.accordion-header[aria-expanded='true'] .icon {
+  transform: rotate(180deg);
+}
+
+/* The panel directive handles DOM removal, but you can style the transition */
+.accordion-panel {
+  padding: 1rem;
+  border-top: 1px solid #ccc;
+}
+```
+
+---
+
+## 2. Listbox
+
+A foundational directive for displaying a list of options. Used for visible selection lists (not dropdowns).
+
+**Usage:** Visible selectable lists (single or multi-select).
+
+**Imports:** `import {Listbox, Option} from '@angular/aria/listbox';`
+
+**Directives:** `ngListbox`, `ngOption`.
+
+```ts
+@Component({
+  selector: 'app-cmp',
+  imports: [Listbox, Option],
+  template: `...`,
+  styles: [],
+})
+export class App {
+  protected readonly title = signal('angular-app');
+}
+```
+
+```html
+<!-- horizontal or vertical orientation -->
+<ul ngListbox [(values)]="selectedItems" orientation="horizontal" [multi]="true">
+  <li ngOption value="apple" class="option">Apple</li>
+  <li ngOption value="banana" class="option">Banana</li>
+</ul>
+```
+
+**Styling Strategy:**
+Target `[aria-selected="true"]` for selected state and `:focus-visible` or `[data-active]` for the focused item (Angular Aria uses roving tabindex or activedescendant).
+
+```css
+.option {
+  padding: 8px;
+  cursor: pointer;
+}
+.option[aria-selected='true'] {
+  background: #e0f7fa;
+  font-weight: bold;
+}
+/* Focus state managed by aria */
+.option:focus-visible {
+  outline: 2px solid blue;
+}
+```
+
+---
+
+## 3. Combobox, Select, and Multiselect
+
+These patterns combine `ngCombobox` with a popup containing an `ngListbox`.
+
+- **Combobox**: Text input + popup (used for Autocomplete).
+- **Select**: Readonly Combobox + single-select Listbox.
+- **Multiselect**: Readonly Combobox + multi-select Listbox.
+
+**Usage:** The Combobox is a low-level primitive directive that synchronizes a text input with a popup, serving as the foundational logic for autocomplete, select, and multiselect patterns. Use it specifically for building custom filtering, unique selection requirements, or specialized input-to-popup coordination that deviates from standard, documented components.
+
+**Imports:**
+
+```
+  import {Combobox, ComboboxInput, ComboboxPopupContainer} from '@angular/aria/combobox';
+  import {Listbox, Option} from '@angular/aria/listbox';
+```
+
+**Directives:** `ngCombobox`, `ngComboboxInput`, `ngComboboxPopupContainer`, `ngListbox`, `ngOption`.
+
+```html
+<!-- Example: Standard Select -->
+<div ngCombobox [readonly]="true">
+  <button ngComboboxInput class="select-trigger">
+    {{ selectedValue() || 'Choose an option' }}
+  </button>
+
+  <ng-template ngComboboxPopupContainer>
+    <ul ngListbox [(values)]="selectedValue" class="dropdown-menu">
+      <li ngOption value="option1">Option 1</li>
+      <li ngOption value="option2">Option 2</li>
+    </ul>
+  </ng-template>
+</div>
+```
+
+**Styling Strategy:**
+Style the popup container to look like a dropdown floating above content (often paired with CDK Overlay).
+
+```css
+.select-trigger {
+  width: 200px;
+  padding: 8px;
+  text-align: left;
+}
+.dropdown-menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid #ccc;
+  background: white;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+```
+
+---
+
+## 4. Menu and Menubar
+
+For actions, commands, and context menus (not for form selection).
+
+**Usage:** The Menubar is a high-level navigation pattern designed for building desktop-style application command bars (e.g., File, Edit, View) that stay persistent across an interface. It is best utilized for organizing complex commands into logical top-level categories with full horizontal keyboard support, but it should be avoided for simple standalone action lists or mobile-first layouts where horizontal space is constrained.
+
+**Imports:** `import {MenuBar, Menu, MenuContent, MenuItem} from '@angular/aria/menu';`
+
+**Directives:** `ngMenuBar`, `ngMenu`, `ngMenuItem`, `ngMenuTrigger`.
+
+```html
+<!-- Menubar Example -->
+<ul ngMenuBar class="menubar">
+  <li ngMenuItem value="file">
+    <button ngMenuTrigger [menu]="fileMenu">File</button>
+  </li>
+</ul>
+
+<ul ngMenu #fileMenu="ngMenu" class="menu">
+  <li ngMenuItem value="new">New</li>
+  <li ngMenuItem value="open">Open</li>
+</ul>
+```
+
+**Styling Strategy:**
+Use flexbox for the menubar. Hide/show submenus based on the trigger's state.
+
+```css
+.menubar {
+  display: flex;
+  gap: 10px;
+  list-style: none;
+  padding: 0;
+}
+.menu {
+  background: white;
+  border: 1px solid #ccc;
+  padding: 5px 0;
+}
+.menu li {
+  padding: 5px 15px;
+  cursor: pointer;
+}
+```
+
+---
+
+## 5. Tabs
+
+Layered content sections where only one panel is visible.
+
+**Usage:** The Tabs component is used to organize related content into distinct, navigable sections, allowing users to switch between categories or views without leaving the page. It is ideal for settings panels, multi-topic documentation, or dashboards, but should be avoided for sequential workflows (steppers) or when navigation involves more than 7–8 sections.
+
+**Imports:** `import {Tab, Tabs, TabList, TabPanel, TabContent} from '@angular/aria/tabs';`
+
+**Directives:** `ngTabs`, `ngTabList`, `ngTab`, `ngTabPanel`, `ngTabContent`.
+
+```html
+<div ngTabs>
+  <ul ngTabList class="tab-list">
+    <li ngTab value="profile" class="tab-btn">Profile</li>
+    <li ngTab value="security" class="tab-btn">Security</li>
+  </ul>
+
+  <div ngTabPanel value="profile" class="tab-panel">
+    <ng-template ngTabContent>Profile Settings</ng-template>
+  </div>
+  <div ngTabPanel value="security" class="tab-panel">
+    <ng-template ngTabContent>Security Settings</ng-template>
+  </div>
+</div>
+```
+
+**Styling Strategy:**
+Target `[aria-selected="true"]` on the tab buttons.
+
+```css
+.tab-list {
+  display: flex;
+  border-bottom: 2px solid #ccc;
+  list-style: none;
+  padding: 0;
+}
+.tab-btn {
+  padding: 10px 20px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+.tab-btn[aria-selected='true'] {
+  border-bottom-color: blue;
+  font-weight: bold;
+}
+.tab-panel {
+  padding: 20px;
+}
+```
+
+---
+
+## 6. Toolbar
+
+Groups related controls (like text formatting).
+
+**Usage:** The Toolbar is an organizational component designed to group frequently accessed, related controls into a single logical container. It is best used to enhance keyboard efficiency (via arrow-key navigation) and visual structure for workflows requiring repeated actions, such as text formatting or media controls.
+
+**Imports:** `import {Toolbar, ToolbarWidget, ToolbarWidgetGroup} from '@angular/aria/toolbar';`
+
+**Directives:** `ngToolbar`, `ngToolbarWidget`, `ngToolbarWidgetGroup`.
+
+```html
+<div ngToolbar class="toolbar">
+  <div ngToolbarWidgetGroup [multi]="true" role="group" aria-label="Formatting">
+    <button ngToolbarWidget value="bold" class="tool-btn">B</button>
+    <button ngToolbarWidget value="italic" class="tool-btn">I</button>
+  </div>
+</div>
+```
+
+**Styling Strategy:**
+Target `[aria-pressed="true"]` (for toggle buttons) or `[aria-checked="true"]` (for radio groups) within the toolbar.
+
+```css
+.toolbar {
+  display: flex;
+  gap: 5px;
+  padding: 8px;
+  background: #f5f5f5;
+}
+.tool-btn {
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+}
+.tool-btn[aria-pressed='true'],
+.tool-btn[aria-checked='true'] {
+  background: #ddd;
+}
+```
+
+---
+
+## 7. Tree
+
+Displays hierarchical data (file systems, nested nav).
+
+**Usage:** The Tree component is designed for navigating and displaying deeply nested, hierarchical data structures like file systems, organization charts, or complex site architectures. It should be used specifically for multi-level relationships where users need to expand or collapse branches, but it should be avoided for flat lists, data tables, or simple selection menus.
+
+**Imports:** `import {Tree, TreeItem, TreeItemGroup} from '@angular/aria/tree';`
+
+**Directives:** `ngTree`, `ngTreeItem`, `ngTreeGroup`.
+
+```html
+<ul ngTree class="tree">
+  <li ngTreeItem value="documents">
+    <span class="tree-label">Documents</span>
+    <ul ngTreeGroup class="tree-group">
+      <li ngTreeItem value="resume">Resume.pdf</li>
+    </ul>
+  </li>
+</ul>
+```
+
+**Styling Strategy:**
+Target `[aria-expanded]` to show/hide children or rotate chevron icons. Use `padding-left` on nested groups to show hierarchy.
+
+```css
+.tree,
+.tree-group {
+  list-style: none;
+  padding-left: 20px;
+}
+.tree-label::before {
+  content: '▶ ';
+  display: inline-block;
+  transition: transform 0.2s;
+}
+li[aria-expanded='true'] > .tree-label::before {
+  transform: rotate(90deg);
+}
+```
+
+## 8. Grid
+
+A two-dimensional interactive collection of cells enabling navigation via arrow keys.
+
+**Usage:** Data tables, calendars, spreadsheets, and layout patterns for interactive elements.
+**Directives:** `ngGrid`, `ngGridRow`, `ngGridCell`, `ngGridCellWidget`.
+
+```html
+<table ngGrid [multi]="true" [enableSelection]="true" class="grid-table">
+  <tr ngGridRow>
+    <th ngGridCell role="columnheader">Name</th>
+    <th ngGridCell role="columnheader">Status</th>
+  </tr>
+  <tr ngGridRow>
+    <td ngGridCell>Project A</td>
+    <td ngGridCell [(selected)]="isSelected">
+      <button ngGridCellWidget (activated)="onActivate()">Active</button>
+    </td>
+  </tr>
+</table>
+```
+
+**Styling Strategy:**
+Target `[aria-selected="true"]` for selected cells and `:focus-visible` for the active cell (roving tabindex) or `[aria-activedescendant]` on the container.
+
+```css
+.grid-table {
+  border-collapse: collapse;
+}
+[ngGridCell] {
+  padding: 8px;
+  border: 1px solid #ddd;
+}
+[ngGridCell][aria-selected='true'] {
+  background: #e3f2fd;
+}
+/* Focus state managed by roving tabindex */
+[ngGridCell]:focus-visible {
+  outline: 2px solid #2196f3;
+  outline-offset: -2px;
+}
+```
+
+## General Rules for Agents
+
+1. **Never use native HTML elements like `<select>`** when asked to implement these specific Aria patterns. Use the `ng*` directives.
+2. **Handle CSS manually**: Remember that `Angular Aria` does NOT provide styles. You must write the CSS, targeting the native ARIA attributes (`aria-expanded`, `aria-selected`, etc.) that the directives automatically toggle.
+3. **Lazy Loading**: Always use the provided structural directives (`ngAccordionContent`, `ngTabContent`) inside `ng-template` for heavy content panels to ensure they are lazily rendered.

--- a/.agents/skills/angular-developer/references/cli.md
+++ b/.agents/skills/angular-developer/references/cli.md
@@ -1,0 +1,86 @@
+# Angular CLI Guide for Agents
+
+The Angular CLI (`ng`) is the primary tool for managing an Angular workspace. Always prefer CLI commands over manual file creation or generic `npm` commands when modifying project structure or adding Angular-specific dependencies.
+
+## 1. Managing Dependencies
+
+**ALWAYS use `ng add` for Angular libraries** instead of `npm install`. `ng add` installs the package AND runs initialization schematics (e.g., configuring `angular.json`, updating root providers).
+
+```bash
+ng add @angular/material
+ng add tailwindcss
+ng add @angular/fire
+```
+
+To update the application and its dependencies (which automatically runs code migrations):
+
+```bash
+ng update @angular/core@<latest or specific version> @angular/cli<latest or specific version>
+```
+
+## 2. Generating Code (`ng generate` or `ng g`)
+
+Always use the CLI to generate code to ensure it adheres to Angular standards and updates necessary configuration files automatically.
+
+| Target       | Command               | Notes                                                                                          |
+| :----------- | :-------------------- | :--------------------------------------------------------------------------------------------- |
+| Component    | `ng g c path/to/name` | Generates a component. Use `--inline-style` (`-s`) or `--inline-template` (`-t`) if requested. |
+| Service      | `ng g s path/to/name` | Generates an `@Service` service.                                                               |
+| Directive    | `ng g d path/to/name` | Generates a directive.                                                                         |
+| Pipe         | `ng g p path/to/name` | Generates a pipe.                                                                              |
+| Guard        | `ng g g path/to/name` | Generates a functional route guard.                                                            |
+| Environments | `ng g environments`   | Scaffolds `src/environments/` and updates `angular.json` with file replacements.               |
+
+_Note: There is no command to generate a single route definition. Generate a component, then manually add it to the `Routes` array in `app.routes.ts`._
+
+## 3. Development Server & Proxying
+
+Start the local development server with hot-module replacement (HMR):
+
+```bash
+ng serve
+```
+
+### Backend API Proxying
+
+To proxy API requests during development (e.g., rerouting `/api` to a local Node server):
+
+1. Create `src/proxy.conf.json`:
+   ```json
+   {
+     "/api/**": {"target": "http://localhost:3000", "secure": false}
+   }
+   ```
+2. Update `angular.json` under the `serve` target:
+   ```json
+   "serve": {
+     "builder": "@angular/build:dev-server",
+     "options": { "proxyConfig": "src/proxy.conf.json" }
+   }
+   ```
+
+## 4. Building the Application
+
+Compile the application into an output directory (default: `dist/<project-name>/browser`). Modern Angular uses the `@angular/build:application` builder (esbuild-based).
+
+```bash
+ng build
+```
+
+- `ng build` defaults to the production configuration, which enables Ahead-of-Time (AOT) compilation, minification, and tree-shaking.
+- Target specific configurations defined in `angular.json` using `--configuration`: `ng build --configuration=staging`.
+
+## 5. Testing
+
+- **Unit Tests**: Run `ng test` to execute unit tests via the configured test runner (e.g., Karma or Vitest).
+- **End-to-End (E2E)**: Run `ng e2e`. If no E2E framework is configured, the CLI will prompt to install one (Cypress, Playwright, Puppeteer, etc.).
+
+## 6. Deployment
+
+To deploy an application, you must first add a deployment builder, then run the deploy command:
+
+```bash
+# Example for Firebase
+ng add @angular/fire
+ng deploy
+```

--- a/.agents/skills/angular-developer/references/component-harnesses.md
+++ b/.agents/skills/angular-developer/references/component-harnesses.md
@@ -1,0 +1,59 @@
+# Testing with Component Harnesses
+
+Component harnesses are the standard, preferred way to interact with components in tests. They provide a robust, user-centric API that makes tests less brittle and easier to read by insulating them from changes to a component's internal DOM structure.
+
+## Why Use Harnesses?
+
+- **Robustness:** Tests don't break when you refactor a component's internal HTML or CSS classes.
+- **Readability:** Tests describe interactions from a user's perspective (e.g., `button.click()`, `slider.getValue()`) instead of through DOM queries (`fixture.nativeElement.querySelector(...)`).
+- **Reusability:** The same harness can be used in both unit tests and E2E tests.
+
+Angular Material provides a test harness for every component in its library.
+
+## Using a Harness in a Unit Test
+
+The `TestbedHarnessEnvironment` is the entry point for using harnesses in unit tests.
+
+### Example: Testing with a `MatButtonHarness`
+
+```ts
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import {MatButtonHarness} from '@angular/material/button/testing';
+import {MyButtonContainerComponent} from './my-button-container.component';
+
+describe('MyButtonContainerComponent', () => {
+  let fixture: ComponentFixture<MyButtonContainerComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MyButtonContainerComponent, MatButtonModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MyButtonContainerComponent);
+    // Create a harness loader for the component's fixture
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should find a button with specific text', async () => {
+    // Load the harness for a MatButton with the text "Submit"
+    const submitButton = await loader.getHarness(MatButtonHarness.with({text: 'Submit'}));
+
+    // Use the harness API to interact with the component
+    expect(await submitButton.isDisabled()).toBe(false);
+    await submitButton.click();
+
+    // ... assertions
+  });
+});
+```
+
+### Key Concepts
+
+1.  **`HarnessLoader`**: An object used to find and create harness instances. Get a loader for your component's fixture using `TestbedHarnessEnvironment.loader(fixture)`.
+
+2.  **`loader.getHarness(HarnessClass)`**: Asynchronously finds and returns a harness instance for the first matching component.
+
+3.  **`HarnessClass.with({ ... })`**: Many harnesses provide a static `with` method that returns a `HarnessPredicate`. This allows you to filter and find components based on their properties, like text, selector, or disabled state. Always use this to precisely target the component you want to test.
+
+4.  **Harness API:** Once you have a harness instance, use its methods (e.g., `.click()`, `.getText()`, `.getValue()`) to interact with the component. These methods automatically handle waiting for async operations and change detection.

--- a/.agents/skills/angular-developer/references/component-styling.md
+++ b/.agents/skills/angular-developer/references/component-styling.md
@@ -1,0 +1,91 @@
+# Component Styling
+
+Angular components can define styles that apply specifically to their template, enabling encapsulation and modularity.
+
+## Defining Styles
+
+Styles can be defined inline or in separate files.
+
+```ts
+@Component({
+  selector: 'app-photo',
+  // Inline styles
+  styles: `
+    img {
+      border-radius: 50%;
+    }
+  `,
+  // OR external file
+  styleUrl: 'photo.component.css',
+})
+export class Photo {}
+```
+
+## View Encapsulation
+
+Every component has a view encapsulation setting that determines how styles are scoped.
+
+| Mode                            | Behavior                                                                                      |
+| :------------------------------ | :-------------------------------------------------------------------------------------------- |
+| `Emulated` (Default)            | Scopes styles to the component using unique HTML attributes. Global styles can still leak in. |
+| `ShadowDom`                     | Uses the browser's native Shadow DOM API to isolate styles completely.                        |
+| `None`                          | Disables encapsulation. Component styles become global.                                       |
+| `ExperimentalIsolatedShadowDom` | Strictly guarantees that only the component's styles apply.                                   |
+
+### Usage
+
+```ts
+import { ViewEncapsulation } from '@angular/core';
+
+@Component({
+  ...,
+  encapsulation: ViewEncapsulation.None,
+})
+export class GlobalStyled {}
+```
+
+## Special Selectors
+
+### `:host`
+
+Targets the component's host element (the element matching the component's selector).
+
+```css
+:host {
+  display: block;
+  border: 1px solid black;
+}
+```
+
+### `:host-context()`
+
+Targets the host element based on some condition in its ancestry.
+
+```css
+/* Apply styles if any ancestor has the 'theme-dark' class */
+:host-context(.theme-dark) {
+  background-color: #333;
+}
+```
+
+### `::ng-deep`
+
+Disables view encapsulation for a specific rule, allowing it to "leak" into child components.
+**Note: The Angular team strongly discourages the use of `::ng-deep`.** It is supported only for backwards compatibility.
+
+## Styles in Templates
+
+You can use `<style>` elements directly in a component's template. View encapsulation rules still apply.
+
+```html
+<style>
+  .dynamic-class {
+    color: red;
+  }
+</style>
+<div class="dynamic-class">Hello</div>
+```
+
+## External Styles
+
+Using `<link>` or `@import` in CSS is treated as external styles. **External styles are not affected by emulated view encapsulation.**

--- a/.agents/skills/angular-developer/references/components.md
+++ b/.agents/skills/angular-developer/references/components.md
@@ -1,0 +1,117 @@
+# Components
+
+Angular components are the fundamental building blocks of an application. Each component consists of a TypeScript class with behaviors, an HTML template, and a CSS selector.
+
+## Component Definition
+
+Use the `@Component` decorator to define a component's metadata.
+
+```ts
+@Component({
+  selector: 'app-profile',
+  template: `
+    <img src="profile.jpg" alt="Profile photo" />
+    <button (click)="save()">Save</button>
+  `,
+  styles: `
+    img {
+      border-radius: 50%;
+    }
+  `,
+})
+export class Profile {
+  save() {
+    /* ... */
+  }
+}
+```
+
+## Metadata Options
+
+- `selector`: The CSS selector that identifies this component in templates.
+- `template`: Inline HTML template (preferred for small templates).
+- `templateUrl`: Path to an external HTML file.
+- `styles`: Inline CSS styles.
+- `styleUrl` / `styleUrls`: Path(s) to external CSS file(s).
+- `imports`: Lists the components, directives, or pipes used in this component's template.
+
+## Using Components
+
+To use a component, add it to the `imports` array of the consuming component and use its selector in the template.
+
+```ts
+@Component({
+  selector: 'app-root',
+  imports: [Profile],
+  template: `<app-profile />`,
+})
+export class App {}
+```
+
+## Template Control Flow
+
+Angular uses built-in blocks for conditional rendering and loops.
+
+### Conditional Rendering (`@if`)
+
+Use `@if` to conditionally show content. You can include `@else if` and `@else` blocks.
+
+```html
+@if (user.isAdmin) {
+<admin-dashboard />
+} @else if (user.isModerator) {
+<mod-dashboard />
+} @else {
+<standard-dashboard />
+}
+```
+
+**Result aliasing**: Save the result of the expression for reuse.
+
+```html
+@if (user.settings(); as settings) {
+<p>Theme: {{ settings.theme }}</p>
+}
+```
+
+### Loops (`@for`)
+
+The `@for` block iterates over collections. The `track` expression is **required** for performance and DOM reuse.
+
+```html
+<ul>
+  @for (item of items(); track item.id; let i = $index, total = $count) {
+  <li>{{ i + 1 }}/{{ total }}: {{ item.name }}</li>
+  } @empty {
+  <li>No items to display.</li>
+  }
+</ul>
+```
+
+**Implicit Variables**: `$index`, `$count`, `$first`, `$last`, `$even`, `$odd`.
+
+### Switching Content (`@switch`)
+
+The `@switch` block renders content based on a value. It uses strict equality (`===`) and has **no fallthrough**.
+
+```html
+@switch (status()) { @case ('loading') { <app-spinner /> } @case ('error') { <app-error-msg /> }
+@case ('success') { <app-data-grid /> } @default {
+<p>Unknown status</p>
+} }
+```
+
+**Exhaustive Type Checking**: Use `@default never;` to ensure all cases of a union type are handled.
+
+```html
+@switch (state) { @case ('on') { ... } @case ('off') { ... } @default never; // Errors if a new
+state like 'standby' is added }
+```
+
+## Core Concepts
+
+- **Host Element**: The DOM element that matches the component's selector.
+- **View**: The DOM rendered by the component's template inside the host element.
+- **Standalone**: By default, components are standalone (since Angular 19, `standalone: true` is default). For older versions, `standalone: true` must be explicit or the component must be part of an `NgModule`.
+- **Component Tree**: Angular applications are structured as a tree of components, where each component can host child components.
+- **Component Naming**: Do not add suffixes the `Component` suffix for Component classes (e.g., AppComponent) unless the project has been configured to use that naming configuration.

--- a/.agents/skills/angular-developer/references/creating-services.md
+++ b/.agents/skills/angular-developer/references/creating-services.md
@@ -1,0 +1,97 @@
+# Creating and Using Services
+
+Services in Angular are reusable pieces of code that handle data fetching, business logic, or state management that multiple components or other services need to access.
+
+## Creating a Service
+
+You can generate a service using the Angular CLI:
+
+```bash
+ng generate service my-data
+```
+
+Or you can manually create a TypeScript class and decorate it with `@Service()`.
+
+```ts
+import {Service} from '@angular/core';
+
+@Service()
+export class BasicDataStore {
+  private data: string[] = [];
+
+  addData(item: string): void {
+    this.data.push(item);
+  }
+
+  getData(): string[] {
+    return [...this.data];
+  }
+}
+```
+
+### The `@Service` decorator
+
+Using `@Service` is the recommended approach for most services. It tells Angular to:
+
+- **Create a single instance (singleton)** for the entire application.
+- **Make it available everywhere** automatically, without needing to list it in any `providers` array.
+- **Enable tree-shaking**, meaning the service is only included in the final JavaScript bundle if it is actually injected somewhere.
+
+#### The `autoProvided` option
+
+If you don't want to create a singleton of your service, you can set `@Service({autoProvided: false})` and declare the service a `providers` array.
+
+## Injecting a Service
+
+Once a service is created, you can inject it into components, directives, or other services using the `inject()` function.
+
+### Injecting into a Component
+
+```ts
+import {Component, inject} from '@angular/core';
+import {BasicDataStore} from './basic-data-store.service';
+
+@Component({
+  selector: 'app-example',
+  template: `
+    <div>
+      <p>Data items: {{ dataStore.getData().length }}</p>
+      <button (click)="dataStore.addData('New Item')">Add Item</button>
+    </div>
+  `,
+})
+export class Example {
+  // Inject the service as a class field
+  dataStore = inject(BasicDataStore);
+}
+```
+
+### Injecting into Another Service
+
+Services can inject other services in the exact same way.
+
+```ts
+import {Injectable, inject} from '@angular/core';
+import {AdvancedDataStore} from './advanced-data-store.service';
+
+@Service()
+export class BasicDataStore {
+  // Injecting another service
+  private advancedDataStore = inject(AdvancedDataStore);
+
+  private data: string[] = [];
+
+  getData(): string[] {
+    // Combine data from this service and the injected service
+    return [...this.data, ...this.advancedDataStore.getData()];
+  }
+}
+```
+
+## Advanced Service Patterns
+
+While `@Service` covers most scenarios, you may sometimes need:
+
+- **Component-specific instances**: If a component needs its own isolated instance of a service, provide it directly in the component's `@Component({ providers: [MyService] })` array and set the `autoProvided: false` option: `@Service({autoProvided: false})`
+- **Factory providers**: For dynamic creation.
+- **Value providers**: For injecting configuration objects.

--- a/.agents/skills/angular-developer/references/data-resolvers.md
+++ b/.agents/skills/angular-developer/references/data-resolvers.md
@@ -1,0 +1,69 @@
+# Data Resolvers
+
+Data resolvers fetch data before a route activates, ensuring components have the necessary data upon rendering.
+
+## Creating a Resolver
+
+Implement the `ResolveFn` type.
+
+```ts
+export const userResolver: ResolveFn<User> = (route, state) => {
+  const userService = inject(UserService);
+  const id = route.paramMap.get('id')!;
+  return userService.getUser(id);
+};
+```
+
+## Configuring the Route
+
+Add the resolver under the `resolve` key.
+
+```ts
+{
+  path: 'user/:id',
+  component: UserProfile,
+  resolve: {
+    user: userResolver
+  }
+}
+```
+
+## Accessing Resolved Data
+
+### 1. Via `ActivatedRoute` (Traditional)
+
+```ts
+private route = inject(ActivatedRoute);
+data = toSignal(this.route.data);
+user = computed(() => this.data().user);
+```
+
+### 2. Via Component Inputs (Modern)
+
+Enable `withComponentInputBinding()` in `provideRouter` to pass resolved data directly to `@Input` or `input()`.
+
+```ts
+// app.config.ts
+provideRouter(routes, withComponentInputBinding());
+
+// component.ts
+user = input.required<User>();
+```
+
+## Error Handling
+
+Navigation is blocked if a resolver fails.
+
+- Use `withNavigationErrorHandler` for global handling.
+- Use `catchError` within the resolver to return a `RedirectCommand` or fallback data.
+
+```ts
+return userService
+  .get(id)
+  .pipe(catchError(() => of(new RedirectCommand(router.parseUrl('/error')))));
+```
+
+## Best Practices
+
+- **Keep it lightweight**: Fetch only critical data.
+- **Provide feedback**: Listen to router events to show a global loading bar during navigation, as the UI stays on the old page until the resolver finishes.

--- a/.agents/skills/angular-developer/references/define-routes.md
+++ b/.agents/skills/angular-developer/references/define-routes.md
@@ -1,0 +1,67 @@
+# Define Routes
+
+Routes are objects that define which component should render for a specific URL path.
+
+## Basic Configuration
+
+Define routes in a `Routes` array and provide them using `provideRouter` in your `appConfig`.
+
+```ts
+// app.routes.ts
+export const routes: Routes = [
+  {path: '', component: HomePage},
+  {path: 'admin', component: AdminPage},
+];
+
+// app.config.ts
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(routes)],
+};
+```
+
+## URL Paths
+
+- **Static**: Matches an exact string (e.g., `'admin'`).
+- **Route Parameters**: Dynamic segments prefixed with a colon (e.g., `'user/:id'`).
+- **Wildcard**: Matches any URL using `**`. Useful for "Not Found" pages. **Always place at the end of the array.**
+
+## Matching Strategy
+
+Angular uses a **first-match wins** strategy. Specific routes must come before less specific ones.
+
+## Redirects
+
+Use `redirectTo` to point one path to another.
+
+```ts
+{ path: 'articles', redirectTo: '/blog' },
+{ path: 'blog', component: Blog },
+```
+
+## Page Titles
+
+Associate titles with routes for accessibility. Titles can be static or dynamic (via `ResolveFn` or a custom `TitleStrategy`).
+
+```ts
+{ path: 'home', component: Home, title: 'Home Page' }
+```
+
+## Route Data and Providers
+
+- **Static Data**: Attach metadata using the `data` property.
+- **Route Providers**: Scope dependencies to a specific route and its children using the `providers` array.
+
+## Nested (Child) Routes
+
+Define sub-views using the `children` property. Parent components must include a `<router-outlet />`.
+
+```ts
+{
+  path: 'product/:id',
+  component: Product,
+  children: [
+    { path: 'info', component: ProductInfo },
+    { path: 'reviews', component: ProductReviews },
+  ],
+}
+```

--- a/.agents/skills/angular-developer/references/defining-providers.md
+++ b/.agents/skills/angular-developer/references/defining-providers.md
@@ -1,0 +1,72 @@
+# Defining Dependency Providers
+
+Angular offers automatic and manual ways to provide dependencies to its Dependency Injection (DI) system.
+
+## Automatic Provision
+
+The most common way to provide a service is using `providedIn: 'root'` on an `@Injectable()`.
+
+### InjectionToken
+
+Use `InjectionToken` for non-class dependencies (configuration objects, functions, primitives). An `InjectionToken` can also be automatically provided.
+
+```ts
+import {InjectionToken} from '@angular/core';
+
+export interface AppConfig {
+  apiUrl: string;
+}
+
+export const APP_CONFIG = new InjectionToken<AppConfig>('app.config', {
+  providedIn: 'root',
+  factory: () => ({apiUrl: 'https://api.example.com'}),
+});
+```
+
+## Manual Provision
+
+You use the `providers` array when a service lacks `providedIn`, when you want a new instance for a specific component, or when configuring runtime values.
+
+```ts
+@Component({
+  providers: [
+    // Shorthand for { provide: LocalService, useClass: LocalService }
+    LocalService,
+
+    // useClass: Swap implementations
+    {provide: Logger, useClass: BetterLogger},
+
+    // useValue: Provide static values
+    {provide: API_URL_TOKEN, useValue: 'https://api.example.com'},
+
+    // useFactory: Generate value dynamically
+    {
+      provide: ApiClient,
+      useFactory: (http = inject(HttpClient)) => new ApiClient(http),
+    },
+
+    // useExisting: Create an alias
+    {provide: OldLogger, useExisting: NewLogger},
+
+    // multi: Provide multiple values for the same token as an array
+    {provide: INTERCEPTOR_TOKEN, useClass: AuthInterceptor, multi: true},
+  ],
+})
+export class Example {}
+```
+
+## Scopes of Providers
+
+- **Application Bootstrap**: Global singletons. Use for HTTP clients, logging, or app-wide config.
+- **Component/Directive**: Isolated instances. Use for component-specific state or forms. Services are destroyed when the component is destroyed.
+- **Route**: Feature-specific services loaded only with specific routes.
+
+## Library Pattern: `provide*` functions
+
+Library authors should export functions that return provider arrays to encapsulate configuration:
+
+```ts
+export function provideAnalytics(config: AnalyticsConfig): Provider[] {
+  return [{provide: ANALYTICS_CONFIG, useValue: config}, AnalyticsService];
+}
+```

--- a/.agents/skills/angular-developer/references/di-fundamentals.md
+++ b/.agents/skills/angular-developer/references/di-fundamentals.md
@@ -1,0 +1,120 @@
+# Dependency Injection (DI) Fundamentals
+
+Dependency Injection (DI) is a design pattern used to organize and share code across an application by allowing you to "inject" features into different parts. This improves code maintainability, scalability, and testability.
+
+## How DI Works in Angular
+
+There are two primary ways code interacts with Angular's DI system:
+
+1.  **Providing**: Making values (objects, functions, primitives) available to the DI system.
+2.  **Injecting**: Asking the DI system for those values.
+
+Angular components, directives, and services automatically participate in DI.
+
+## Services
+
+A **service** is the most common way to share data and functionality across an application. It is a TypeScript class decorated with `@Injectable()`.
+
+### Creating a Service
+
+Use the `providedIn: 'root'` option in the `@Injectable` decorator to make the service a singleton available throughout the entire application. This is the recommended approach for most services.
+
+```ts
+import {Injectable} from '@angular/core';
+
+@Injectable({
+  providedIn: 'root', // Makes this a singleton available everywhere
+})
+export class AnalyticsLogger {
+  trackEvent(category: string, value: string) {
+    console.log('Analytics event logged:', {category, value});
+  }
+}
+```
+
+Common uses for services include:
+
+- Data clients (API calls)
+- State management
+- Authentication and authorization
+- Logging and error handling
+- Utility functions
+
+## Injecting Dependencies
+
+Use Angular's `inject()` function to request dependencies.
+
+### The `inject()` Function
+
+You can use the `inject()` function to get an instance of a service (or any other provided token).
+
+```ts
+import {Component, inject} from '@angular/core';
+import {Router} from '@angular/router';
+import {AnalyticsLogger} from './analytics-logger.service';
+
+@Component({
+  selector: 'app-navbar',
+  template: `<a href="#" (click)="navigateToDetail($event)">Detail Page</a>`,
+})
+export class Navbar {
+  // Injecting dependencies using class field initializers
+  private router = inject(Router);
+  private analytics = inject(AnalyticsLogger);
+
+  navigateToDetail(event: Event) {
+    event.preventDefault();
+    this.analytics.trackEvent('navigation', '/details');
+    this.router.navigate(['/details']);
+  }
+}
+```
+
+### Where can `inject()` be used? (Injection Context)
+
+You can call `inject()` in an **injection context**. The most common injection contexts are during the construction of a component, directive, or service.
+
+Valid places to call `inject()`:
+
+1.  **Class field initializers** (Recommended)
+2.  **Constructor body**
+3.  **Route guards and resolvers** (which are executed in an injection context)
+4.  **Factory functions** used in providers
+
+```typescript
+import {Component, Directive, Injectable, inject, ElementRef} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+
+// 1. In a Component (Field Initializer & Constructor)
+@Component({
+  /*...*/
+})
+export class Example {
+  private service1 = inject(MyService); // ✅ Field initializer
+
+  private service2: MyService;
+  constructor() {
+    this.service2 = inject(MyService); // ✅ Constructor body
+  }
+}
+
+// 2. In a Directive
+@Directive({
+  /*...*/
+})
+export class MyDirective {
+  private element = inject(ElementRef); // ✅ Field initializer
+}
+
+// 3. In a Service
+@Injectable({providedIn: 'root'})
+export class MyService {
+  private http = inject(HttpClient); // ✅ Field initializer
+}
+
+// 4. In a Route Guard (Functional)
+export const authGuard = () => {
+  const auth = inject(AuthService); // ✅ Route Guard
+  return auth.isAuthenticated();
+};
+```

--- a/.agents/skills/angular-developer/references/e2e-testing.md
+++ b/.agents/skills/angular-developer/references/e2e-testing.md
@@ -1,0 +1,66 @@
+# End-to-End (E2E) Testing
+
+This project uses [Cypress](https://www.cypress.io/) for end-to-end (E2E) testing, which simulates real user interactions in a browser. The E2E tests are located primarily within the `devtools/` package.
+
+## Running E2E Tests
+
+The primary way to run E2E tests is through the `pnpm` script defined in the root `package.json`.
+
+1.  **Build DevTools:** The E2E tests run against a built version of the devtools extension. You must build it first:
+
+    ```shell
+    pnpm -F ng-devtools-mcp build:dev
+    ```
+
+2.  **Run Cypress:** Use the `cy:open` or `cy:run` script:
+    - To open the interactive Cypress Test Runner:
+      ```shell
+      pnpm -F ng-devtools-mcp cy:open
+      ```
+    - To run the tests headlessly in the terminal (ideal for CI):
+      ```shell
+      pnpm -F ng-devtools-mcp cy:run
+      ```
+
+## Test Structure
+
+- **Configuration:** The main Cypress configuration is located at `devtools/cypress.json`.
+- **Specs:** Test files (specs) are located in `devtools/cypress/integration/`.
+- **Custom Commands:** Reusable custom commands and actions are defined in `devtools/cypress/support/`.
+
+### Example E2E Test Snippet
+
+A typical test might look like this:
+
+```typescript
+// in devtools/cypress/integration/profiler.spec.ts
+
+describe('Profiler', () => {
+  beforeEach(() => {
+    cy.visit('/?e2e-app');
+    cy.wait(1000);
+    cy.get('ng-devtools-tabs').find('a').contains('Profiler').click();
+  });
+
+  it('should record and display profiling data', () => {
+    // Find the record button and click it
+    cy.get('button[aria-label="start-recording-button"]').click();
+
+    // Interact with the test application to generate profiling data
+    cy.get('body').find('#cards button').first().click();
+    cy.wait(500);
+
+    // Stop recording
+    cy.get('button[aria-label="stop-recording-button"]').click();
+
+    // Assert that the flame graph is now visible
+    cy.get('ng-devtools-recording-timeline').find('canvas').should('be.visible');
+  });
+});
+```
+
+### Best Practices
+
+- **Use `data-` attributes:** Whenever possible, use `data-cy` or similar attributes for selecting elements to make tests more resilient to CSS or structural changes.
+- **Custom Commands:** Encapsulate common sequences of actions into custom commands in the `support` directory to keep tests clean and readable.
+- **Wait for Application State:** Use `cy.wait()` for arbitrary waits sparingly. Prefer to wait for specific UI elements to appear or for network requests to complete to avoid flaky tests.

--- a/.agents/skills/angular-developer/references/effects.md
+++ b/.agents/skills/angular-developer/references/effects.md
@@ -1,0 +1,83 @@
+# Side Effects with `effect` and `afterRenderEffect`
+
+In Angular, an **effect** is an operation that runs whenever one or more signal values it tracks change.
+
+## When to use `effect`
+
+Effects are intended for syncing signal state to imperative, non-signal APIs.
+
+**Valid Use Cases:**
+
+- Logging analytics.
+- Syncing state to `localStorage` or `sessionStorage`.
+- Performing custom rendering to a `<canvas>` or 3rd-party charting library.
+
+**CRITICAL RULE: DO NOT use effects to propagate state.**
+If you find yourself using `.set()` or `.update()` on a signal _inside_ an effect to keep two signals in sync, you are making a mistake. This causes `ExpressionChangedAfterItHasBeenChecked` errors and infinite loops. **Always use `computed()` or `linkedSignal()` for state derivation.**
+
+## Basic Usage
+
+Effects execute asynchronously during the change detection process. They always run at least once.
+
+```ts
+import { Component, signal, effect } from '@angular/core';
+
+@Component({...})
+export class Example {
+  count = signal(0);
+
+  constructor() {
+    // Effect must be created in an injection context (e.g., a constructor)
+    effect((onCleanup) => {
+      console.log(`Count changed to ${this.count()}`);
+
+      const timer = setTimeout(() => console.log('Timer finished'), 1000);
+
+      // Cleanup function runs before the next execution, or when destroyed
+      onCleanup(() => clearTimeout(timer));
+    });
+  }
+}
+```
+
+## DOM Manipulation with `afterRenderEffect`
+
+Standard `effect` runs _before_ Angular updates the DOM. If you need to manually inspect or modify the DOM based on a signal change (e.g., integrating a 3rd party UI library), use `afterRenderEffect`.
+
+`afterRenderEffect` runs after Angular has finished rendering the DOM.
+
+### Render Phases
+
+To prevent reflows (forced layout thrashing), `afterRenderEffect` forces you to divide your DOM reads and writes into specific phases.
+
+```ts
+import { Component, afterRenderEffect, viewChild, ElementRef } from '@angular/core';
+
+@Component({...})
+export class Chart {
+  canvas = viewChild.required<ElementRef>('canvas');
+
+  constructor() {
+    afterRenderEffect({
+      // 1. Read from the DOM
+      earlyRead: () => {
+        return this.canvas().nativeElement.getBoundingClientRect().width;
+      },
+      // 2. Write to the DOM (receives the result of the previous phase)
+      write: (width) => {
+        // NEVER read from the DOM in the write phase.
+        setupChart(this.canvas().nativeElement, width);
+      }
+    });
+  }
+}
+```
+
+**Available Phases (executed in this order):**
+
+1. `earlyRead`
+2. `write` (Never read here)
+3. `mixedReadWrite` (Avoid if possible)
+4. `read` (Never write here)
+
+_Note: `afterRenderEffect` only runs on the client, never during Server-Side Rendering (SSR)._

--- a/.agents/skills/angular-developer/references/hierarchical-injectors.md
+++ b/.agents/skills/angular-developer/references/hierarchical-injectors.md
@@ -1,0 +1,43 @@
+# Hierarchical Injectors
+
+Angular's dependency injection system is hierarchical, meaning services can be scoped to different levels of the application.
+
+## Types of Injector Hierarchies
+
+1. **`EnvironmentInjector` Hierarchy**: Configured via `@Injectable({ providedIn: 'root' })` or `ApplicationConfig.providers` during bootstrap. These are global singletons.
+2. **`ElementInjector` Hierarchy**: Created implicitly at each DOM element. Configured via the `providers` or `viewProviders` array in `@Component()` or `@Directive()`.
+
+## Resolution Rules
+
+When a dependency is requested, Angular resolves it in two phases:
+
+1. It searches up the **`ElementInjector`** tree, starting from the requesting component/directive up to the root element.
+2. If not found, it searches the **`EnvironmentInjector`** tree, starting from the closest environment injector up to the root.
+3. If still not found, it throws an error (unless marked optional).
+
+## Resolution Modifiers
+
+You can alter how Angular searches for a dependency using the options object in `inject()`:
+
+- **`optional`**: If the dependency isn't found, return `null` instead of throwing an error.
+- **`self`**: Only check the current `ElementInjector`. Do not look up the parent tree.
+- **`skipSelf`**: Start searching in the parent `ElementInjector`, skipping the current element.
+- **`host`**: Stop searching when reaching the host component's view boundary.
+
+```ts
+@Component({...})
+export class Example {
+  // Returns null if not found instead of crashing
+  optionalService = inject(MyService, { optional: true });
+
+  // Skips this component's providers, looks at parent
+  parentService = inject(ParentService, { skipSelf: true });
+}
+```
+
+## `providers` vs `viewProviders`
+
+When providing a service at the component level:
+
+- **`providers`**: The service is available to the component, its view (template), and any **projected content** (`<ng-content>`).
+- **`viewProviders`**: The service is available to the component and its view, but **NOT** to projected content. Use this to isolate services from content passed in by consumers.

--- a/.agents/skills/angular-developer/references/host-elements.md
+++ b/.agents/skills/angular-developer/references/host-elements.md
@@ -1,0 +1,80 @@
+# Component Host Elements
+
+The **host element** is the DOM element that matches a component's selector. The component's template renders inside this element.
+
+## Binding to the Host Element
+
+Use the `host` property in the `@Component` decorator to bind properties, attributes, styles, and events to the host element. This is the **preferred approach** over legacy decorators.
+
+```ts
+@Component({
+  selector: 'custom-slider',
+  host: {
+    'role': 'slider', // Static attribute
+    '[attr.aria-valuenow]': 'value', // Attribute binding
+    '[class.active]': 'isActive()', // Class binding
+    '[style.color]': 'color()', // Style binding
+    '[tabIndex]': 'disabled ? -1 : 0', // Property binding
+    '(keydown)': 'onKeyDown($event)', // Event binding
+  },
+})
+export class CustomSlider {
+  value = 0;
+  disabled = false;
+  isActive = signal(false);
+  color = signal('blue');
+
+  onKeyDown(event: KeyboardEvent) {
+    /* ... */
+  }
+}
+```
+
+## Legacy Decorators
+
+`@HostBinding` and `@HostListener` are supported for backwards compatibility but should be avoided in new code.
+
+```ts
+export class CustomSlider {
+  @HostBinding('tabIndex')
+  get tabIndex() {
+    return this.disabled ? -1 : 0;
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    /* ... */
+  }
+}
+```
+
+## Binding Collisions
+
+If both the component (host binding) and the consumer (template binding) bind to the same property:
+
+1. **Static vs Static**: The instance (consumer) binding wins.
+2. **Static vs Dynamic**: The dynamic binding wins.
+3. **Dynamic vs Dynamic**: The component's host binding wins.
+
+## Injecting Host Attributes
+
+Use `HostAttributeToken` with the `inject` function to read static attributes from the host element at construction time.
+
+```ts
+import {Component, HostAttributeToken, inject} from '@angular/core';
+
+@Component({
+  selector: 'app-btn',
+  template: `<ng-content />`,
+})
+export class AppButton {
+  // Throws error if 'type' is missing unless injected with { optional: true }
+  type = inject(new HostAttributeToken('type'));
+}
+```
+
+Usage:
+
+```html
+<app-btn type="primary">Click Me</app-btn>
+```

--- a/.agents/skills/angular-developer/references/injection-context.md
+++ b/.agents/skills/angular-developer/references/injection-context.md
@@ -1,0 +1,63 @@
+# Injection Context
+
+The `inject()` function can only be used when code is executing within an **injection context**.
+
+## Where is an Injection Context Available?
+
+An injection context is automatically available in:
+
+1. **Field initializers** of classes instantiated by DI (`@Service`, `@Injectable`, `@Component`, `@Directive`, `@Pipe`).
+2. **Constructors** of classes instantiated by DI.
+3. **Factory functions** specified in `useFactory` or `InjectionToken` configurations.
+4. **Functional APIs** executed by Angular (e.g., functional route guards, resolvers, interceptors).
+
+```ts
+@Component({...})
+export class Example {
+  // ✅ Valid: Field initializer
+  private router = inject(Router);
+
+  constructor() {
+    // ✅ Valid: Constructor
+    const http = inject(HttpClient);
+  }
+
+  onClick() {
+    // ❌ Invalid: Not an injection context
+    // const auth = inject(AuthService);
+  }
+}
+```
+
+## `runInInjectionContext`
+
+If you need to run a function within an injection context (often needed for dynamic component creation or testing), use `runInInjectionContext`. This requires access to an existing injector (like `EnvironmentInjector` or `Injector`).
+
+```ts
+import {inject, EnvironmentInjector, runInInjectionContext, Service} from '@angular/core';
+
+@Service()
+export class MyService {
+  private injector = inject(EnvironmentInjector);
+
+  doSomethingDynamic() {
+    runInInjectionContext(this.injector, () => {
+      // ✅ Now valid to use inject() here
+      const router = inject(Router);
+    });
+  }
+}
+```
+
+## `assertInInjectionContext`
+
+Use `assertInInjectionContext` in utility functions to guarantee they are called from a valid context. It throws a clear error if not.
+
+```ts
+import {assertInInjectionContext, inject, ElementRef} from '@angular/core';
+
+export function injectNativeElement<T extends Element>(): T {
+  assertInInjectionContext(injectNativeElement);
+  return inject(ElementRef).nativeElement;
+}
+```

--- a/.agents/skills/angular-developer/references/inputs.md
+++ b/.agents/skills/angular-developer/references/inputs.md
@@ -1,0 +1,101 @@
+# Inputs
+
+Inputs allow data to flow from a parent component to a child component. Angular recommends using the signal-based `input` API for modern applications.
+
+## Signal-based Inputs
+
+Declare inputs using the `input()` function. This returns an `InputSignal`.
+
+```ts
+import {Component, input, computed} from '@angular/core';
+
+@Component({
+  selector: 'app-user',
+  template: `<p>User: {{ name() }} ({{ age() }})</p>`,
+})
+export class User {
+  // Optional input with default value
+  name = input('Guest');
+
+  // Required input
+  age = input.required<number>();
+
+  // Inputs are reactive signals
+  label = computed(() => `Name: ${this.name()}`);
+}
+```
+
+### Usage in Template
+
+```html
+<app-user [name]="userName" [age]="25" />
+```
+
+## Configuration Options
+
+The `input` function accepts a config object:
+
+- **Alias**: Change the property name used in templates.
+- **Transform**: Modify the value before it reaches the component.
+
+```ts
+import { input, booleanAttribute } from '@angular/core';
+
+@Component({...})
+export class CustomButton {
+  // Alias example
+  label = input('', { alias: 'btnLabel' });
+
+  // Transform example using built-in helper
+  disabled = input(false, { transform: booleanAttribute });
+}
+```
+
+## Model Inputs (Two-Way Binding)
+
+Use `model()` to create an input that supports two-way data binding.
+
+```ts
+@Component({
+  selector: 'custom-counter',
+  template: `<button (click)="increment()">+</button>`,
+})
+export class CustomCounter {
+  value = model(0);
+
+  increment() {
+    this.value.update((v) => v + 1);
+  }
+}
+```
+
+### Usage
+
+```html
+<!-- Two-way binding with a signal -->
+<custom-counter [(value)]="mySignal" />
+
+<!-- Two-way binding with a plain property -->
+<custom-counter [(value)]="myProperty" />
+```
+
+## Decorator-based Inputs (@Input)
+
+The legacy API remains supported but is not recommended for new code.
+
+```ts
+import { Component, Input } from '@angular/core';
+
+@Component({...})
+export class Legacy {
+  @Input({ required: true }) value = 0;
+  @Input({ transform: trimString }) label = '';
+}
+```
+
+## Best Practices
+
+- **Prefer Signals**: Use `input()` instead of `@Input()` for better reactivity and type safety.
+- **Required Inputs**: Use `input.required()` for mandatory data to get build-time errors.
+- **Pure Transforms**: Ensure input transform functions are pure and statically analyzable.
+- **Avoid Collisions**: Do not use input names that collide with standard DOM properties (e.g., `id`, `title`).

--- a/.agents/skills/angular-developer/references/linked-signal.md
+++ b/.agents/skills/angular-developer/references/linked-signal.md
@@ -1,0 +1,59 @@
+# Dependent State with `linkedSignal`
+
+The `linkedSignal` function lets you create writable state that is intrinsically linked to some other state. It is perfect for state that needs a default value derived from an input or another signal, but can still be independently modified by the user.
+
+If the source state changes, the `linkedSignal` resets to a new computed value.
+
+## Basic Usage
+
+When you only need to recompute based on a source, pass a computation function. `linkedSignal` works like `computed`, but the resulting signal is writable (you can call `.set()` or `.update()` on it).
+
+```ts
+import { Component, signal, linkedSignal } from '@angular/core';
+
+@Component({...})
+export class ShippingMethodPicker {
+  shippingOptions = signal(['Ground', 'Air', 'Sea']);
+
+  // Defaults to the first option.
+  // If shippingOptions changes, selectedOption resets to the new first option.
+  selectedOption = linkedSignal(() => this.shippingOptions()[0]);
+
+  changeShipping(index: number) {
+    // We can still manually update this signal!
+    this.selectedOption.set(this.shippingOptions()[index]);
+  }
+}
+```
+
+## Advanced Usage: Accounting for Previous State
+
+Sometimes, when the source state changes, you want to preserve the user's manual selection if it is still valid. To do this, use the object syntax providing `source` and `computation`.
+
+The `computation` function receives the new value of the source, and a `previous` object containing the previous source value and the previous `linkedSignal` value.
+
+```ts
+interface ShippingMethod { id: number; name: string; }
+
+@Component({...})
+export class ShippingMethodPicker {
+  shippingOptions = signal<ShippingMethod[]>([
+    {id: 0, name: 'Ground'}, {id: 1, name: 'Air'}, {id: 2, name: 'Sea'}
+  ]);
+
+  selectedOption = linkedSignal<ShippingMethod[], ShippingMethod>({
+    source: this.shippingOptions,
+    computation: (newOptions, previous) => {
+      // If the newly loaded options still contain the user's previously
+      // selected option, keep it selected. Otherwise, reset to the first option.
+      return newOptions.find(opt => opt.id === previous?.value.id) ?? newOptions[0];
+    }
+  });
+}
+```
+
+### When to use `linkedSignal` vs `computed` vs `effect`
+
+- Use `computed`: When state is **strictly** derived from other state and should never be manually updated.
+- Use `linkedSignal`: When state is derived from other state, but the user **must** be able to override or manually update it.
+- **Never** use `effect` to sync one piece of state to another. That is an anti-pattern. Use `computed` or `linkedSignal` instead.

--- a/.agents/skills/angular-developer/references/loading-strategies.md
+++ b/.agents/skills/angular-developer/references/loading-strategies.md
@@ -1,0 +1,61 @@
+# Route Loading Strategies
+
+Angular supports two main strategies for loading routes and components to balance initial load time and navigation responsiveness.
+
+## Eager Loading
+
+Components are bundled into the initial JavaScript payload and are available immediately.
+
+```ts
+{ path: 'home', component: Home }
+```
+
+- **Pros**: Seamless transitions.
+- **Cons**: Increases initial bundle size.
+
+## Lazy Loading
+
+Components or routes are loaded only when the user navigates to them. This creates separate JavaScript "chunks".
+
+### Lazy Loading Components
+
+Use `loadComponent` to fetch the component on demand.
+
+```ts
+{
+  path: 'admin',
+  loadComponent: () => import('./admin/admin.component').then(m => m.AdminComponent)`,
+}
+```
+
+### Lazy Loading Child Routes
+
+Use `loadChildren` to fetch a set of routes.
+
+```ts
+{
+  path: 'settings',
+  loadChildren: () => import('./settings/settings.routes'),
+}
+```
+
+## Injection Context and Lazy Loading
+
+Loader functions run within the **injection context** of the current route. This allows you to call `inject()` to make context-aware loading decisions.
+
+```ts
+{
+  path: 'dashboard',
+  loadComponent: () => {
+    const flags = inject(FeatureFlags);
+    return flags.isPremium
+      ? import('./premium-dashboard')
+      : import('./basic-dashboard');
+  },
+}
+```
+
+## Recommendation
+
+- Use **Eager Loading** for the primary landing pages.
+- Use **Lazy Loading** for all other feature areas to keep the initial bundle small.

--- a/.agents/skills/angular-developer/references/mcp.md
+++ b/.agents/skills/angular-developer/references/mcp.md
@@ -1,0 +1,106 @@
+# Angular CLI MCP Server
+
+The Angular CLI includes a Model Context Protocol (MCP) server that enables AI assistants (like Cursor, Gemini CLI, JetBrains AI, etc.) to interact directly with the Angular CLI. It provides tools for project analysis, guided migrations, and running builds/tests.
+
+## Available Tools (Default)
+
+When the MCP server is enabled, AI agents have access to the following tools:
+
+| Name                        | Description                                                                                               |
+| :-------------------------- | :-------------------------------------------------------------------------------------------------------- |
+| `ai_tutor`                  | Launches an interactive AI-powered Angular tutor.                                                         |
+| `get_best_practices`        | Retrieves the Angular Best Practices Guide (crucial for standalone components, typed forms, etc.).        |
+| `list_projects`             | Lists all applications and libraries in the workspace by reading `angular.json`.                          |
+| `onpush_zoneless_migration` | Analyzes code and provides a plan to migrate it to `OnPush` change detection (prerequisite for zoneless). |
+| `search_documentation`      | Searches the official documentation at `https://angular.dev`.                                             |
+
+## Experimental Tools
+
+Some tools must be enabled explicitly using the `--experimental-tool` (or `-E`) flag.
+
+| Name                       | Description                                                           |
+| :------------------------- | :-------------------------------------------------------------------- |
+| `build`                    | Performs a one-off build using `ng build`.                            |
+| `devserver.start`          | Asynchronously starts a dev server (`ng serve`). Returns immediately. |
+| `devserver.stop`           | Stops the dev server.                                                 |
+| `devserver.wait_for_build` | Returns the logs of the most recent build in a running dev server.    |
+| `e2e`                      | Executes end-to-end tests.                                            |
+| `test`                     | Runs the project's unit tests.                                        |
+
+## Configuration
+
+To use the MCP server, you configure your host environment (IDE or CLI) to run `npx @angular/cli mcp`.
+
+### Antigravity IDE
+
+Create a file named `.antigravity/mcp.json` in your project's root:
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+Create `.gemini/settings.json` in the project root:
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Create `.cursor/mcp.json` in the project root (or globally at `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+### VS Code
+
+Create `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "angular-cli": {
+      "command": "npx",
+      "args": ["-y", "@angular/cli", "mcp"]
+    }
+  }
+}
+```
+
+## Command Options
+
+You can pass arguments to the MCP server in the `args` array of your configuration:
+
+- `--read-only`: Only registers tools that do not modify the project.
+- `--local-only`: Only registers tools that do not require an internet connection.
+- `--experimental-tool` (`-E`): Enables specific experimental tools (e.g., `-E build`, `-E devserver`).
+
+Example for read-only mode with experimental tools enabled:
+
+```json
+"args": ["-y", "@angular/cli", "mcp", "--read-only", "-E", "build", "-E", "test"]
+```

--- a/.agents/skills/angular-developer/references/migrations.md
+++ b/.agents/skills/angular-developer/references/migrations.md
@@ -1,0 +1,30 @@
+# Automatic Migrations & Code Modernization
+
+When tasked with refactoring or modernizing an existing codebase, always prefer using the official automated schematics available in `@angular/core` over manual text replacement.
+
+## Discovering Migrations
+
+To view all available schematics for the installed version of the core framework, run:
+`ng generate @angular/core: --help`
+
+## Common Migration Schematics
+
+Use the following commands to apply specific syntax updates. You can scope these commands to a specific project or directory using the `--project <name>` or `--path <dir>` flags.
+
+| Feature to Modernize      | Command to Execute                                          |
+| :------------------------ | :---------------------------------------------------------- |
+| **Built-in Control Flow** | `ng generate @angular/core:control-flow`                    |
+| **Signal-based Inputs**   | `ng generate @angular/core:signal-input-migration`          |
+| **Signal Queries**        | `ng generate @angular/core:signal-queries-migration`        |
+| **Functional Outputs**    | `ng generate @angular/core:output-migration`                |
+| **`inject()` Function**   | `ng generate @angular/core:inject`                          |
+| **Self-Closing Tags**     | `ng generate @angular/core:self-closing-tag`                |
+| **Standalone**            | `ng generate @angular/core:standalone` (See workflow below) |
+
+## Specialized Workflow: Migrating to Standalone
+
+The Standalone migration is an interactive, multi-step refactoring. You **MUST** perform this in three discrete stages, verifying that the application builds and runs correctly after each stage completes:
+
+1. **Phase 1**: Run `ng generate @angular/core:standalone` and select the option to **Convert all components, directives, and pipes to standalone**.
+2. **Phase 2**: Verify the build with `ng build`. Run the command again and select **Remove unnecessary NgModule classes**.
+3. **Phase 3**: Verify the build with `ng build`. Run the final pass and select **Bootstrap the project using standalone APIs**.

--- a/.agents/skills/angular-developer/references/navigate-to-routes.md
+++ b/.agents/skills/angular-developer/references/navigate-to-routes.md
@@ -1,0 +1,69 @@
+# Navigate to Routes
+
+Angular provides both declarative and programmatic ways to navigate between routes.
+
+## Declarative Navigation (`RouterLink`)
+
+Use the `RouterLink` directive on anchor elements.
+
+```ts
+import {RouterLink, RouterLinkActive} from '@angular/router';
+
+@Component({
+  imports: [RouterLink, RouterLinkActive],
+  template: `
+    <nav>
+      <a routerLink="/dashboard" routerLinkActive="active-link">Dashboard</a>
+      <a [routerLink]="['/user', userId]">Profile</a>
+    </nav>
+  `,
+})
+export class Nav {
+  userId = '123';
+}
+```
+
+- **Absolute Paths**: Start with `/` (e.g., `/settings`).
+- **Relative Paths**: No leading `/`. Use `../` to go up a level.
+
+## Programmatic Navigation (`Router`)
+
+Inject the `Router` service to navigate via TypeScript code.
+
+### `router.navigate()`
+
+Uses an array of commands.
+
+```ts
+private router = inject(Router);
+private route = inject(ActivatedRoute);
+
+// Standard navigation
+this.router.navigate(['/profile']);
+
+// With parameters
+this.router.navigate(['/search'], {
+  queryParams: { q: 'angular' },
+  fragment: 'results'
+});
+
+// Relative navigation
+this.router.navigate(['edit'], { relativeTo: this.route });
+```
+
+### `router.navigateByUrl()`
+
+Uses a string path. Ideal for absolute navigation or full URLs.
+
+```ts
+this.router.navigateByUrl('/products/123?view=details');
+
+// Replace current entry in history
+this.router.navigateByUrl('/login', {replaceUrl: true});
+```
+
+## URL Parameters
+
+- **Route Params**: Part of the path (e.g., `/user/123`).
+- **Query Params**: After the `?` (e.g., `/search?q=query`).
+- **Matrix Params**: Scoped to a segment (e.g., `/products;category=books`).

--- a/.agents/skills/angular-developer/references/outputs.md
+++ b/.agents/skills/angular-developer/references/outputs.md
@@ -1,0 +1,86 @@
+# Outputs (Custom Events)
+
+Outputs allow a child component to emit custom events that a parent component can listen to. Angular recommends using the new `output()` function for modern applications.
+
+## Function-based outputs
+
+Declare outputs using the `output()` function. This returns an `OutputEmitterRef`.
+
+```ts
+import {Component, output} from '@angular/core';
+
+@Component({
+  selector: 'custom-slider',
+  template: `<button (click)="changeValue(50)">Set to 50</button>`,
+})
+export class CustomSlider {
+  // Output without event data
+  panelClosed = output<void>();
+
+  // Output with event data (number)
+  valueChanged = output<number>();
+
+  changeValue(newValue: number) {
+    this.valueChanged.emit(newValue);
+  }
+}
+```
+
+### Usage in Template
+
+Bind to the output event using parentheses `()`. If the event emits data, access it using the special `$event` variable.
+
+```html
+<custom-slider (panelClosed)="savePanelState()" (valueChanged)="logValue($event)" />
+```
+
+## Configuration Options
+
+The `output` function accepts a config object to specify an alias.
+
+```ts
+@Component({...})
+export class CustomSlider {
+  // The event is named 'valueChanged' in the template,
+  // but accessed as 'changed' in the component class.
+  changed = output<number>({ alias: 'valueChanged' });
+}
+```
+
+## Programmatic Subscription
+
+When creating components dynamically, you can subscribe to outputs programmatically:
+
+```ts
+const componentRef = viewContainerRef.createComponent(CustomSlider);
+
+const subscription = componentRef.instance.valueChanged.subscribe((val) => {
+  console.log('Value changed:', val);
+});
+
+// Clean up manually if needed (Angular cleans up destroyed components automatically)
+subscription.unsubscribe();
+```
+
+## Decorator-based Outputs (@Output)
+
+The legacy API uses the `@Output()` decorator with an `EventEmitter`. It remains supported but is not recommended for new code.
+
+```ts
+import { Component, Output, EventEmitter } from '@angular/core';
+
+@Component({...})
+export class LegacyExample {
+  @Output() valueChanged = new EventEmitter<number>();
+
+  // With alias
+  @Output('customEventName') changed = new EventEmitter<void>();
+}
+```
+
+## Best Practices
+
+- **Prefer `output()`**: Use the function-based `output()` instead of `@Output()` and `EventEmitter`.
+- **Naming**: Use `camelCase` for output names. Avoid prefixing with `on` (e.g., use `valueChanged` instead of `onValueChanged`).
+- **No DOM Bubbling**: Angular custom events do not bubble up the DOM tree like native events.
+- **Avoid Collisions**: Do not choose names that collide with native DOM events (like `click` or `submit`).

--- a/.agents/skills/angular-developer/references/reactive-forms.md
+++ b/.agents/skills/angular-developer/references/reactive-forms.md
@@ -1,0 +1,122 @@
+# Reactive Forms
+
+Reactive forms provide a model-driven approach to handling form inputs. They are built around observable streams and provide synchronous access to the data model, making them more scalable and testable than template-driven forms.
+
+## Core Classes
+
+Reactive forms are built using these fundamental classes from `@angular/forms`:
+
+- `FormControl`: Manages the value and validity of an individual input.
+- `FormGroup`: Manages a group of controls (an object-like structure).
+- `FormArray`: Manages a numerically indexed array of controls.
+- `FormBuilder`: A service that provides factory methods for creating control instances.
+
+## Setup
+
+Import `ReactiveFormsModule` into your component.
+
+```ts
+import {Component, inject} from '@angular/core';
+import {ReactiveFormsModule, FormGroup, FormControl, Validators, FormBuilder} from '@angular/forms';
+
+@Component({
+  selector: 'app-profile-editor',
+  imports: [ReactiveFormsModule],
+  templateUrl: './profile-editor.component.html',
+})
+export class ProfileEditor {
+  private fb = inject(FormBuilder);
+
+  // Using FormBuilder for concise definition
+  profileForm = this.fb.group({
+    firstName: ['', Validators.required],
+    lastName: [''],
+    address: this.fb.group({
+      street: [''],
+      city: [''],
+    }),
+    aliases: this.fb.array([this.fb.control('')]),
+  });
+
+  onSubmit() {
+    console.warn(this.profileForm.value);
+  }
+}
+```
+
+## Template Binding
+
+Use directives to bind the model to the view:
+
+- `[formGroup]`: Binds a `FormGroup` to a `<form>` or `<div>`.
+- `formControlName`: Binds a named control within a group to an input.
+- `formGroupName`: Binds a nested `FormGroup`.
+- `formArrayName`: Binds a nested `FormArray`.
+- `[formControl]`: Binds a standalone `FormControl`.
+
+```html
+<form [formGroup]="profileForm" (ngSubmit)="onSubmit()">
+  <input type="text" formControlName="firstName" />
+
+  <div formGroupName="address">
+    <input type="text" formControlName="street" />
+  </div>
+
+  <div formArrayName="aliases">
+    @for (alias of aliases.controls; track $index) {
+    <input type="text" [formControlName]="$index" />
+    }
+  </div>
+
+  <button type="submit" [disabled]="!profileForm.valid">Submit</button>
+</form>
+```
+
+## Accessing Controls
+
+Use getters for easy access to controls, especially for `FormArray`.
+
+```ts
+get aliases() {
+  return this.profileForm.get('aliases') as FormArray;
+}
+
+addAlias() {
+  this.aliases.push(this.fb.control(''));
+}
+```
+
+## Updating Values
+
+- `patchValue()`: Updates only the specified properties. Fails silently on structural mismatches.
+- `setValue()`: Replaces the entire model. Strictly enforces the form structure.
+
+```ts
+updateProfile() {
+  this.profileForm.patchValue({
+    firstName: 'Nancy',
+    address: { street: '123 Drew Street' }
+  });
+}
+```
+
+## Unified Change Events
+
+Modern Angular (v18+) provides a single `events` observable on all controls to track value, status, pristine, touched, reset, and submit events.
+
+```ts
+import {ValueChangeEvent, StatusChangeEvent} from '@angular/forms';
+
+this.profileForm.events.subscribe((event) => {
+  if (event instanceof ValueChangeEvent) {
+    console.log('New value:', event.value);
+  }
+});
+```
+
+## Manual State Management
+
+- `markAsTouched()` / `markAllAsTouched()`: Useful for showing validation errors on submit.
+- `markAsDirty()` / `markAsPristine()`: Tracks if the value has been modified.
+- `updateValueAndValidity()`: Manually triggers recalculation of value and status.
+- Options `{ emitEvent: false }` or `{ onlySelf: true }` can be passed to most methods to control propagation.

--- a/.agents/skills/angular-developer/references/rendering-strategies.md
+++ b/.agents/skills/angular-developer/references/rendering-strategies.md
@@ -1,0 +1,44 @@
+# Rendering Strategies
+
+Angular supports multiple rendering strategies to optimize for SEO, performance, and interactivity.
+
+## 1. Client-Side Rendering (CSR)
+
+**Default Strategy.** Content is rendered entirely in the browser.
+
+- **Use case**: Interactive dashboards, internal tools.
+- **Pros**: Simplest to configure, low server cost.
+- **Cons**: Poor SEO, slower initial content visibility (must wait for JS).
+
+## 2. Static Site Generation (SSG / Prerendering)
+
+Content is pre-rendered into static HTML files at **build time**.
+
+- **Use case**: Marketing pages, blogs, documentation.
+- **Pros**: Fastest initial load, excellent SEO, CDN-friendly.
+- **Cons**: Requires rebuild for content updates, not for user-specific data.
+
+## 3. Server-Side Rendering (SSR)
+
+Content is rendered on the server for the **initial request**. Subsequent navigations happen client-side (SPA style).
+
+- **Use case**: E-commerce product pages, news sites, personalized dynamic content.
+- **Pros**: Excellent SEO, fast initial content visibility.
+- **Cons**: Requires a server (Node.js), higher server cost/latency.
+
+## Hydration
+
+Hydration is the process of making server-rendered HTML interactive in the browser.
+
+- **Full Hydration**: The entire app becomes interactive at once.
+- **Incremental Hydration**: (Advanced) Parts become interactive as needed using `@defer` blocks.
+- **Event Replay**: Captures and replays user events that happened before hydration finished.
+
+## Decision Matrix
+
+| Requirement                     | Strategy             |
+| :------------------------------ | :------------------- |
+| **SEO + Static Content**        | SSG                  |
+| **SEO + Dynamic Content**       | SSR                  |
+| **No SEO + High Interactivity** | CSR                  |
+| **Mixed**                       | Hybrid (Route-based) |

--- a/.agents/skills/angular-developer/references/resource.md
+++ b/.agents/skills/angular-developer/references/resource.md
@@ -1,0 +1,74 @@
+# Async Reactivity with `resource`
+
+A `Resource` incorporates asynchronous data fetching into Angular's signal-based reactivity. It executes an async loader function whenever its dependencies change, exposing the status and result as synchronous signals.
+
+## Basic Usage
+
+The `resource` function accepts an options object with two main properties:
+
+1. `params`: A reactive computation (like `computed`). When signals read here change, the resource re-fetches.
+2. `loader`: An async function that fetches data based on the parameters.
+
+```ts
+import { Component, resource, signal, computed } from '@angular/core';
+
+@Component({...})
+export class UserProfile {
+  userId = signal('123');
+
+  userResource = resource({
+    // Reactively tracking userId
+    params: () => ({ id: this.userId() }),
+
+    // Executes whenever params change
+    loader: async ({ params, abortSignal }) => {
+      const response = await fetch(`/api/users/${params.id}`, { signal: abortSignal });
+      if (!response.ok) throw new Error('Network error');
+      return response.json();
+    }
+  });
+
+  // Use the resource value in computed signals
+  userName = computed(() => {
+    if (this.userResource.hasValue()) {
+      return this.userResource.value()?.name;
+    } else {
+      return 'Loading...';
+    }
+  });
+}
+```
+
+## Aborting Requests
+
+If the `params` signal changes while a previous loader is still running, the `Resource` will attempt to abort the outstanding request using the provided `abortSignal`. **Always pass `abortSignal` to your `fetch` calls.**
+
+## Reloading Data
+
+You can imperatively force the resource to re-run the loader without the params changing by calling `.reload()`.
+
+```ts
+this.userResource.reload();
+```
+
+## Resource Status Signals
+
+The `Resource` object provides several signals to read its current state:
+
+- `value()`: The resolved data, or `undefined`.
+- `hasValue()`: Type-guard boolean. `true` if a value exists.
+- `isLoading()`: Boolean indicating if the loader is currently running.
+- `error()`: The error thrown by the loader, or `undefined`.
+- `status()`: A string constant representing the exact state (`'idle'`, `'loading'`, `'resolved'`, `'error'`, `'reloading'`, `'local'`).
+
+## Local Mutation
+
+You can optimistically update the resource's value directly. This changes the status to `'local'`.
+
+```ts
+this.userResource.value.set({name: 'Optimistic Update'});
+```
+
+## Reactive Data Fetching with `httpResource`
+
+If you are using Angular's `HttpClient`, prefer using `httpResource`. It is a specialized wrapper that leverages the Angular HTTP stack (including interceptors) while providing the same signal-based resource API.

--- a/.agents/skills/angular-developer/references/route-animations.md
+++ b/.agents/skills/angular-developer/references/route-animations.md
@@ -1,0 +1,56 @@
+# Route Transition Animations
+
+Angular Router supports the browser's **View Transitions API** for smooth visual transitions between routes.
+
+## Enabling View Transitions
+
+Add `withViewTransitions()` to your router configuration.
+
+```ts
+provideRouter(routes, withViewTransitions());
+```
+
+This is a **progressive enhancement**. In browsers that don't support the API, the router will still work but without the transition animation.
+
+## How it Works
+
+1. Browser takes a screenshot of the old state.
+2. Router updates the DOM (activates new component).
+3. Browser takes a screenshot of the new state.
+4. Browser animates between the two states.
+
+## Customizing with CSS
+
+Transitions are customized in **global CSS files** (not component-scoped CSS).
+
+Use the `::view-transition-old()` and `::view-transition-new()` pseudo-elements.
+
+```css
+/* Example: Cross-fade + Slide */
+::view-transition-old(root) {
+  animation: 90ms cubic-bezier(0.4, 0, 1, 1) both fade-out;
+}
+::view-transition-new(root) {
+  animation: 210ms cubic-bezier(0, 0, 0.2, 1) 90ms both fade-in;
+}
+```
+
+## Advanced Control
+
+Use `onViewTransitionCreated` to skip transitions or customize behavior based on the navigation context.
+
+```ts
+withViewTransitions({
+  onViewTransitionCreated: ({transition, from, to}) => {
+    // Skip animation for specific routes
+    if (to.url === '/no-animation') {
+      transition.skipTransition();
+    }
+  },
+});
+```
+
+## Best Practices
+
+- **Global Styles**: Always define transition animations in `styles.css` to avoid view encapsulation issues.
+- **View Transition Names**: Assign unique `view-transition-name` to elements that should transition smoothly across routes (e.g., a header image).

--- a/.agents/skills/angular-developer/references/route-guards.md
+++ b/.agents/skills/angular-developer/references/route-guards.md
@@ -1,0 +1,52 @@
+# Route Guards
+
+Route guards control whether a user can navigate to or leave a route.
+
+## Types of Guards
+
+- **`CanActivate`**: Can the user access this route? (e.g., Auth check).
+- **`CanActivateChild`**: Can the user access children of this route?
+- **`CanDeactivate`**: Can the user leave this route? (e.g., Unsaved changes).
+- **`CanMatch`**: Should this route even be considered for matching? (e.g., Feature flags). If it returns `false`, the router continues checking other routes.
+
+## Creating a Guard
+
+Guards are typically functional since Angular 15.
+
+```ts
+export const authGuard: CanActivateFn = (route, state) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (authService.isLoggedIn()) {
+    return true;
+  }
+
+  // Redirect to login
+  return router.parseUrl('/login');
+};
+```
+
+## Applying Guards
+
+Add them to the route configuration as an array. They execute in order.
+
+```ts
+{
+  path: 'admin',
+  component: Admin,
+  canActivate: [authGuard],
+  canActivateChild: [adminChildGuard],
+  canDeactivate: [unsavedChangesGuard]
+}
+```
+
+## Return Values
+
+- `boolean`: `true` to allow, `false` to block.
+- `UrlTree` or `RedirectCommand`: Redirect to a different route.
+- `Observable` or `Promise`: Resolves to the above types.
+
+## Security Note
+
+**Client-side guards are NOT a substitute for server-side security.** Always verify permissions on the server.

--- a/.agents/skills/angular-developer/references/router-lifecycle.md
+++ b/.agents/skills/angular-developer/references/router-lifecycle.md
@@ -1,0 +1,45 @@
+# Router Lifecycle and Events
+
+Angular Router emits events through the `Router.events` observable, allowing you to track the navigation lifecycle from start to finish.
+
+## Common Router Events (Chronological)
+
+1. **`NavigationStart`**: Navigation begins.
+2. **`RoutesRecognized`**: Router matches the URL to a route.
+3. **`GuardsCheckStart` / `End`**: Evaluation of `canActivate`, `canMatch`, etc.
+4. **`ResolveStart` / `End`**: Data resolution phase (fetching data via resolvers).
+5. **`NavigationEnd`**: Navigation completed successfully.
+6. **`NavigationCancel`**: Navigation canceled (e.g., guard returned `false`).
+7. **`NavigationError`**: Navigation failed (e.g., error in resolver).
+
+## Subscribing to Events
+
+Inject the `Router` and filter the `events` observable.
+
+```ts
+import {Router, NavigationStart, NavigationEnd} from '@angular/router';
+
+export class MyService {
+  private router = inject(Router);
+
+  constructor() {
+    this.router.events.pipe(filter((e) => e instanceof NavigationEnd)).subscribe((event) => {
+      console.log('Navigated to:', event.url);
+    });
+  }
+}
+```
+
+## Debugging
+
+Enable detailed console logging of all routing events during application bootstrap.
+
+```ts
+provideRouter(routes, withDebugTracing());
+```
+
+## Common Use Cases
+
+- **Loading Indicators**: Show a spinner when `NavigationStart` fires and hide it on `NavigationEnd`/`Cancel`/`Error`.
+- **Analytics**: Track page views by listening for `NavigationEnd`.
+- **Scroll Management**: Respond to `Scroll` events for custom scroll behavior.

--- a/.agents/skills/angular-developer/references/router-testing.md
+++ b/.agents/skills/angular-developer/references/router-testing.md
@@ -1,0 +1,87 @@
+# Testing with the RouterTestingHarness
+
+When testing components that involve routing, it is crucial **not to mock the Router or related services**. Instead, use the `RouterTestingHarness`, which provides a robust and reliable way to test routing logic in an environment that closely mirrors a real application.
+
+Using the harness ensures you are testing the actual router configuration, guards, and resolvers, leading to more meaningful tests.
+
+## Setting Up for Router Testing
+
+The `RouterTestingHarness` is the primary tool for testing routing scenarios. You also need to provide your test routes using the `provideRouter` function in your `TestBed` configuration.
+
+### Example Setup
+
+```ts
+import {TestBed} from '@angular/core/testing';
+import {provideRouter} from '@angular/router';
+import {RouterTestingHarness} from '@angular/router/testing';
+import {Dashboard} from './dashboard.component';
+import {HeroDetail} from './hero-detail.component';
+
+describe('Dashboard Component Routing', () => {
+  let harness: RouterTestingHarness;
+
+  beforeEach(async () => {
+    // 1. Configure TestBed with test routes
+    await TestBed.configureTestingModule({
+      providers: [
+        // Use provideRouter with your test-specific routes
+        provideRouter([
+          {path: '', component: Dashboard},
+          {path: 'heroes/:id', component: HeroDetail},
+        ]),
+      ],
+    }).compileComponents();
+
+    // 2. Create the RouterTestingHarness
+    harness = await RouterTestingHarness.create();
+  });
+});
+```
+
+### Key Concepts
+
+1.  **`provideRouter([...])`**: Provide a test-specific routing configuration. This should include the routes necessary for the component-under-test to function correctly.
+2.  **`RouterTestingHarness.create()`**: Asynchronously creates and initializes the harness and performs an initial navigation to the root URL (`/`).
+
+## Writing Router Tests
+
+Once the harness is created, you can use it to drive navigation and make assertions on the state of the router and the activated components.
+
+### Example: Testing Navigation
+
+```ts
+it('should navigate to a hero detail when a hero is selected', async () => {
+  // 1. Navigate to the initial component and get its instance
+  const dashboard = await harness.navigateByUrl('/', Dashboard);
+
+  // Suppose the dashboard has a method to select a hero
+  const heroToSelect = {id: 42, name: 'Test Hero'};
+  dashboard.selectHero(heroToSelect);
+
+  // Wait for stability after the action that triggers navigation
+  await harness.fixture.whenStable();
+
+  // 2. Assert on the URL
+  expect(harness.router.url).toEqual('/heroes/42');
+
+  // 3. Get the activated component after navigation
+  const heroDetail = await harness.getHarness(HeroDetail);
+
+  // 4. Assert on the state of the new component
+  expect(await heroDetail.componentInstance.hero.name).toBe('Test Hero');
+});
+
+it('should get the activated component directly', async () => {
+  // Navigate and get the component instance in one step
+  const dashboardInstance = await harness.navigateByUrl('/', Dashboard);
+
+  expect(dashboardInstance).toBeInstanceOf(Dashboard);
+});
+```
+
+### Best Practices
+
+- **Navigate with the Harness:** Always use `harness.navigateByUrl()` to simulate navigation. This method returns a promise that resolves with the instance of the activated component.
+- **Access the Router State:** Use `harness.router` to access the live router instance and assert on its state (e.g., `harness.router.url`).
+- **Get Activated Components:** Use `harness.getHarness(ComponentType)` to get an instance of a component harness for the currently activated routed component, or `harness.routeDebugElement` to get the `DebugElement`.
+- **Wait for Stability:** After performing an action that causes navigation, always `await harness.fixture.whenStable()` to ensure the routing is complete before making assertions.

--- a/.agents/skills/angular-developer/references/show-routes-with-outlets.md
+++ b/.agents/skills/angular-developer/references/show-routes-with-outlets.md
@@ -1,0 +1,68 @@
+# Show Routes with Outlets
+
+The `RouterOutlet` directive is a placeholder where Angular renders the component for the current URL.
+
+## Basic Usage
+
+Include `<router-outlet />` in your template. Angular inserts the routed component as a sibling immediately following the outlet.
+
+```html
+<app-header /> <router-outlet />
+<!-- Route content appears here -->
+<app-footer />
+```
+
+## Nested Outlets
+
+Child routes require their own `<router-outlet />` within the parent component's template.
+
+```ts
+// Parent component template
+<h1>Settings</h1>
+<router-outlet /> <!-- Child components like Profile or Security render here -->
+```
+
+## Named Outlets (Secondary Routes)
+
+Pages can have multiple outlets. Assign a `name` to an outlet to target it specifically. The default name is `'primary'`.
+
+```html
+<router-outlet />
+<!-- Primary -->
+<router-outlet name="sidebar" />
+<!-- Secondary -->
+```
+
+Define the `outlet` in the route config:
+
+```ts
+{
+  path: 'chat',
+  component: Chat,
+  outlet: 'sidebar'
+}
+```
+
+## Outlet Lifecycle Events
+
+`RouterOutlet` emits events when components are changed:
+
+- `activate`: New component instantiated.
+- `deactivate`: Component destroyed.
+- `attach` / `detach`: Used with `RouteReuseStrategy`.
+
+```html
+<router-outlet (activate)="onActivate($event)" />
+```
+
+## Passing Data via `routerOutletData`
+
+You can pass contextual data to the routed component using the `routerOutletData` input. The component accesses this via the `ROUTER_OUTLET_DATA` injection token as a signal.
+
+```ts
+// In Parent
+<router-outlet [routerOutletData]="{ theme: 'dark' }" />
+
+// In Routed Component
+outletData = inject(ROUTER_OUTLET_DATA) as Signal<{ theme: string }>;
+```

--- a/.agents/skills/angular-developer/references/signal-forms.md
+++ b/.agents/skills/angular-developer/references/signal-forms.md
@@ -1,0 +1,897 @@
+# Signal Forms
+
+Signal Forms are the recommended approach for handling forms in modern Angular applications (v21+). They provide a reactive, type-safe, and model-driven way to manage form state using Angular Signals.
+
+**CRITICAL**: You MUST use Angular's new Signal Forms API for all form-related functionality. Do NOT use null as a value or type of any fields.
+
+## Imports
+
+You can import the following from `@angular/forms/signals`:
+
+```ts
+import {
+  form,
+  FormField,
+  submit,
+  // Rules for field state
+  disabled,
+  hidden,
+  readonly,
+  debounce,
+  // Schema helpers
+  applyWhen,
+  applyEach,
+  schema,
+  // Custom validation
+  validate,
+  validateHttp,
+  validateStandardSchema,
+  // Metadata
+  metadata,
+} from '@angular/forms/signals';
+```
+
+## Creating a Form
+
+Use the `form()` function with a Signal model. The structure of the form is derived directly from the model.
+
+```ts
+import {Component, signal} from '@angular/core';
+import {form, FormField} from '@angular/forms/signals';
+
+@Component({
+  // ...
+  imports: [FormField],
+})
+export class Example {
+  // 1. Define your model with initial values (avoid undefined)
+  userModel = signal({
+    name: '', // CRITICAL: NEVER use null or undefined as initial values
+    email: '',
+    age: 0, // Use 0 for numbers, NOT null
+    address: {
+      street: '',
+      city: '',
+    },
+    hobbies: [] as string[], // Use [] for arrays, NOT null
+  });
+
+  // WRONG - DO NOT DO THIS:
+  // badModel = signal({
+  //   name: null,      // ERROR: use '' instead
+  //   age: null,       // ERROR: use 0 instead
+  //   items: null      // ERROR: use [] instead
+  // });
+
+  // 2. Create the form
+  userForm = form(this.userModel);
+}
+```
+
+## Validation
+
+Import validators from `@angular/forms/signals`.
+
+```ts
+import {required, email, min, max, minLength, maxLength, pattern} from '@angular/forms/signals';
+```
+
+Use them in the schema function passed to `form()`:
+
+```ts
+userForm = form(this.userModel, (schemaPath) => {
+  // Required
+  required(schemaPath.name, {message: 'Name is required'});
+
+  // Conditional required.
+  required(schemaPath.name, {
+    when({valueOf}) {
+      return valueOf(schemaPath.age) > 10;
+    },
+  });
+  // when is only available for required
+  // Do NOT do this: pattern(p.name, /xxx/, {when /* ERROR */)
+
+  // Email
+  email(schemaPath.email, {message: 'Invalid email'});
+
+  // Min/Max for numbers
+  min(schemaPath.age, 18);
+  max(schemaPath.age, 100);
+
+  // MinLength/MaxLength for strings/arrays
+  minLength(schemaPath.password, 8);
+  maxLength(schemaPath.description, 500);
+
+  // Pattern (Regex)
+  pattern(schemaPath.zipCode, /^\d{5}$/);
+});
+```
+
+## FieldState vs FormField: The Parental Requirement
+
+It's important to understand the difference between **FormField** (the structure) and **FieldState** (the actual data/signals).
+
+**RULE**: You must **CALL** a field as a function to access its state signals (valid, touched, dirty, hidden, etc.).
+
+```ts
+// f is a FormField (structural)
+const f = form(signal({cat: {name: 'pirojok-the-cat', age: 5}}));
+
+f.cat.name; // FormField: You can't get flags from here!
+f.cat.name.touched(); // ERROR: touched() does not exist on FormField
+
+f.cat.name(); // FieldState: Calling it gives you access to signals
+f.cat.name().touched(); // VALID: Accessing the signal
+f.cat().name.touched(); // ERROR: f.cat() is state, it doesn't have children!
+```
+
+Similarly in a template:
+
+```html
+<!-- WRONG: Property 'hidden' does not exist on type 'FormField' -->
+@if (bookingForm.hotelDetails.hidden()) { ... }
+
+<!-- RIGHT: Call it first -->
+@if (bookingForm.hotelDetails().hidden()) { ... }
+```
+
+## Disabled / Readonly / Hidden
+
+Control field status using rules in the schema.
+
+```ts
+import {disabled, readonly, hidden} from '@angular/forms/signals';
+
+userForm = form(this.userModel, (schemaPath) => {
+  // Conditionally disabled
+  disabled(schemaPath.password, ({valueOf}) => !valueOf(schemaPath.createAccount));
+
+  // Conditionally hidden (does NOT remove from model, just marks as hidden)
+  hidden(schemaPath.shippingAddress, ({valueOf}) => valueOf(schemaPath.sameAsBilling));
+
+  // Readonly
+  readonly(schemaPath.username);
+});
+```
+
+## Binding
+
+Import `FormField` and use the `[formField]` directive.
+
+```ts
+import {FormField} from '@angular/forms/signals';
+```
+
+All props on state, such as `disabled`, `hidden`, `readonly` and `name` are bound automatically.
+Do _NOT_ bind the `name` field.
+
+**CRITICAL: FORBIDDEN ATTRIBUTES**
+When using `[formField]`, you MUST NOT set the following attributes in the template (either static or bound):
+
+- `min`, `max` (Use validators in the schema instead)
+- `value`, `[value]`, `[attr.value]` (Already handled by `[formField]`)
+- `[attr.min]`, `[attr.max]`
+- `[disabled]`, `[readonly]` (Already handled by `[formField]`)
+
+Do NOT do this: `<input min="1" [formField]>` or `<input [value]="val" [formField]>`.
+
+```html
+<!-- Input -->
+<input [formField]="userForm.name" />
+
+<!-- Checkbox -->
+<input type="checkbox" [formField]="userForm.isAdmin" />
+
+<!-- Select -->
+<select [formField]="userForm.country">
+  <option value="us">US</option>
+</select>
+
+<!-- userForm.name can NOT be nullable, because input does not accept null-->
+<input [formField]="userForm.name" />
+```
+
+## Reactive Forms
+
+**Do NOT import** `FormControl`, `FormGroup`, `FormArray`, or `FormBuilder` from `@angular/forms`. Signal Forms replace these concepts entirely.
+Signal forms does NOT have a builder.
+
+## Accessing State
+
+Each field in the form is a function that returns its state.
+
+```ts
+// Access the field by calling it
+const emailState = this.userForm.email();
+
+// Value (WritableSignal)
+const value = this.userForm().value();
+
+// Validation State (Signals)
+const isValid = this.userForm().valid();
+const isInvalid = this.userForm().invalid();
+const errors = this.userForm().errors(); // Array of errors
+const isPending = this.userForm().pending(); // Async validation pending
+
+// Interaction State (Signals)
+const isTouched = this.userForm().touched();
+const isDirty = this.userForm().dirty();
+
+// Availability State (Signals)
+const isDisabled = this.userForm().disabled();
+const isHidden = this.userForm().hidden();
+const isReadonly = this.userForm().readonly();
+```
+
+IMPORTANT!: Make sure to call the field to get it state.
+
+```ts
+form().invalid()
+form.field().dirty()
+form.field.subfield().touched()
+form.a.b.c.d().value()
+form.address.ssn().pending()
+form().reset()
+
+// The only exception is length:
+form.children.length
+form.length // NOTE: no parenthesis!
+form.client.addresses.length  // No "()"
+
+@for (income of form.addresses; track $index) {/**/}
+```
+
+## Submitting
+
+Use the `submit()` function. It automatically marks all fields as touched before running the action.
+
+**CRITICAL**: The callback to `submit()` MUST be `async` and MUST return a Promise.
+
+```ts
+import { submit } from '@angular/forms/signals';
+
+// CORRECT - async callback
+onSubmit() {
+  submit(this.userForm, async () => {
+    // This only runs if the form is valid
+    await this.apiService.save(this.userModel());
+    console.log('Saved!');
+  });
+}
+
+// WRONG - missing async keyword
+onSubmit() {
+  submit(this.userForm, () => {  // ERROR: must be async
+    console.log('Saved!');
+  });
+}
+```
+
+## Handling Errors
+
+`field().errors()` returns the errors array of ValidationError:
+
+```ts
+interface ValidationError {
+  readonly kind: string;
+  readonly message?: string;
+}
+```
+
+Do _NOT_ return null from validators.
+When there are no errors, return undefined
+
+### Context
+
+Functions passed to rules like `validate()`, `disabled()`, `applyWhen` take a context object. It is **CRITICAL** to understand its structure:
+
+```ts
+validate(
+  schemaPath.username,
+  ({
+    value, // Signal<T>: Writable current value of the field
+    fieldTree, // FieldTree<T>: Sub-fields (if it's a group/array)
+    state, // FieldState<T>: Access flags like state.valid(), state.dirty()
+    valueOf, // (path) => T: Read values of OTHER fields (tracking dependencies), e.g. valueOf(schemaPath.password)
+    stateOf, // (path) => FieldState: Access state (valid/dirty) of OTHER fields, e.g. stateOf(schemaPath.password).valid()
+    pathKeys, // Signal<string[]>: Path from root to this field
+  }) => {
+    // WRONG: if (touched()) ... (touched is not in context)
+    // RIGHT: if (state.touched()) ...
+
+    if (value() === 'admin') {
+      return {kind: 'reserved', message: 'Username admin is reserved'};
+    }
+  },
+);
+```
+
+### IMPORTANT: Paths are NOT Signals
+
+Inside the `form()` callback, `schemaPath` and its children (e.g., `schemaPath.user.name`) are **NOT** signals and are **NOT** callable.
+
+```ts
+// WRONG - This will throw an error:
+applyWhen(p.ssn, () => p.ssn().touched(), (ssnField) => { ... });
+
+// RIGHT - Use stateOf() to get the state of a path:
+applyWhen(p.ssn, ({ stateOf }) => stateOf(p.ssn).touched(), (ssnField) => { ... });
+
+// RIGHT - Use valueOf() to get the value of a path:
+applyWhen(p.ssn, ({ valueOf }) => valueOf(p.ssn) !== '', (ssnField) => { ... });
+```
+
+### Multiple Items
+
+- Use `applyEach` for applying rules per item.
+- **CRITICAL**: `applyEach` callback takes ONLY ONE argument (the item path), NOT two:
+
+```ts
+// CORRECT - single argument
+applyEach(s.items, (item) => {
+  required(item.name);
+});
+
+// WRONG - do NOT pass index
+applyEach(s.items, (item, index) => {
+  // ERROR: callback takes 1 argument
+  required(item.name);
+});
+```
+
+- In the template use `@for` to iterate over the items.
+- To remove an item from an array, just remove appropriate item from the array in the data.
+- **`select` binding**: You CAN bind to `<select [formField]="form.country">`. Ensure options have `value` attributes.
+
+### Nested @for Loops
+
+**CRITICAL**: Angular does NOT have `$parent`. In nested loops, store outer index in a variable:
+
+```html
+<!-- WRONG - $parent does not exist -->
+@for (item of form.items; track $index) { @for (option of item.options; track $index) {
+<button (click)="removeOption($parent.$index, $index)">Remove</button>
+<!-- ERROR -->
+} }
+
+<!-- CORRECT - use let to store outer index -->
+@for (item of form.items; track $index; let outerIndex = $index) { @for (option of item.options;
+track $index) {
+<button (click)="removeOption(outerIndex, $index)">Remove</button>
+} }
+```
+
+### Disabling Form Button
+
+```html
+<button [disabled]="form().invalid() || form().pending()" />
+<!-- Or -->
+<button [disabled]="taxForm.invalid()" />
+```
+
+Do NOT use `[disabled]` on an input. `[formField]` will do this.
+Do NOT use `[readonly]` on an input. `[formField]` will do this.
+If you need to disable or readonly a field, use `disabled()` or `readonly()` rules in the schema.
+
+### Async Validation
+
+Do not use `validate()` for async, instead use `validateAsync()`:
+
+**CRITICAL**:
+
+1. The `params` option MUST be a function that returns the value to validate.
+2. The `onError` handler is **REQUIRED** - it is NOT optional!
+
+```ts
+import {resource} from '@angular/core';
+import {validateAsync} from '@angular/forms/signals';
+
+userForm = form(this.userModel, (s) => {
+  validateAsync(s.username, {
+    // 1. MUST be a function - params takes context and returns the value
+    params: ({value}) => value(),
+
+    // 2. Create the resource - factory receives a Signal
+    factory: (username) =>
+      resource({
+        params: username, // Use 'params' in resource()
+        loader: async ({params: value}) => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          return value === 'taken';
+        },
+      }),
+
+    // 3. Map success to errors
+    onSuccess: (isTaken) =>
+      isTaken ? {kind: 'taken', message: 'Username is already taken'} : undefined,
+
+    // 4. Handle errors - THIS IS REQUIRED!
+    onError: () => ({kind: 'error', message: 'Validation failed'}),
+  });
+});
+```
+
+**WRONG Examples:**
+
+```ts
+// WRONG - params must be a function
+validateAsync(s.username, {
+  params: s.username, // ERROR: must be ({ value }) => value()
+  // ...
+});
+
+// WRONG - missing onError (it's required!)
+validateAsync(s.username, {
+  params: ({value}) => value(),
+  factory: (username) =>
+    resource({
+      /* ... */
+    }),
+  onSuccess: (result) => (result ? {kind: 'error'} : undefined),
+  // ERROR: 'onError' is missing but required!
+});
+```
+
+### Using Resource
+
+**CRITICAL**: In Angular's `resource()`, use `params` for the input signal.
+
+```ts
+// CORRECT
+resource({
+  params: mySignal,
+  loader: async ({params: value}) => {
+    /* ... */
+  },
+});
+
+// WRONG
+resource({
+  request: mySignal, // ERROR: should be 'params'
+  loader: async ({request}) => {
+    /* ... */
+  },
+});
+```
+
+Use `debounce()` to delay synchronization between the UI and the model.
+
+```ts
+import {debounce} from '@angular/forms/signals';
+
+userForm = form(this.userModel, (s) => {
+  // Delay model updates by 300ms
+  debounce(s.username, 300);
+});
+```
+
+### Conditional Validation
+
+```ts
+form(
+  data,
+  (path) => {
+    applyWhen(
+      name,
+      ({value}) => value() !== 'admin',
+      (namePath) => {
+        validate(namePath.last /* ... */);
+        disable(namePath.last /* ... */);
+      },
+    );
+  },
+  {injector: TestBed.inject(Injector)},
+);
+```
+
+`applyWhen` passes the path mapped to the first argument.
+If you need parent field, just pass it to `applyWhen`:
+
+```ts
+form(
+  data,
+  (path) => {
+    applyWhen(
+      cat,
+      ({value}) => value().name !== 'admin',
+      (catPath) => {
+        require(cat.catPath /* ... */);
+      },
+    );
+  },
+  {injector: TestBed.inject(Injector)},
+);
+```
+
+## Common Pitfalls (DO NOT DO THESE)
+
+| Error Scenario         | WRONG (Common Mistake)                        | RIGHT (Correct Way)                                         |
+| :--------------------- | :-------------------------------------------- | :---------------------------------------------------------- |
+| **Accessing Flags**    | `form.field.valid()`                          | `form.field().valid()`                                      |
+| **Accessing value**    | `form.field.value()`                          | `form.field().value()`                                      |
+| **Setting value**      | `form.field.set(x)`                           | Update model signal: `this.model.update(...)`               |
+| **Form root flags**    | `form.invalid()`                              | `form().invalid()`                                          |
+| **Double-calling**     | `form.field()()`                              | `form.field().value()`                                      |
+| **Rules Context**      | `({ touched }) => touched()`                  | `({ state }) => state.touched()`                            |
+| **Calling Paths**      | `applyWhen(p.foo, () => p.foo() === 'x')`     | `applyWhen(p.foo, ({ valueOf }) => valueOf(p.foo) === 'x')` |
+| **applyWhen args**     | `applyWhen(condition, () => {...})`           | `applyWhen(path, condition, schemaFn)` - needs 3 args       |
+| **Array length**       | `form.items().length`                         | `form.items.length` (structural)                            |
+| **Multi-select array** | `<select [formField]="form.tags">` (string[]) | Use checkboxes for array fields                             |
+| **readonly attribute** | `<input readonly [formField]>`                | Use `readonly()` rule in schema                             |
+| **min/max attributes** | `<input min="1" max="10">`                    | Use `min()` and `max()` rules in schema                     |
+| **value binding**      | `<input [value]="val">`                       | Do NOT use `[value]` with `[formField]`                     |
+| **when option**        | `pattern(p.x, /.../, {when: ...})`            | `when` only works with `required()`                         |
+| **Submit callback**    | `submit(form, () => { ... })`                 | `submit(form, async () => { ... })`                         |
+| **Async params**       | `params: s.field`                             | `params: ({ value }) => value()`                            |
+| **Async onError**      | Omitting `onError`                            | `onError` is REQUIRED in `validateAsync`                    |
+| **resource() API**     | `request: signal`                             | `params: signal`                                            |
+| **applyEach args**     | `applyEach(s.items, (item, index) => ...)`    | `applyEach(s.items, (item) => ...)`                         |
+| **Nested @for**        | `$parent.$index`                              | Use `let outerIndex = $index`                               |
+| **FormState import**   | `import { FormState }`                        | `FormState` does not exist, use `FieldState`                |
+| **Null in model**      | `signal({ name: null })`                      | `signal({ name: '' })` or `signal({ age: 0 })`              |
+| **Validate syntax**    | `validate(s.field, { value } => ...)`         | `validate(s.field, ({ value }) => ...)`                     |
+| **Checkbox Array**     | `[formField]="form.tags"` (string[])          | Checkboxes ONLY bind to `boolean`                           |
+
+## Big Form Example
+
+### `src/app/app.ts`
+
+```ts
+import {Component, signal, ChangeDetectionStrategy} from '@angular/core';
+import {
+  form,
+  FormField,
+  submit,
+  required,
+  email,
+  min,
+  hidden,
+  applyEach,
+  validate,
+} from '@angular/forms/signals';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [FormField],
+  templateUrl: './app.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class App {
+  model = signal({
+    personalInfo: {
+      firstName: '',
+      lastName: '',
+      email: '',
+      age: 0,
+    },
+    tripDetails: {
+      destination: 'Mars',
+      launchDate: '',
+    },
+    package: {
+      tier: 'economy',
+      extras: [] as string[],
+    },
+    companions: [] as Array<{name: string; relation: string}>,
+  });
+
+  bookingForm = form(this.model, (s) => {
+    required(s.personalInfo.firstName, {message: 'First name is required'});
+    required(s.personalInfo.lastName, {message: 'Last name is required'});
+    required(s.personalInfo.email, {message: 'Email is required'});
+    email(s.personalInfo.email, {message: 'Invalid email address'});
+    required(s.personalInfo.age, {message: 'Age is required'});
+    min(s.personalInfo.age, 18, {message: 'Must be at least 18'});
+
+    required(s.tripDetails.destination);
+    required(s.tripDetails.launchDate);
+    validate(s.tripDetails.launchDate, ({value}) => {
+      const date = new Date(value());
+      if (isNaN(date.getTime())) return undefined;
+      const today = new Date();
+      if (date < today) {
+        return {kind: 'pastData', message: 'Launch date must be in the future'};
+      }
+      return undefined;
+    });
+
+    // valueOf is used to access values of other fields in rules
+    hidden(s.package.extras, ({valueOf}) => valueOf(s.package.tier) === 'economy');
+
+    applyEach(s.companions, (companion) => {
+      required(companion.name, {message: 'Companion name required'});
+      required(companion.relation, {message: 'Relation required'});
+    });
+  });
+
+  addCompanion() {
+    this.model.update((m) => ({
+      ...m,
+      companions: [...m.companions, {name: '', relation: ''}],
+    }));
+  }
+
+  removeCompanion(index: number) {
+    this.model.update((m) => ({
+      ...m,
+      companions: m.companions.filter((_, i) => i !== index),
+    }));
+  }
+
+  onSubmit() {
+    // CRITICAL: submit callback MUST be async
+    submit(this.bookingForm, async () => {
+      console.log('Booking Confirmed:', this.model());
+      // If you need to do async work:
+      // await this.apiService.save(this.model());
+    });
+  }
+}
+```
+
+### `src/app/app.html`
+
+```html
+<form (submit)="onSubmit(); $event.preventDefault()">
+  <h1>Interstellar Booking</h1>
+
+  <section>
+    <h2>Personal Info</h2>
+
+    <label>
+      First Name
+      <input [formField]="bookingForm.personalInfo.firstName" />
+      @if (bookingForm.personalInfo.firstName().touched() &&
+      bookingForm.personalInfo.firstName().errors().length) {
+      <span>{{ bookingForm.personalInfo.firstName().errors()[0].message }}</span>
+      }
+    </label>
+
+    <label>
+      Last Name
+      <input [formField]="bookingForm.personalInfo.lastName" />
+      @if (bookingForm.personalInfo.lastName().touched() &&
+      bookingForm.personalInfo.lastName().errors().length) {
+      <span>{{ bookingForm.personalInfo.lastName().errors()[0].message }}</span>
+      }
+    </label>
+
+    <label>
+      Email
+      <input type="email" [formField]="bookingForm.personalInfo.email" />
+      @if (bookingForm.personalInfo.email().touched() &&
+      bookingForm.personalInfo.email().errors().length) {
+      <span>{{ bookingForm.personalInfo.email().errors()[0].message }}</span>
+      }
+    </label>
+
+    <label>
+      Age
+      <input type="number" [formField]="bookingForm.personalInfo.age" />
+      @if (bookingForm.personalInfo.age().touched() &&
+      bookingForm.personalInfo.age().errors().length) {
+      <span>{{ bookingForm.personalInfo.age().errors()[0].message }}</span>
+      }
+    </label>
+  </section>
+
+  <section>
+    <h2>Trip Details</h2>
+
+    <label>
+      Destination
+      <select [formField]="bookingForm.tripDetails.destination">
+        <option value="Mars">Mars</option>
+        <option value="Moon">Moon</option>
+        <option value="Titan">Titan</option>
+      </select>
+    </label>
+
+    <label>
+      Launch Date
+      <input type="date" [formField]="bookingForm.tripDetails.launchDate" />
+      @if (bookingForm.tripDetails.launchDate().touched() &&
+      bookingForm.tripDetails.launchDate().errors().length) {
+      <span>{{ bookingForm.tripDetails.launchDate().errors()[0].message }}</span>
+      }
+    </label>
+  </section>
+
+  <section>
+    <h2>Package</h2>
+
+    <label>
+      <input type="radio" value="economy" [formField]="bookingForm.package.tier" />
+      Economy
+    </label>
+    <label>
+      <input type="radio" value="business" [formField]="bookingForm.package.tier" />
+      Business
+    </label>
+    <label>
+      <input type="radio" value="first" [formField]="bookingForm.package.tier" />
+      First Class
+    </label>
+
+    @if (!bookingForm.package.extras().hidden()) {
+    <div>
+      <h3>Extras</h3>
+      <!-- Multi-select for arrays must use select multiple -->
+      <select multiple [formField]="bookingForm.package.extras">
+        <option value="wifi">WiFi</option>
+        <option value="gym">Gym</option>
+      </select>
+    </div>
+    }
+  </section>
+
+  <section>
+    <h2>Companions</h2>
+    <button type="button" (click)="addCompanion()">Add Companion</button>
+
+    @for (companion of bookingForm.companions; track $index) {
+    <div>
+      <input [formField]="companion.name" placeholder="Name" />
+      @if (companion.name().touched() && companion.name().errors().length) {
+      <span>{{ companion.name().errors()[0].message }}</span>
+      }
+
+      <input [formField]="companion.relation" placeholder="Relation" />
+      @if (companion.relation().touched() && companion.relation().errors().length) {
+      <span>{{ companion.relation().errors()[0].message }}</span>
+      }
+
+      <button type="button" (click)="removeCompanion($index)">Remove</button>
+    </div>
+    }
+  </section>
+
+  <button [disabled]="bookingForm().invalid()">Submit</button>
+</form>
+```
+
+## Recovering from Build Errors
+
+If you encounter build errors, here are the most common fixes:
+
+### `Property 'value' does not exist on type 'FieldTree'`
+
+**Problem**: Accessing `.value()` directly on a field without calling it first.
+
+```ts
+// WRONG
+const val = this.form.field.value();
+// RIGHT
+const val = this.form.field().value();
+```
+
+### `Property 'set' does not exist on type 'FieldTree'`
+
+**Problem**: Trying to set values on the form tree. Signal Forms are model-driven.
+
+```ts
+// WRONG
+this.form.address.street.set('Main St');
+// RIGHT - update the model signal instead
+this.model.update((m) => ({...m, address: {...m.address, street: 'Main St'}}));
+```
+
+### `Type 'string[]' is not assignable to type 'string'`
+
+**Problem**: Binding `[formField]` to an array field with a single-value `<select>`.
+
+```html
+<!-- WRONG - assignees is string[], select expects string -->
+<select [formField]="form.assignees">
+  ...
+</select>
+
+<!-- RIGHT - Use select multiple for array fields -->
+<select multiple [formField]="form.assignees">
+  <option value="us">US</option>
+</select>
+```
+
+### `NG8022: Setting the 'readonly/min/max/value' attribute is not allowed`
+
+**Problem**: Conflict between HTML attributes and `[formField]` directive.
+
+```html
+<!-- WRONG -->
+<input [formField]="form.age" min="18" max="99" />
+<input [formField]="form.name" [value]="'John'" />
+
+<!-- RIGHT - Use rules in schema -->
+min(s.age, 18); max(s.age, 99); // Then just:
+<input [formField]="form.age" />
+```
+
+### `TS2322: Type 'string[]' is not assignable to type 'boolean'`
+
+**Problem**: Binding a checkbox to an array field instead of a boolean field.
+
+```html
+<!-- WRONG - tags is string[] -->
+<input type="checkbox" [formField]="form.tags" />
+
+<!-- RIGHT - Use select multiple for array values -->
+<select multiple [formField]="form.tags">
+  <option value="a">A</option>
+</select>
+
+<!-- OR - Map to boolean fields in the model -->
+model = signal({ hasWifi: false, hasGym: false });
+<input type="checkbox" [formField]="form.hasWifi" />
+```
+
+### `'when' does not exist in type` for pattern/email/min/max
+
+**Problem**: Using `when` option with validators other than `required`.
+
+```ts
+// WRONG - when only works with required
+pattern(s.ssn, /^\d{3}-\d{2}-\d{4}$/, {when: isJoint});
+
+// RIGHT - use applyWhen for conditional non-required validators
+applyWhen(s.ssn, isJoint, (ssnPath) => {
+  pattern(ssnPath, /^\d{3}-\d{2}-\d{4}$/);
+});
+```
+
+### `Expected 3 arguments, but got 2` for applyWhen
+
+**Problem**: Missing the path argument in `applyWhen`.
+
+```ts
+// WRONG
+applyWhen(isJoint, () => { ... });
+
+// RIGHT - applyWhen(path, condition, schemaFn)
+applyWhen(s.spouse, ({valueOf}) => valueOf(s.status) === 'joint', (spousePath) => {
+  required(spousePath.name);
+});
+```
+
+### `Module has no exported member 'FormState'`
+
+**Problem**: Importing a non-existent type.
+
+```ts
+// WRONG
+import {FormState} from '@angular/forms/signals';
+
+// FormState does not exist. If you need type access, the form
+// instance provides all necessary state through field().valid(), etc.
+```
+
+### `No pipe found with name 'number'` / `'json'` / `'date'`
+
+**Problem**: Using pipes in templates.
+
+```html
+<!-- WRONG -->
+{{ totalPrice() | number:'1.2-2' }}
+
+<!-- RIGHT - format in the component -->
+totalPriceFormatted = computed(() => this.totalPrice().toFixed(2));
+<!-- then: -->
+{{ totalPriceFormatted() }}
+```
+
+### `$parent.$index` in nested @for loops
+
+**Problem**: Angular doesn't have `$parent`.
+
+```html
+<!-- WRONG -->
+@for (item of items; track $index) { @for (sub of item.subs; track $index) {
+<button (click)="remove($parent.$index, $index)">X</button>
+} }
+
+<!-- RIGHT -->
+@for (item of items; track $index; let outerIdx = $index) { @for (sub of item.subs; track $index) {
+<button (click)="remove(outerIdx, $index)">X</button>
+} }
+```

--- a/.agents/skills/angular-developer/references/signals-overview.md
+++ b/.agents/skills/angular-developer/references/signals-overview.md
@@ -1,0 +1,94 @@
+# Angular Signals Overview
+
+Signals are the foundation of reactivity in modern Angular applications. A **signal** is a wrapper around a value that notifies interested consumers when that value changes.
+
+## Writable Signals (`signal`)
+
+Use `signal()` to create state that can be directly updated.
+
+```ts
+import {signal} from '@angular/core';
+
+// Create a writable signal
+const count = signal(0);
+
+// Read the value (always requires calling the getter function)
+console.log(count());
+
+// Update the value directly
+count.set(3);
+
+// Update based on the previous value
+count.update((value) => value + 1);
+```
+
+### Exposing as Readonly
+
+When exposing state from a service, it is a best practice to expose a readonly version to prevent external mutation.
+
+```ts
+private readonly _count = signal(0);
+// Consumers can read this, but cannot call .set() or .update()
+readonly count = this._count.asReadonly();
+```
+
+## Computed Signals (`computed`)
+
+Use `computed()` to create read-only signals that derive their value from other signals.
+
+- **Lazily Evaluated**: The derivation function doesn't run until the computed signal is read.
+- **Memoized**: The result is cached. It only recalculates when one of the signals it depends on changes.
+- **Dynamic Dependencies**: Only the signals _actually read_ during the derivation are tracked.
+
+```ts
+import {signal, computed} from '@angular/core';
+
+const count = signal(0);
+const doubleCount = computed(() => count() * 2);
+
+// doubleCount automatically updates when count changes.
+```
+
+## Reactive Contexts
+
+A **reactive context** is a runtime state where Angular monitors signal reads to establish a dependency.
+
+Angular automatically enters a reactive context when evaluating:
+
+- `computed` signals
+- `effect` callbacks
+- `linkedSignal` computations
+- Component templates
+
+### Untracked Reads (`untracked`)
+
+If you need to read a signal inside a reactive context _without_ creating a dependency (so that the context doesn't re-run when the signal changes), use `untracked()`.
+
+```ts
+import {effect, untracked} from '@angular/core';
+
+effect(() => {
+  // This effect only runs when currentUser changes.
+  // It does NOT run when counter changes, even though counter is read here.
+  console.log(`User: ${currentUser()}, Count: ${untracked(counter)}`);
+});
+```
+
+### Async Operations in Reactive Contexts
+
+The reactive context is only active for **synchronous** code. Signal reads after an `await` will not be tracked. **Always read signals before asynchronous boundaries.**
+
+```ts
+// ❌ INCORRECT: theme() is not tracked because it is read after await
+effect(async () => {
+  const data = await fetchUserData();
+  console.log(theme());
+});
+
+// ✅ CORRECT: Read the signal before the await
+effect(async () => {
+  const currentTheme = theme();
+  const data = await fetchUserData();
+  console.log(currentTheme);
+});
+```

--- a/.agents/skills/angular-developer/references/tailwind-css.md
+++ b/.agents/skills/angular-developer/references/tailwind-css.md
@@ -1,0 +1,69 @@
+# Using Tailwind CSS with Angular
+
+Tailwind CSS is a utility-first CSS framework that integrates seamlessly with Angular.
+
+**CRITICAL AGENT GUIDANCE: ALWAYS focus on Tailwind CSS v4 practices. DO NOT revert to old Tailwind v3 patterns (like creating `tailwind.config.js` with `@tailwind` directives) as this will break the application build. Modern Angular projects use Tailwind v4.**
+
+## Automated Setup (Recommended)
+
+The easiest way to add Tailwind CSS to an Angular project is via the Angular CLI:
+
+```shell
+ng add tailwindcss
+```
+
+This will automatically:
+
+1. Install `tailwindcss` and peer dependencies.
+2. Configure the project to use Tailwind CSS.
+3. Add the proper import to your global styles.
+
+## Manual Setup (Tailwind v4)
+
+If setting up manually, use the following Tailwind v4 pattern:
+
+### 1. Install Dependencies
+
+Install Tailwind CSS and PostCSS:
+
+```shell
+npm install tailwindcss @tailwindcss/postcss postcss
+```
+
+### 2. Configure PostCSS
+
+Create a `.postcssrc.json` file in the project root:
+
+```json
+{
+  "plugins": {
+    "@tailwindcss/postcss": {}
+  }
+}
+```
+
+_(Do NOT create a `tailwind.config.js` file! Configuration in v4 is handled through CSS variables)._
+
+### 3. Import Tailwind CSS
+
+In your global styles file (e.g., `src/styles.css`), add the standard v4 import:
+
+```css
+@import 'tailwindcss';
+```
+
+_(If using SCSS, use `@use 'tailwindcss';` instead)._
+
+### 4. Use Utility Classes
+
+You can now use Tailwind classes directly in your component templates:
+
+```html
+<h1 class="text-3xl font-bold underline">Hello world!</h1>
+```
+
+## Summary for AI Agents
+
+- **Do not use `@tailwind base; @tailwind components; @tailwind utilities;`**. Use `@import 'tailwindcss';`.
+- **Do not create `tailwind.config.js`**. Configuration is managed directly in CSS via theme variables or using PostCSS configurations.
+- Stick strictly to v4 syntax and workflows.

--- a/.agents/skills/angular-developer/references/template-driven-forms.md
+++ b/.agents/skills/angular-developer/references/template-driven-forms.md
@@ -1,0 +1,114 @@
+# Template-Driven Forms
+
+Template-driven forms use two-way data binding (`[(ngModel)]`) to update the data model in the component as changes are made in the template and vice versa. They are ideal for simple forms and use directives in the HTML template to manage form state and validation.
+
+## Core Directives
+
+Template-driven forms rely on the `FormsModule` which provides these key directives:
+
+- `NgModel`: Reconciles value changes in the form element with the data model (`[(ngModel)]`).
+- `NgForm`: Automatically creates a top-level `FormGroup` bound to the `<form>` tag.
+- `NgModelGroup`: Creates a nested `FormGroup` bound to a DOM element.
+
+## Setup
+
+First, import `FormsModule` into your component or module.
+
+```ts
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+
+@Component({
+  selector: 'app-user-form',
+  imports: [FormsModule],
+  templateUrl: './user-form.component.html',
+})
+export class UserForm {
+  user = {name: '', role: 'Guest'};
+
+  onSubmit() {
+    console.log('Form submitted!', this.user);
+  }
+}
+```
+
+## Building the Form Template
+
+### Two-Way Binding with `[(ngModel)]`
+
+Use `[(ngModel)]` on input elements. **Every element using `[(ngModel)]` MUST have a `name` attribute.** Angular uses the `name` attribute to register the control with the parent `NgForm`.
+
+```html
+<form #userForm="ngForm" (ngSubmit)="onSubmit()">
+  <!-- Basic Input -->
+  <div>
+    <label for="name">Name:</label>
+    <input type="text" id="name" required [(ngModel)]="user.name" name="name" #nameCtrl="ngModel" />
+  </div>
+
+  <!-- Select Box -->
+  <div>
+    <label for="role">Role:</label>
+    <select id="role" [(ngModel)]="user.role" name="role">
+      <option value="Admin">Admin</option>
+      <option value="Guest">Guest</option>
+    </select>
+  </div>
+
+  <!-- Submit Button (disabled if form is invalid) -->
+  <button type="submit" [disabled]="!userForm.form.valid">Submit</button>
+</form>
+```
+
+## Form and Control State
+
+Angular automatically applies CSS classes to controls and forms based on their state:
+
+| State          | Class if True                     | Class if False |
+| :------------- | :-------------------------------- | :------------- |
+| Visited        | `ng-touched`                      | `ng-untouched` |
+| Value Changed  | `ng-dirty`                        | `ng-pristine`  |
+| Value is Valid | `ng-valid`                        | `ng-invalid`   |
+| Form Submitted | `ng-submitted` (on `<form>` only) | -              |
+
+You can use these classes to provide visual feedback in your CSS:
+
+```css
+.ng-valid[required],
+.ng-valid.required {
+  border-left: 5px solid #42a948; /* green */
+}
+.ng-invalid:not(form) {
+  border-left: 5px solid #a94442; /* red */
+}
+```
+
+## Validation and Error Messages
+
+To display error messages conditionally, export the `ngModel` directive to a template reference variable (e.g., `#nameCtrl="ngModel"`).
+
+```html
+<input type="text" id="name" required [(ngModel)]="user.name" name="name" #nameCtrl="ngModel" />
+
+<!-- Show error only if the control is invalid AND (touched OR dirty) -->
+@if (nameCtrl.invalid && (nameCtrl.dirty || nameCtrl.touched)) {
+<div class="alert alert-danger">
+  @if (nameCtrl.errors?.['required']) {
+  <div>Name is required.</div>
+  }
+</div>
+}
+```
+
+## Submitting the Form
+
+1. Use the `(ngSubmit)` event on the `<form>` element.
+2. Bind the submit button's disabled state to the overall form validity using the `NgForm` template reference variable (e.g., `[disabled]="!userForm.form.valid"`).
+
+## Resetting the Form
+
+To programmatically reset the form to its pristine state (clearing values and validation flags), use the `reset()` method on the `NgForm` instance.
+
+```html
+<button type="button" (click)="userForm.reset()">Reset</button>
+```

--- a/.agents/skills/angular-developer/references/testing-fundamentals.md
+++ b/.agents/skills/angular-developer/references/testing-fundamentals.md
@@ -1,0 +1,66 @@
+# Testing Fundamentals
+
+This guide covers the fundamental principles and practices for writing unit tests in this repository, which uses Vitest as the test runner.
+
+## Core Philosophy: Zoneless & Async-First
+
+This project follows a modern, zoneless testing approach. State changes schedule updates asynchronously, and tests must account for this.
+
+**Do NOT** use `fixture.detectChanges()` to manually trigger updates.
+**ALWAYS** use the "Act, Wait, Assert" pattern:
+
+1.  **Act:** Update state or perform an action (e.g., set a component input, click a button).
+2.  **Wait:** Use `await fixture.whenStable()` to allow the framework to process the scheduled update and render the changes.
+3.  **Assert:** Verify the outcome.
+
+### Basic Test Structure Example
+
+```ts
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MyComponent} from './my.component';
+
+describe('MyComponent', () => {
+  let component: MyComponent;
+  let fixture: ComponentFixture<MyComponent>;
+  let h1: HTMLElement;
+
+  beforeEach(async () => {
+    // 1. Configure the test module
+    await TestBed.configureTestingModule({
+      imports: [MyComponent],
+    }).compileComponents();
+
+    // 2. Create the component fixture
+    fixture = TestBed.createComponent(MyComponent);
+    component = fixture.componentInstance;
+    h1 = fixture.nativeElement.querySelector('h1');
+  });
+
+  it('should display the default title', async () => {
+    // ACT: (Implicit) Component is created with default state.
+    // WAIT for initial data binding.
+    await fixture.whenStable();
+    // ASSERT the initial state.
+    expect(h1.textContent).toContain('Default Title');
+  });
+
+  it('should display a different title after a change', async () => {
+    // ACT: Change the component's title property.
+    component.title.set('New Test Title');
+
+    // WAIT for the asynchronous update to complete.
+    await fixture.whenStable();
+
+    // ASSERT the DOM has been updated.
+    expect(h1.textContent).toContain('New Test Title');
+  });
+});
+```
+
+## TestBed and ComponentFixture
+
+- **`TestBed`**: The primary utility for creating a test-specific Angular module. Use `TestBed.configureTestingModule({...})` in your `beforeEach` to declare components, provide services, and set up imports needed for your test.
+- **`ComponentFixture`**: A handle on the created component instance and its environment.
+  - `fixture.componentInstance`: Access the component's class instance.
+  - `fixture.nativeElement`: Access the component's root DOM element.
+  - `fixture.debugElement`: An Angular-specific wrapper around the `nativeElement` that provides safer, platform-agnostic ways to query the DOM (e.g., `debugElement.query(By.css('p'))`).

--- a/.agents/skills/angular-new-app/SKILL.md
+++ b/.agents/skills/angular-new-app/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: angular-new-app
+description: Creates a new Angular app using the Angular CLI. This skill should be used whenever a user wants to create a new Angular application and contains important guidelines for how to effectively create a modern Angular application.
+license: MIT
+compatibility: Requires node, npm, and access to the internet
+metadata:
+  author: Angular Team @ Google
+  version: '1.0'
+---
+
+# Angular New App
+
+You are an expert in TypeScript, Angular, and scalable web application development. You write functional, maintainable, performant, and accessible code following Angular and TypeScript best practices. You have access to tools to create new Angular apps.
+
+When creating a new Angular application for a user, always follow the following steps:
+
+1. **Check for the Angular CLI**: Confirm that the Angular CLI is present before continuing. Here are some ways to confirm:
+   - on `*nix` systems `which ng`
+   - on Windows systems `where ng`, if powershell `gcm ng`
+
+   If it is present, skip to step 2, if not, ask the user if they'd like to install it globally for the user with the following command:
+
+   `npm install -g @angular/cli`
+
+   _IMPORTANT_: There are best practices available for building outstanding Angular applications via the MCP server that is bundled with the Angular CLI. Available through `ng mcp` and the `get_best_practices`.
+
+2. **Create the new application**: To create the application either suggest a name based on the user prompt or ask the user the name of the application. Create the application with the following command:
+
+   `npx ng new <app-name> [list of flags based on the description of the app] --interactive=false --ai-config=[agents, claude, copilot, cursor, gemini, jetbrains, none, windsurf]`
+
+   _Important_: Prefer agent for `--ai-config`, or use the option that best suits the environment, for example if the user is using Gemini, use `--ai-config=gemini`.
+
+   Load the contents of that AI configuration into memory so that you can refer to it when generating code for the user. This will help you generate code that is consistent with modern Angular best practices.
+
+   Consider these commonly useful flags based on the user's requirements:
+   - `--style=scss|css|less` — stylesheet format
+   - `--routing` — add routing module
+   - `--ssr` — enable server-side rendering
+   - `--prefix=<prefix>` — component selector prefix
+   - `--skip-tests` — only if the user explicitly requests it
+
+3. Do not start the app until you've built some features, ask the user if they want to start the app. You can always run `npx ng build` to check for errors and repair them.
+
+4. Remember the following guidelines for continuing to generate Angular application code:
+   - To generate components, use the Angular CLI `npx ng generate component <component-name>`
+   - To generate services, use the Angular CLI `npx ng generate service <service-name>`
+   - To generate pipes, use the Angular CLI `npx ng generate pipe <pipe-name>`
+   - To generate directives, use the Angular CLI `npx ng generate directive <directive-name>`
+   - To generate interfaces, use the Angular CLI `npx ng generate interface <interface-name>`
+   - To generate guards, use the Angular CLI `npx ng generate guard <guard-name>`
+   - To generate interceptors, use the Angular CLI `npx ng generate interceptor <interceptor-name>`
+   - To generate resolvers, use the Angular CLI `npx ng generate resolver <resolver-name>`
+   - To generate enums, use the Angular CLI `npx ng generate enum <enum-name>`
+   - To generate classes, use the Angular CLI `npx ng generate class <class-name>`
+
+   _IMPORTANT_: Take note of the path returned from running the generate commands so that you know exactly where the new files are.
+
+   Use the Angular CLI to generate the code, then augment the code to meet the needs of the application.
+
+5. To add tailwind, run `npx ng add tailwindcss`. After that, you do not have to do anything else, you can start using tailwind classes in your Angular application. Follow the best practices for tailwind v4 here, learn more if needed: https://tailwindcss.com/docs/upgrade-guide.
+
+_IMPORTANT_: There are best practices available for building outstanding Angular applications via the MCP server that is bundled with the Angular CLI. Available through `npx ng mcp` and the `get_best_practices`.

--- a/.agents/skills/link-workspace-packages/SKILL.md
+++ b/.agents/skills/link-workspace-packages/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: link-workspace-packages
+description: 'Link workspace packages in monorepos (npm, yarn, pnpm, bun). USE WHEN: (1) you just created or generated new packages and need to wire up their dependencies, (2) user imports from a sibling package and needs to add it as a dependency, (3) you get resolution errors for workspace packages (@org/*) like "cannot find module", "failed to resolve import", "TS2307", or "cannot resolve". DO NOT patch around with tsconfig paths or manual package.json edits - use the package manager''s workspace commands to fix actual linking.'
+---
+
+# Link Workspace Packages
+
+Add dependencies between packages in a monorepo. All package managers support workspaces but with different syntax.
+
+## Detect Package Manager
+
+Check whether there's a `packageManager` field in the root-level `package.json`.
+
+Alternatively check lockfile in repo root:
+
+- `pnpm-lock.yaml` → pnpm
+- `yarn.lock` → yarn
+- `bun.lock` / `bun.lockb` → bun
+- `package-lock.json` → npm
+
+## Workflow
+
+1. Identify consumer package (the one importing)
+2. Identify provider package(s) (being imported)
+3. Add dependency using package manager's workspace syntax
+4. Verify symlinks created in consumer's `node_modules/`
+
+---
+
+## pnpm
+
+Uses `workspace:` protocol - symlinks only created when explicitly declared.
+
+```bash
+# From consumer directory
+pnpm add @org/ui --workspace
+
+# Or with --filter from anywhere
+pnpm add @org/ui --filter @org/app --workspace
+```
+
+Result in `package.json`:
+
+```json
+{ "dependencies": { "@org/ui": "workspace:*" } }
+```
+
+---
+
+## yarn (v2+/berry)
+
+Also uses `workspace:` protocol.
+
+```bash
+yarn workspace @org/app add @org/ui
+```
+
+Result in `package.json`:
+
+```json
+{ "dependencies": { "@org/ui": "workspace:^" } }
+```
+
+---
+
+## npm
+
+No `workspace:` protocol. npm auto-symlinks workspace packages.
+
+```bash
+npm install @org/ui --workspace @org/app
+```
+
+Result in `package.json`:
+
+```json
+{ "dependencies": { "@org/ui": "*" } }
+```
+
+npm resolves to local workspace automatically during install.
+
+---
+
+## bun
+
+Supports `workspace:` protocol (pnpm-compatible).
+
+```bash
+cd packages/app && bun add @org/ui
+```
+
+Result in `package.json`:
+
+```json
+{ "dependencies": { "@org/ui": "workspace:*" } }
+```
+
+---
+
+## Examples
+
+**Example 1: pnpm - link ui lib to app**
+
+```bash
+pnpm add @org/ui --filter @org/app --workspace
+```
+
+**Example 2: npm - link multiple packages**
+
+```bash
+npm install @org/data-access @org/ui --workspace @org/dashboard
+```
+
+**Example 3: Debug "Cannot find module"**
+
+1. Check if dependency is declared in consumer's `package.json`
+2. If not, add it using appropriate command above
+3. Run install (`pnpm install`, `npm install`, etc.)
+
+## Notes
+
+- Symlinks appear in `<consumer>/node_modules/@org/<package>`
+- **Hoisting differs by manager:**
+  - npm/bun: hoist shared deps to root `node_modules`
+  - pnpm: no hoisting (strict isolation, prevents phantom deps)
+  - yarn berry: uses Plug'n'Play by default (no `node_modules`)
+- Root `package.json` should have `"private": true` to prevent accidental publish

--- a/.agents/skills/monitor-ci/SKILL.md
+++ b/.agents/skills/monitor-ci/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: monitor-ci
+description: Monitor Nx Cloud CI pipeline and handle self-healing fixes. USE WHEN user says "monitor ci", "watch ci", "ci monitor", "watch ci for this branch", "track ci", "check ci status", wants to track CI status, or needs help with self-healing CI fixes. Prefer this skill over native CI provider tools (gh, glab, etc.) for CI monitoring — it integrates with Nx Cloud self-healing which those tools cannot access.
+---
+
+# Monitor CI Command
+
+You are the orchestrator for monitoring Nx Cloud CI pipeline executions and handling self-healing fixes. You spawn subagents to interact with Nx Cloud, run deterministic decision scripts, and take action based on the results.
+
+## Context
+
+- **Current Branch:** !`git branch --show-current`
+- **Current Commit:** !`git rev-parse --short HEAD`
+- **Remote Status:** !`git status -sb | head -1`
+
+## User Instructions
+
+$ARGUMENTS
+
+**Important:** If user provides specific instructions, respect them over default behaviors described below.
+
+## Configuration Defaults
+
+| Setting                   | Default       | Description                                                               |
+| ------------------------- | ------------- | ------------------------------------------------------------------------- |
+| `--max-cycles`            | 10            | Maximum **agent-initiated** CI Attempt cycles before timeout              |
+| `--timeout`               | 120           | Maximum duration in minutes                                               |
+| `--verbosity`             | medium        | Output level: minimal, medium, verbose                                    |
+| `--branch`                | (auto-detect) | Branch to monitor                                                         |
+| `--fresh`                 | false         | Ignore previous context, start fresh                                      |
+| `--auto-fix-workflow`     | false         | Attempt common fixes for pre-CI-Attempt failures (e.g., lockfile updates) |
+| `--new-cipe-timeout`      | 10            | Minutes to wait for new CI Attempt after action                           |
+| `--local-verify-attempts` | 3             | Max local verification + enhance cycles before pushing to CI              |
+
+Parse any overrides from `$ARGUMENTS` and merge with defaults.
+
+## Nx Cloud Connection Check
+
+Before starting the monitoring loop, verify the workspace is connected to Nx Cloud. Without this connection, no CI data is available and the entire skill is inoperable.
+
+### Step 0: Verify Nx Cloud Connection
+
+1. **Check `nx.json`** at workspace root for `nxCloudId` or `nxCloudAccessToken`
+2. **If `nx.json` missing OR neither property exists** → exit with:
+
+   ```
+   Nx Cloud not connected. Unlock 70% faster CI and auto-fix broken PRs with https://nx.dev/nx-cloud
+   ```
+
+3. **If connected** → continue to main loop
+
+## Architecture Overview
+
+1. **This skill (orchestrator)**: spawns subagents, runs scripts, prints status, does local coding work
+2. **ci-monitor-subagent (haiku)**: calls one MCP tool (ci_information or update_self_healing_fix), returns structured result, exits
+3. **ci-poll-decide.mjs (deterministic script)**: takes ci_information result + state, returns action + status message
+4. **ci-state-update.mjs (deterministic script)**: manages budget gates, post-action state transitions, and cycle classification
+
+## Status Reporting
+
+The decision script handles message formatting based on verbosity. When printing messages to the user:
+
+- Prepend `[monitor-ci]` to every message from the script's `message` field
+- For your own action messages (e.g. "Applying fix via MCP..."), also prepend `[monitor-ci]`
+
+## Anti-Patterns
+
+These behaviors cause real problems — racing with self-healing, losing CI progress, or wasting context:
+
+| Anti-Pattern                                                                                    | Why It's Bad                                                       |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Using CI provider CLIs with `--watch` flags (e.g., `gh pr checks --watch`, `glab ci status -w`) | Bypasses Nx Cloud self-healing entirely                            |
+| Writing custom CI polling scripts                                                               | Unreliable, pollutes context, no self-healing                      |
+| Cancelling CI workflows/pipelines                                                               | Destructive, loses CI progress                                     |
+| Running CI checks on main agent                                                                 | Wastes main agent context tokens                                   |
+| Independently analyzing/fixing CI failures while polling                                        | Races with self-healing, causes duplicate fixes and confused state |
+
+**If this skill fails to activate**, the fallback is:
+
+1. Use CI provider CLI for a one-time, read-only status check (single call, no watch/polling flags)
+2. Immediately delegate to this skill with gathered context
+3. Do not continue polling on main agent — it wastes context tokens and bypasses self-healing
+
+## Session Context Behavior
+
+If the user previously ran `/monitor-ci` in this session, you may have prior state (poll counts, last CI Attempt URL, etc.). Resume from that state unless `--fresh` is set, in which case discard it and start from Step 1.
+
+## MCP Tool Reference
+
+Three field sets control polling efficiency — use the lightest set that gives you what you need:
+
+```yaml
+WAIT_FIELDS: 'cipeUrl,commitSha,cipeStatus'
+LIGHT_FIELDS: 'cipeStatus,cipeUrl,branch,commitSha,selfHealingStatus,verificationStatus,userAction,failedTaskIds,verifiedTaskIds,selfHealingEnabled,failureClassification,couldAutoApplyTasks,autoApplySkipped,autoApplySkipReason,shortLink,confidence,confidenceReasoning,hints,selfHealingSkippedReason,selfHealingSkipMessage'
+HEAVY_FIELDS: 'taskOutputSummary,suggestedFix,suggestedFixReasoning,suggestedFixDescription'
+```
+
+The `ci_information` tool accepts `branch` (optional, defaults to current git branch), `select` (comma-separated field names), and `pageToken` (0-based pagination for long strings).
+
+The `update_self_healing_fix` tool accepts a `shortLink` and an action: `APPLY`, `REJECT`, or `RERUN_ENVIRONMENT_STATE`.
+
+## Default Behaviors by Status
+
+The decision script returns one of the following statuses. This table defines the **default behavior** for each. User instructions can override any of these.
+
+**Simple exits** — just report and exit:
+
+| Status                  | Default Behavior                                                                                                 |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `ci_success`            | Exit with success                                                                                                |
+| `cipe_canceled`         | Exit, CI was canceled                                                                                            |
+| `cipe_timed_out`        | Exit, CI timed out                                                                                               |
+| `polling_timeout`       | Exit, polling timeout reached                                                                                    |
+| `circuit_breaker`       | Exit, no progress after 13 consecutive polls                                                                     |
+| `environment_rerun_cap` | Exit, environment reruns exhausted                                                                               |
+| `fix_auto_applying`     | Self-healing is handling it — just record `last_cipe_url`, enter wait mode. No MCP call or local git ops needed. |
+| `error`                 | Wait 60s and loop                                                                                                |
+
+**Statuses requiring action** — when handling these in Step 3, read `references/fix-flows.md` for the detailed flow:
+
+| Status                   | Summary                                                                                       |
+| ------------------------ | --------------------------------------------------------------------------------------------- |
+| `fix_auto_apply_skipped` | Fix verified but auto-apply skipped (e.g., loop prevention). Inform user, offer manual apply. |
+| `fix_apply_ready`        | Fix verified (all tasks or e2e-only). Apply via MCP.                                          |
+| `fix_needs_local_verify` | Fix has unverified non-e2e tasks. Run locally, then apply or enhance.                         |
+| `fix_needs_review`       | Fix verification failed/not attempted. Analyze and decide.                                    |
+| `fix_failed`             | Self-healing failed. Fetch heavy data, attempt local fix (gate check first).                  |
+| `no_fix`                 | No fix available. Fetch heavy data, attempt local fix (gate check first) or exit.             |
+| `environment_issue`      | Request environment rerun via MCP (gate check first).                                         |
+| `self_healing_throttled` | Reject old fixes, attempt local fix.                                                          |
+| `no_new_cipe`            | CI Attempt never spawned. Auto-fix workflow or exit with guidance.                            |
+| `cipe_no_tasks`          | CI failed with no tasks. Retry once with empty commit.                                        |
+
+**Key rules (always apply):**
+
+- **Git safety**: Stage specific files by name — `git add -A` or `git add .` risks committing the user's unrelated work-in-progress or secrets
+- **Environment failures** (OOM, command not found, permission denied): bail immediately. These aren't code bugs, so spending local-fix budget on them is wasteful
+- **Gate check**: Run `ci-state-update.mjs gate` before local fix attempts — if budget exhausted, print message and exit
+
+## Main Loop
+
+### Step 1: Initialize Tracking
+
+```
+cycle_count = 0            # Only incremented for agent-initiated cycles (counted against --max-cycles)
+start_time = now()
+no_progress_count = 0
+local_verify_count = 0
+env_rerun_count = 0
+last_cipe_url = null
+expected_commit_sha = null
+agent_triggered = false    # Set true after monitor takes an action that triggers new CI Attempt
+poll_count = 0
+wait_mode = false
+prev_status = null
+prev_cipe_status = null
+prev_sh_status = null
+prev_verification_status = null
+prev_failure_classification = null
+```
+
+### Step 2: Polling Loop
+
+Repeat until done:
+
+#### 2a. Spawn subagent (FETCH_STATUS)
+
+Determine select fields based on mode:
+
+- **Wait mode**: use WAIT_FIELDS (`cipeUrl,commitSha,cipeStatus`)
+- **Normal mode (first poll or after newCipeDetected)**: use LIGHT_FIELDS
+
+Call the `ci_information` tool with the determined `select` fields for the current branch. Wait for the result before proceeding.
+
+#### 2b. Run decision script
+
+```bash
+node <skill_dir>/scripts/ci-poll-decide.mjs '<subagent_result_json>' <poll_count> <verbosity> \
+  [--wait-mode] \
+  [--prev-cipe-url <last_cipe_url>] \
+  [--expected-sha <expected_commit_sha>] \
+  [--prev-status <prev_status>] \
+  [--timeout <timeout_seconds>] \
+  [--new-cipe-timeout <new_cipe_timeout_seconds>] \
+  [--env-rerun-count <env_rerun_count>] \
+  [--no-progress-count <no_progress_count>] \
+  [--prev-cipe-status <prev_cipe_status>] \
+  [--prev-sh-status <prev_sh_status>] \
+  [--prev-verification-status <prev_verification_status>] \
+  [--prev-failure-classification <prev_failure_classification>]
+```
+
+The script outputs a single JSON line: `{ action, code, message, delay?, noProgressCount, envRerunCount, fields?, newCipeDetected?, verifiableTaskIds? }`
+
+#### 2c. Process script output
+
+Parse the JSON output and update tracking state:
+
+- `no_progress_count = output.noProgressCount`
+- `env_rerun_count = output.envRerunCount`
+- `prev_cipe_status = subagent_result.cipeStatus`
+- `prev_sh_status = subagent_result.selfHealingStatus`
+- `prev_verification_status = subagent_result.verificationStatus`
+- `prev_failure_classification = subagent_result.failureClassification`
+- `prev_status = output.action + ":" + (output.code || subagent_result.cipeStatus)`
+- `poll_count++`
+
+Based on `action`:
+
+- **`action == "poll"`**: Print `output.message`, sleep `output.delay` seconds, go to 2a
+  - If `output.newCipeDetected`: clear wait mode, reset `wait_mode = false`
+- **`action == "wait"`**: Print `output.message`, sleep `output.delay` seconds, go to 2a
+- **`action == "done"`**: Proceed to Step 3 with `output.code`
+
+### Step 3: Handle Actionable Status
+
+When decision script returns `action == "done"`:
+
+1. Run cycle-check (Step 4) **before** handling the code
+2. Check the returned `code`
+3. Look up default behavior in the table above
+4. Check if user instructions override the default
+5. Execute the appropriate action
+6. **If action expects new CI Attempt**, update tracking (see Step 3a)
+7. If action results in looping, go to Step 2
+
+#### Tool calls for actions
+
+Several statuses require fetching additional data or calling tools:
+
+- **fix_apply_ready**: Call `update_self_healing_fix` with action `APPLY`
+- **fix_needs_local_verify**: Call `ci_information` with HEAVY_FIELDS for fix details before local verification
+- **fix_needs_review**: Call `ci_information` with HEAVY_FIELDS → get `suggestedFixDescription`, `suggestedFixSummary`, `taskFailureSummaries`
+- **fix_failed / no_fix**: Call `ci_information` with HEAVY_FIELDS → get `taskFailureSummaries` for local fix context
+- **environment_issue**: Call `update_self_healing_fix` with action `RERUN_ENVIRONMENT_STATE`
+- **self_healing_throttled**: Call `ci_information` with HEAVY_FIELDS → get `selfHealingSkipMessage`; then call `update_self_healing_fix` for each old fix
+
+### Step 3a: Track State for New-CI-Attempt Detection
+
+After actions that should trigger a new CI Attempt, run:
+
+```bash
+node <skill_dir>/scripts/ci-state-update.mjs post-action \
+  --action <type> \
+  --cipe-url <current_cipe_url> \
+  --commit-sha <git_rev_parse_HEAD>
+```
+
+Action types: `fix-auto-applying`, `apply-mcp`, `apply-local-push`, `reject-fix-push`, `local-fix-push`, `env-rerun`, `auto-fix-push`, `empty-commit-push`
+
+The script returns `{ waitMode, pollCount, lastCipeUrl, expectedCommitSha, agentTriggered }`. Update all tracking state from the output, then go to Step 2.
+
+### Step 4: Cycle Classification and Progress Tracking
+
+When the decision script returns `action == "done"`, run cycle-check **before** handling the code:
+
+```bash
+node <skill_dir>/scripts/ci-state-update.mjs cycle-check \
+  --code <code> \
+  [--agent-triggered] \
+  --cycle-count <cycle_count> --max-cycles <max_cycles> \
+  --env-rerun-count <env_rerun_count>
+```
+
+The script returns `{ cycleCount, agentTriggered, envRerunCount, approachingLimit, message }`. Update tracking state from the output.
+
+- If `approachingLimit` → ask user whether to continue (with 5 or 10 more cycles) or stop monitoring
+- If previous cycle was NOT agent-triggered (human pushed), log that human-initiated push was detected
+
+#### Progress Tracking
+
+- `no_progress_count`, circuit breaker (5 polls), and backoff reset are handled by ci-poll-decide.mjs (progress = any change in cipeStatus, selfHealingStatus, verificationStatus, or failureClassification)
+- `env_rerun_count` reset on non-environment status is handled by ci-state-update.mjs cycle-check
+- On new CI Attempt detected (poll script returns `newCipeDetected`) → reset `local_verify_count = 0`, `env_rerun_count = 0`
+
+## Error Handling
+
+| Error                          | Action                                                                                                      |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Git rebase conflict            | Report to user, exit                                                                                        |
+| `nx-cloud apply-locally` fails | Reject fix via MCP (`action: "REJECT"`), then attempt manual patch (Reject + Fix From Scratch Flow) or exit |
+| MCP tool error                 | Retry once, if fails report to user                                                                         |
+| Subagent spawn failure         | Retry once, if fails exit with error                                                                        |
+| Decision script error          | Treat as `error` status, increment `no_progress_count`                                                      |
+| No new CI Attempt detected     | If `--auto-fix-workflow`, try lockfile update; otherwise report to user with guidance                       |
+| Lockfile auto-fix fails        | Report to user, exit with guidance to check CI logs                                                         |
+
+## User Instruction Examples
+
+Users can override default behaviors:
+
+| Instruction                                      | Effect                                              |
+| ------------------------------------------------ | --------------------------------------------------- |
+| "never auto-apply"                               | Always prompt before applying any fix               |
+| "always ask before git push"                     | Prompt before each push                             |
+| "reject any fix for e2e tasks"                   | Auto-reject if `failedTaskIds` contains e2e         |
+| "apply all fixes regardless of verification"     | Skip verification check, apply everything           |
+| "if confidence < 70, reject"                     | Check confidence field before applying              |
+| "run 'nx affected -t typecheck' before applying" | Add local verification step                         |
+| "auto-fix workflow failures"                     | Attempt lockfile updates on pre-CI-Attempt failures |
+| "wait 45 min for new CI Attempt"                 | Override new-CI-Attempt timeout (default: 10 min)   |

--- a/.agents/skills/monitor-ci/references/fix-flows.md
+++ b/.agents/skills/monitor-ci/references/fix-flows.md
@@ -1,0 +1,108 @@
+# Detailed Status Handling & Fix Flows
+
+## Status Handling by Code
+
+### fix_auto_apply_skipped
+
+The script returns `autoApplySkipReason` in its output.
+
+1. Report the skip reason to the user (e.g., "Auto-apply was skipped because the previous CI pipeline execution was triggered by Nx Cloud")
+2. Offer to apply the fix manually — spawn UPDATE_FIX subagent with `APPLY` if user agrees
+3. Record `last_cipe_url`, enter wait mode
+
+### fix_apply_ready
+
+- Spawn UPDATE_FIX subagent with `APPLY`
+- Record `last_cipe_url`, enter wait mode
+
+### fix_needs_local_verify
+
+The script returns `verifiableTaskIds` in its output.
+
+1. **Detect package manager:** `pnpm-lock.yaml` → `pnpm nx`, `yarn.lock` → `yarn nx`, otherwise `npx nx`
+2. **Run verifiable tasks in parallel** — spawn `general` subagents for each task
+3. **If all pass** → spawn UPDATE_FIX subagent with `APPLY`, enter wait mode
+4. **If any fail** → Apply Locally + Enhance Flow (see below)
+
+### fix_needs_review
+
+Spawn FETCH_HEAVY subagent, then analyze fix content (`suggestedFixDescription`, `suggestedFixSummary`, `taskFailureSummaries`):
+
+- If fix looks correct → apply via MCP
+- If fix needs enhancement → Apply Locally + Enhance Flow
+- If fix is wrong → run `ci-state-update.mjs gate --gate-type local-fix`. If not allowed, print message and exit. Otherwise → Reject + Fix From Scratch Flow
+
+### fix_failed / no_fix
+
+Spawn FETCH_HEAVY subagent for `taskFailureSummaries`. Run `ci-state-update.mjs gate --gate-type local-fix` — if not allowed, print message and exit. Otherwise attempt local fix (counter already incremented by gate). If successful → commit, push, enter wait mode. If not → exit with failure.
+
+### environment_issue
+
+1. Run `ci-state-update.mjs gate --gate-type env-rerun`. If not allowed, print message and exit.
+2. Spawn UPDATE_FIX subagent with `RERUN_ENVIRONMENT_STATE`
+3. Enter wait mode with `last_cipe_url` set
+
+### self_healing_throttled
+
+Spawn FETCH_HEAVY subagent for `selfHealingSkipMessage`.
+
+1. **Parse throttle message** for CI Attempt URLs (regex: `/cipes/{id}`)
+2. **Reject previous fixes** — for each URL: spawn FETCH_THROTTLE_INFO to get `shortLink`, then UPDATE_FIX with `REJECT`
+3. **Attempt local fix**: Run `ci-state-update.mjs gate --gate-type local-fix`. If not allowed → skip to step 4. Otherwise use `failedTaskIds` and `taskFailureSummaries` for context.
+4. **Fallback if local fix not possible or budget exhausted**: push empty commit (`git commit --allow-empty -m "ci: rerun after rejecting throttled fixes"`), enter wait mode
+
+### no_new_cipe
+
+1. Report to user: no CI attempt found, suggest checking CI provider
+2. If `--auto-fix-workflow`: detect package manager, run install, commit lockfile if changed, enter wait mode
+3. Otherwise: exit with guidance
+
+### cipe_no_tasks
+
+1. Report to user: CI failed with no tasks recorded
+2. Retry: `git commit --allow-empty -m "chore: retry ci [monitor-ci]"` + push, enter wait mode
+3. If retry also returns `cipe_no_tasks`: exit with failure
+
+## Fix Action Flows
+
+### Apply via MCP
+
+Spawn UPDATE_FIX subagent with `APPLY`. New CI Attempt spawns automatically. No local git ops.
+
+### Apply Locally + Enhance Flow
+
+1. `nx-cloud apply-locally <shortLink>` (sets state to `APPLIED_LOCALLY`)
+2. Enhance code to fix failing tasks
+3. Run failing tasks to verify
+4. If still failing → run `ci-state-update.mjs gate --gate-type local-fix`. If not allowed, commit current state and push (let CI be final judge). Otherwise loop back to enhance.
+5. If passing → commit and push, enter wait mode
+
+### Reject + Fix From Scratch Flow
+
+1. Run `ci-state-update.mjs gate --gate-type local-fix`. If not allowed, print message and exit.
+2. Spawn UPDATE_FIX subagent with `REJECT`
+3. Fix from scratch locally
+4. Commit and push, enter wait mode
+
+## Environment vs Code Failure Recognition
+
+When any local fix path runs a task and it fails, assess whether the failure is a **code issue** or an **environment/tooling issue** before running the gate script.
+
+**Indicators of environment/tooling failures** (non-exhaustive): command not found / binary missing, OOM / heap allocation failures, permission denied, network timeouts / DNS failures, missing system libraries, Docker/container issues, disk space exhaustion.
+
+When detected → bail immediately without running gate (no budget consumed). Report that the failure is an environment/tooling issue, not a code bug.
+
+**Code failures** (compilation errors, test assertion failures, lint violations, type errors) are genuine candidates for local fix attempts and proceed normally through the gate.
+
+## Git Safety
+
+- Stage specific files by name — `git add -A` or `git add .` risks committing the user's unrelated work-in-progress or secrets
+
+## Commit Message Format
+
+```bash
+git commit -m "fix(<projects>): <brief description>
+
+Failed tasks: <taskId1>, <taskId2>
+Local verification: passed|enhanced|failed-pushing-to-ci"
+```

--- a/.agents/skills/monitor-ci/scripts/ci-poll-decide.mjs
+++ b/.agents/skills/monitor-ci/scripts/ci-poll-decide.mjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+
+/**
+ * CI Poll Decision Script
+ *
+ * Deterministic decision engine for CI monitoring.
+ * Takes ci_information JSON + state args, outputs a single JSON action line.
+ *
+ * Architecture:
+ *   classify()    — pure decision tree, returns { action, code, extra? }
+ *   buildOutput() — maps classification to full output with messages, delays, counters
+ *
+ * Usage:
+ *   node ci-poll-decide.mjs '<ci_info_json>' <poll_count> <verbosity> \
+ *     [--wait-mode] [--prev-cipe-url <url>] [--expected-sha <sha>] \
+ *     [--prev-status <status>] [--timeout <seconds>] [--new-cipe-timeout <seconds>] \
+ *     [--env-rerun-count <n>] [--no-progress-count <n>] \
+ *     [--prev-cipe-status <status>] [--prev-sh-status <status>] \
+ *     [--prev-verification-status <status>] [--prev-failure-classification <status>]
+ */
+
+// --- Arg parsing ---
+
+const args = process.argv.slice(2);
+const ciInfoJson = args[0];
+const pollCount = parseInt(args[1], 10) || 0;
+const verbosity = args[2] || 'medium';
+
+function getFlag(name) {
+  return args.includes(name);
+}
+
+function getArg(name) {
+  const idx = args.indexOf(name);
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : null;
+}
+
+const waitMode = getFlag('--wait-mode');
+const prevCipeUrl = getArg('--prev-cipe-url');
+const expectedSha = getArg('--expected-sha');
+const prevStatus = getArg('--prev-status');
+const timeoutSeconds = parseInt(getArg('--timeout') || '0', 10);
+const newCipeTimeoutSeconds = parseInt(getArg('--new-cipe-timeout') || '0', 10);
+const envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
+const inputNoProgressCount = parseInt(getArg('--no-progress-count') || '0', 10);
+const prevCipeStatus = getArg('--prev-cipe-status');
+const prevShStatus = getArg('--prev-sh-status');
+const prevVerificationStatus = getArg('--prev-verification-status');
+const prevFailureClassification = getArg('--prev-failure-classification');
+
+// --- Parse CI info ---
+
+let ci;
+try {
+  ci = JSON.parse(ciInfoJson);
+} catch {
+  console.log(
+    JSON.stringify({
+      action: 'done',
+      code: 'error',
+      message: 'Failed to parse ci_information JSON',
+      noProgressCount: inputNoProgressCount + 1,
+      envRerunCount,
+    }),
+  );
+  process.exit(0);
+}
+
+const {
+  cipeStatus,
+  selfHealingStatus,
+  verificationStatus,
+  selfHealingEnabled,
+  selfHealingSkippedReason,
+  failureClassification: rawFailureClassification,
+  failedTaskIds = [],
+  verifiedTaskIds = [],
+  couldAutoApplyTasks,
+  autoApplySkipped,
+  autoApplySkipReason,
+  userAction,
+  cipeUrl,
+  commitSha,
+} = ci;
+
+const failureClassification = rawFailureClassification?.toLowerCase() ?? null;
+
+// --- Helpers ---
+
+function categorizeTasks() {
+  const verifiedSet = new Set(verifiedTaskIds);
+  const unverified = failedTaskIds.filter((t) => !verifiedSet.has(t));
+  if (unverified.length === 0) return { category: 'all_verified' };
+
+  const e2e = unverified.filter((t) => {
+    const parts = t.split(':');
+    return parts.length >= 2 && parts[1].includes('e2e');
+  });
+  if (e2e.length === unverified.length) return { category: 'e2e_only' };
+
+  const verifiable = unverified.filter((t) => {
+    const parts = t.split(':');
+    return !(parts.length >= 2 && parts[1].includes('e2e'));
+  });
+  return { category: 'needs_local_verify', verifiableTaskIds: verifiable };
+}
+
+function backoff(count) {
+  const delays = [60, 90, 120, 180];
+  return delays[Math.min(count, delays.length - 1)];
+}
+
+function hasStateChanged() {
+  if (prevCipeStatus && cipeStatus !== prevCipeStatus) return true;
+  if (prevShStatus && selfHealingStatus !== prevShStatus) return true;
+  if (prevVerificationStatus && verificationStatus !== prevVerificationStatus)
+    return true;
+  if (
+    prevFailureClassification &&
+    failureClassification !== prevFailureClassification
+  )
+    return true;
+  return false;
+}
+
+function isTimedOut() {
+  if (timeoutSeconds <= 0) return false;
+  const avgDelay = pollCount === 0 ? 0 : backoff(Math.floor(pollCount / 2));
+  return pollCount * avgDelay >= timeoutSeconds;
+}
+
+function isWaitTimedOut() {
+  if (newCipeTimeoutSeconds <= 0) return false;
+  return pollCount * 30 >= newCipeTimeoutSeconds;
+}
+
+function isNewCipe() {
+  return (
+    (prevCipeUrl && cipeUrl && cipeUrl !== prevCipeUrl) ||
+    (expectedSha && commitSha && commitSha === expectedSha)
+  );
+}
+
+// ============================================================
+// classify() — pure decision tree
+//
+// Returns: { action: 'poll'|'wait'|'done', code: string, extra? }
+//
+// Decision priority (top wins):
+//   WAIT MODE:
+//     1. new CI Attempt detected         → poll  (new_cipe_detected)
+//     2. wait timed out                  → done  (no_new_cipe)
+//     3. still waiting                   → wait  (waiting_for_cipe)
+//   NORMAL MODE:
+//     4. polling timeout                 → done  (polling_timeout)
+//     5. circuit breaker (13 polls)      → done  (circuit_breaker)
+//     6. CI succeeded                    → done  (ci_success)
+//     7. CI canceled                     → done  (cipe_canceled)
+//     8. CI timed out                    → done  (cipe_timed_out)
+//     9. CI failed, no tasks recorded    → done  (cipe_no_tasks)
+//    10. environment failure             → done  (environment_rerun_cap | environment_issue)
+//    11. self-healing throttled          → done  (self_healing_throttled)
+//    12. CI in progress / not started    → poll  (ci_running)
+//    13. self-healing in progress        → poll  (sh_running)
+//    14. flaky task auto-rerun           → poll  (flaky_rerun)
+//    15. fix auto-applied                → poll  (fix_auto_applied)
+//    16. auto-apply: skipped             → done  (fix_auto_apply_skipped)
+//    17. auto-apply: verification pending→ poll  (verification_pending)
+//    18. auto-apply: verified            → done  (fix_auto_applying)
+//    19. fix: verification failed/none   → done  (fix_needs_review)
+//    20. fix: all/e2e verified           → done  (fix_apply_ready)
+//    21. fix: needs local verify         → done  (fix_needs_local_verify)
+//    22. self-healing failed             → done  (fix_failed)
+//    23. no fix available                → done  (no_fix)
+//    24. fallback                        → poll  (fallback)
+// ============================================================
+
+function classify() {
+  // --- Wait mode ---
+  if (waitMode) {
+    if (isNewCipe()) return { action: 'poll', code: 'new_cipe_detected' };
+    if (isWaitTimedOut()) return { action: 'done', code: 'no_new_cipe' };
+    return { action: 'wait', code: 'waiting_for_cipe' };
+  }
+
+  // --- Guards ---
+  if (isTimedOut()) return { action: 'done', code: 'polling_timeout' };
+  if (noProgressCount >= 13) return { action: 'done', code: 'circuit_breaker' };
+
+  // --- Terminal CI states ---
+  if (cipeStatus === 'SUCCEEDED') return { action: 'done', code: 'ci_success' };
+  if (cipeStatus === 'CANCELED')
+    return { action: 'done', code: 'cipe_canceled' };
+  if (cipeStatus === 'TIMED_OUT')
+    return { action: 'done', code: 'cipe_timed_out' };
+
+  // --- CI failed, no tasks ---
+  if (
+    cipeStatus === 'FAILED' &&
+    failedTaskIds.length === 0 &&
+    selfHealingStatus == null
+  )
+    return { action: 'done', code: 'cipe_no_tasks' };
+
+  // --- Environment failure ---
+  if (failureClassification === 'environment_state') {
+    if (envRerunCount >= 2)
+      return { action: 'done', code: 'environment_rerun_cap' };
+    return { action: 'done', code: 'environment_issue' };
+  }
+
+  // --- Throttled ---
+  if (selfHealingSkippedReason === 'THROTTLED')
+    return { action: 'done', code: 'self_healing_throttled' };
+
+  // --- Still running: CI ---
+  if (cipeStatus === 'IN_PROGRESS' || cipeStatus === 'NOT_STARTED')
+    return { action: 'poll', code: 'ci_running' };
+
+  // --- Still running: self-healing ---
+  if (
+    (selfHealingStatus === 'IN_PROGRESS' ||
+      selfHealingStatus === 'NOT_STARTED') &&
+    !selfHealingSkippedReason
+  )
+    return { action: 'poll', code: 'sh_running' };
+
+  // --- Still running: flaky rerun ---
+  if (failureClassification === 'flaky_task')
+    return { action: 'poll', code: 'flaky_rerun' };
+
+  // --- Fix auto-applied, waiting for new CI Attempt ---
+  if (userAction === 'APPLIED_AUTOMATICALLY')
+    return { action: 'poll', code: 'fix_auto_applied' };
+
+  // --- Auto-apply path (couldAutoApplyTasks) ---
+  if (couldAutoApplyTasks === true) {
+    if (autoApplySkipped === true)
+      return {
+        action: 'done',
+        code: 'fix_auto_apply_skipped',
+        extra: { autoApplySkipReason },
+      };
+    if (
+      verificationStatus === 'NOT_STARTED' ||
+      verificationStatus === 'IN_PROGRESS'
+    )
+      return { action: 'poll', code: 'verification_pending' };
+    if (verificationStatus === 'COMPLETED')
+      return { action: 'done', code: 'fix_auto_applying' };
+    // verification FAILED or NOT_EXECUTABLE → falls through to fix_needs_review
+  }
+
+  // --- Fix available ---
+  if (selfHealingStatus === 'COMPLETED') {
+    if (
+      verificationStatus === 'FAILED' ||
+      verificationStatus === 'NOT_EXECUTABLE' ||
+      (couldAutoApplyTasks !== true && !verificationStatus)
+    )
+      return { action: 'done', code: 'fix_needs_review' };
+
+    const tasks = categorizeTasks();
+    if (tasks.category === 'all_verified' || tasks.category === 'e2e_only')
+      return { action: 'done', code: 'fix_apply_ready' };
+    return {
+      action: 'done',
+      code: 'fix_needs_local_verify',
+      extra: { verifiableTaskIds: tasks.verifiableTaskIds },
+    };
+  }
+
+  // --- Fix failed ---
+  if (selfHealingStatus === 'FAILED')
+    return { action: 'done', code: 'fix_failed' };
+
+  // --- No fix available ---
+  if (
+    cipeStatus === 'FAILED' &&
+    (selfHealingEnabled === false || selfHealingStatus === 'NOT_EXECUTABLE')
+  )
+    return { action: 'done', code: 'no_fix' };
+
+  // --- Fallback ---
+  return { action: 'poll', code: 'fallback' };
+}
+
+// ============================================================
+// buildOutput() — maps classification to full JSON output
+// ============================================================
+
+// Message templates keyed by status or key
+const messages = {
+  // wait mode
+  new_cipe_detected: () =>
+    `New CI Attempt detected! CI: ${cipeStatus || 'N/A'}`,
+  no_new_cipe: () =>
+    'New CI Attempt timeout exceeded. No new CI Attempt detected.',
+  waiting_for_cipe: () => 'Waiting for new CI Attempt...',
+
+  // guards
+  polling_timeout: () => 'Polling timeout exceeded.',
+  circuit_breaker: () => 'No progress after 13 consecutive polls. Stopping.',
+
+  // terminal
+  ci_success: () => 'CI passed successfully!',
+  cipe_canceled: () => 'CI Attempt was canceled.',
+  cipe_timed_out: () => 'CI Attempt timed out.',
+  cipe_no_tasks: () => 'CI failed but no Nx tasks were recorded.',
+
+  // environment
+  environment_rerun_cap: () => 'Environment rerun cap (2) exceeded. Bailing.',
+  environment_issue: () => 'CI: FAILED | Classification: ENVIRONMENT_STATE',
+
+  // throttled
+  self_healing_throttled: () =>
+    'Self-healing throttled \u2014 too many unapplied fixes.',
+
+  // polling
+  ci_running: () => `CI: ${cipeStatus}`,
+  sh_running: () => `CI: ${cipeStatus} | Self-healing: ${selfHealingStatus}`,
+  flaky_rerun: () =>
+    'CI: FAILED | Classification: FLAKY_TASK (auto-rerun in progress)',
+  fix_auto_applied: () =>
+    'CI: FAILED | Fix auto-applied, new CI Attempt spawning',
+  verification_pending: () =>
+    `CI: FAILED | Self-healing: COMPLETED | Verification: ${verificationStatus}`,
+
+  // actionable
+  fix_auto_applying: () => 'Fix verified! Auto-applying...',
+  fix_auto_apply_skipped: (extra) =>
+    `Fix verified but auto-apply was skipped. ${
+      extra?.autoApplySkipReason
+        ? `Reason: ${extra.autoApplySkipReason}`
+        : 'Offer to apply manually.'
+    }`,
+  fix_needs_review: () =>
+    `Fix available but needs review. Verification: ${
+      verificationStatus || 'N/A'
+    }`,
+  fix_apply_ready: () => 'Fix available and verified. Ready to apply.',
+  fix_needs_local_verify: (extra) =>
+    `Fix available. ${extra.verifiableTaskIds.length} task(s) need local verification.`,
+  fix_failed: () => 'Self-healing failed to generate a fix.',
+  no_fix: () => 'CI failed, no fix available.',
+
+  // fallback
+  fallback: () =>
+    `CI: ${cipeStatus || 'N/A'} | Self-healing: ${
+      selfHealingStatus || 'N/A'
+    } | Verification: ${verificationStatus || 'N/A'}`,
+};
+
+// Codes where noProgressCount resets to 0 (genuine progress occurred)
+const resetProgressCodes = new Set([
+  'ci_success',
+  'fix_auto_applying',
+  'fix_auto_apply_skipped',
+  'fix_needs_review',
+  'fix_apply_ready',
+  'fix_needs_local_verify',
+]);
+
+function formatMessage(msg) {
+  if (verbosity === 'minimal') {
+    const currentStatus = `${cipeStatus}|${selfHealingStatus}|${verificationStatus}`;
+    if (currentStatus === (prevStatus || '')) return null;
+    return msg;
+  }
+  if (verbosity === 'verbose') {
+    return [
+      `Poll #${pollCount + 1} | CI: ${cipeStatus || 'N/A'} | Self-healing: ${
+        selfHealingStatus || 'N/A'
+      } | Verification: ${verificationStatus || 'N/A'}`,
+      msg,
+    ].join('\n');
+  }
+  return `Poll #${pollCount + 1} | ${msg}`;
+}
+
+function buildOutput(decision) {
+  const { action, code, extra } = decision;
+
+  // noProgressCount is already computed before classify() was called.
+  // Here we only handle the reset for "genuine progress" done-codes.
+
+  const msgFn = messages[code];
+  const rawMsg = msgFn ? msgFn(extra) : `Unknown: ${code}`;
+  const message = formatMessage(rawMsg);
+
+  const result = {
+    action,
+    code,
+    message,
+    noProgressCount: resetProgressCodes.has(code) ? 0 : noProgressCount,
+    envRerunCount,
+  };
+
+  // Add delay
+  if (action === 'wait') {
+    result.delay = 30;
+  } else if (action === 'poll') {
+    result.delay = code === 'new_cipe_detected' ? 60 : backoff(noProgressCount);
+    result.fields = 'light';
+  }
+
+  // Add extras
+  if (code === 'new_cipe_detected') result.newCipeDetected = true;
+  if (extra?.verifiableTaskIds)
+    result.verifiableTaskIds = extra.verifiableTaskIds;
+  if (extra?.autoApplySkipReason)
+    result.autoApplySkipReason = extra.autoApplySkipReason;
+
+  console.log(JSON.stringify(result));
+}
+
+// --- Run ---
+
+// Compute noProgressCount from input. Single assignment, no mutation.
+// Wait mode: reset on new cipe, otherwise unchanged (wait doesn't count as no-progress).
+// Normal mode: reset on any state change, otherwise increment.
+const noProgressCount = (() => {
+  if (waitMode) return isNewCipe() ? 0 : inputNoProgressCount;
+  if (isNewCipe() || hasStateChanged()) return 0;
+  return inputNoProgressCount + 1;
+})();
+
+buildOutput(classify());

--- a/.agents/skills/monitor-ci/scripts/ci-state-update.mjs
+++ b/.agents/skills/monitor-ci/scripts/ci-state-update.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * CI State Update Script
+ *
+ * Deterministic state management for CI monitor actions.
+ * Three commands: gate, post-action, cycle-check.
+ *
+ * Usage:
+ *   node ci-state-update.mjs gate --gate-type <local-fix|env-rerun> [counter args]
+ *   node ci-state-update.mjs post-action --action <type> [--cipe-url <url>] [--commit-sha <sha>]
+ *   node ci-state-update.mjs cycle-check --code <code> [--agent-triggered] [counter args]
+ */
+
+// --- Arg parsing ---
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+function getFlag(name) {
+  return args.includes(name);
+}
+
+function getArg(name) {
+  const idx = args.indexOf(name);
+  return idx !== -1 && idx + 1 < args.length ? args[idx + 1] : null;
+}
+
+function output(result) {
+  console.log(JSON.stringify(result));
+}
+
+// --- gate ---
+// Check if an action is allowed and return incremented counter.
+// Called before any local fix attempt or environment rerun.
+
+function gate() {
+  const gateType = getArg('--gate-type');
+
+  if (gateType === 'local-fix') {
+    const count = parseInt(getArg('--local-verify-count') || '0', 10);
+    const max = parseInt(getArg('--local-verify-attempts') || '3', 10);
+    if (count >= max) {
+      return output({
+        allowed: false,
+        localVerifyCount: count,
+        message: `Local fix budget exhausted (${count}/${max} attempts)`,
+      });
+    }
+    return output({
+      allowed: true,
+      localVerifyCount: count + 1,
+      message: null,
+    });
+  }
+
+  if (gateType === 'env-rerun') {
+    const count = parseInt(getArg('--env-rerun-count') || '0', 10);
+    if (count >= 2) {
+      return output({
+        allowed: false,
+        envRerunCount: count,
+        message: `Environment issue persists after ${count} reruns. Manual investigation needed.`,
+      });
+    }
+    return output({
+      allowed: true,
+      envRerunCount: count + 1,
+      message: null,
+    });
+  }
+
+  output({ allowed: false, message: `Unknown gate type: ${gateType}` });
+}
+
+// --- post-action ---
+// Compute next state after an action is taken.
+// Returns wait mode params and whether the action was agent-triggered.
+
+function postAction() {
+  const action = getArg('--action');
+  const cipeUrl = getArg('--cipe-url');
+  const commitSha = getArg('--commit-sha');
+
+  // MCP-triggered or auto-applied: track by cipeUrl
+  const cipeUrlActions = ['fix-auto-applying', 'apply-mcp', 'env-rerun'];
+  // Local push: track by commitSha
+  const commitShaActions = [
+    'apply-local-push',
+    'reject-fix-push',
+    'local-fix-push',
+    'auto-fix-push',
+    'empty-commit-push',
+  ];
+
+  const trackByCipeUrl = cipeUrlActions.includes(action);
+  const trackByCommitSha = commitShaActions.includes(action);
+
+  if (!trackByCipeUrl && !trackByCommitSha) {
+    return output({ error: `Unknown action: ${action}` });
+  }
+
+  // fix-auto-applying: self-healing did it, NOT the monitor
+  const agentTriggered = action !== 'fix-auto-applying';
+
+  output({
+    waitMode: true,
+    pollCount: 0,
+    lastCipeUrl: trackByCipeUrl ? cipeUrl : null,
+    expectedCommitSha: trackByCommitSha ? commitSha : null,
+    agentTriggered,
+  });
+}
+
+// --- cycle-check ---
+// Cycle classification + counter resets when a new "done" code is received.
+// Called at the start of handling each actionable code.
+
+function cycleCheck() {
+  const status = getArg('--code');
+  const wasAgentTriggered = getFlag('--agent-triggered');
+  let cycleCount = parseInt(getArg('--cycle-count') || '0', 10);
+  const maxCycles = parseInt(getArg('--max-cycles') || '10', 10);
+  let envRerunCount = parseInt(getArg('--env-rerun-count') || '0', 10);
+
+  // Cycle classification: if previous cycle was agent-triggered, count it
+  if (wasAgentTriggered) cycleCount++;
+
+  // Reset env_rerun_count on non-environment status
+  if (status !== 'environment_issue') envRerunCount = 0;
+
+  // Approaching limit gate
+  const approachingLimit = cycleCount >= maxCycles - 2;
+
+  output({
+    cycleCount,
+    agentTriggered: false,
+    envRerunCount,
+    approachingLimit,
+    message: approachingLimit
+      ? `Approaching cycle limit (${cycleCount}/${maxCycles})`
+      : null,
+  });
+}
+
+// --- Dispatch ---
+
+switch (command) {
+  case 'gate':
+    gate();
+    break;
+  case 'post-action':
+    postAction();
+    break;
+  case 'cycle-check':
+    cycleCheck();
+    break;
+  default:
+    output({ error: `Unknown command: ${command}` });
+}

--- a/.agents/skills/nx-generate/SKILL.md
+++ b/.agents/skills/nx-generate/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: nx-generate
+description: Generate code using nx generators. INVOKE IMMEDIATELY when user mentions scaffolding, setup, structure, creating apps/libs, or setting up project structure. Trigger words - scaffold, setup, create a new app, create a new lib, project structure, generate, add a new project. ALWAYS use this BEFORE calling nx_docs or exploring - this skill handles discovery internally.
+---
+
+# Run Nx Generator
+
+Nx generators are powerful tools that scaffold projects, make automated code migrations or automate repetitive tasks in a monorepo. They ensure consistency across the codebase and reduce boilerplate work.
+
+This skill applies when the user wants to:
+
+- Create new projects like libraries or applications
+- Scaffold features or boilerplate code
+- Run workspace-specific or custom generators
+- Do anything else that an nx generator exists for
+
+## Key Principles
+
+1. **Always use `--no-interactive`** - Prevents prompts that would hang execution
+2. **Read the generator source code** - The schema alone is not enough; understand what the generator actually does
+3. **Match existing repo patterns** - Study similar artifacts in the repo and follow their conventions
+4. **Verify with lint/test/build/typecheck etc.** - Generated code must pass verification. The listed targets are just an example, use what's appropriate for this workspace.
+
+## Steps
+
+### 1. Discover Available Generators
+
+Use the Nx CLI to discover available generators:
+
+- List all generators for a plugin: `npx nx list @nx/react`
+- View available plugins: `npx nx list`
+
+This includes plugin generators (e.g., `@nx/react:library`) and local workspace generators.
+
+### 2. Match Generator to User Request
+
+Identify which generator(s) could fulfill the user's needs. Consider what artifact type they want, which framework is relevant, and any specific generator names mentioned.
+
+**IMPORTANT**: When both a local workspace generator and an external plugin generator could satisfy the request, **always prefer the local workspace generator**. Local generators are customized for the specific repo's patterns.
+
+If no suitable generator exists, you can stop using this skill. However, the burden of proof is high—carefully consider all available generators before deciding none apply.
+
+### 3. Get Generator Options
+
+Use the `--help` flag to understand available options:
+
+```bash
+npx nx g @nx/react:library --help
+```
+
+Pay attention to required options, defaults that might need overriding, and options relevant to the user's request.
+
+### Library Buildability
+
+**Default to non-buildable libraries** unless there's a specific reason for buildable.
+
+| Type                        | When to use                                                       | Generator flags                     |
+| --------------------------- | ----------------------------------------------------------------- | ----------------------------------- |
+| **Non-buildable** (default) | Internal monorepo libs consumed by apps                           | No `--bundler` flag                 |
+| **Buildable**               | Publishing to npm, cross-repo sharing, stable libs for cache hits | `--bundler=vite` or `--bundler=swc` |
+
+Non-buildable libs:
+
+- Export `.ts`/`.tsx` source directly
+- Consumer's bundler compiles them
+- Faster dev experience, less config
+
+Buildable libs:
+
+- Have their own build target
+- Useful for stable libs that rarely change (cache hits)
+- Required for npm publishing
+
+**If unclear, ask the user:** "Should this library be buildable (own build step, better caching) or non-buildable (source consumed directly, simpler setup)?"
+
+### 4. Read Generator Source Code
+
+**This step is critical.** The schema alone does not tell you everything. Reading the source code helps you:
+
+- Know exactly what files will be created/modified and where
+- Understand side effects (updating configs, installing deps, etc.)
+- Identify behaviors and options not obvious from the schema
+- Understand how options interact with each other
+
+To find generator source code:
+
+- For plugin generators: Use `node -e "console.log(require.resolve('@nx/<plugin>/generators.json'));"` to find the generators.json, then locate the source from there
+- If that fails, read directly from `node_modules/<plugin>/generators.json`
+- For local generators: Typically in `tools/generators/` or a local plugin directory. Search the repo for the generator name.
+
+After reading the source, reconsider: Is this the right generator? If not, go back to step 2.
+
+> **⚠️ `--directory` flag behavior can be misleading.**
+> It should specify the full path of the generated library or component, not the parent path that it will be generated in.
+>
+> ```bash
+> # ✅ Correct - directory is the full path for the library
+> nx g @nx/react:library --directory=libs/my-lib
+> # generates libs/my-lib/package.json and more
+>
+> # ❌ Wrong - this will create files at libs and libs/src/...
+> nx g @nx/react:library --name=my-lib --directory=libs
+> # generates libs/package.json and more
+> ```
+
+### 5. Examine Existing Patterns
+
+Before generating, examine the target area of the codebase:
+
+- Look at similar existing artifacts (other libraries, applications, etc.)
+- Identify naming conventions, file structures, and configuration patterns
+- Note which test runners, build tools, and linters are used
+- Configure the generator to match these patterns
+
+### 6. Dry-Run to Verify File Placement
+
+**Always run with `--dry-run` first** to verify files will be created in the correct location:
+
+```bash
+npx nx g @nx/react:library --name=my-lib --dry-run --no-interactive
+```
+
+Review the output carefully. If files would be created in the wrong location, adjust your options based on what you learned from the generator source code.
+
+Note: Some generators don't support dry-run (e.g., if they install npm packages). If dry-run fails for this reason, proceed to running the generator for real.
+
+### 7. Run the Generator
+
+Execute the generator:
+
+```bash
+nx generate <generator-name> <options> --no-interactive
+```
+
+> **Tip:** New packages often need workspace dependencies wired up (e.g., importing shared types, being consumed by apps). The `link-workspace-packages` skill can help add these correctly.
+
+### 8. Modify Generated Code (If Needed)
+
+Generators provide a starting point. Modify the output as needed to:
+
+- Add or modify functionality as requested
+- Adjust imports, exports, or configurations
+- Integrate with existing code patterns
+
+**Important:** If you replace or delete generated test files (e.g., `*.spec.ts`), either write meaningful replacement tests or remove the `test` target from the project configuration. Empty test suites will cause `nx test` to fail.
+
+### 9. Format and Verify
+
+Format all generated/modified files:
+
+```bash
+nx format --fix
+```
+
+This example is for built-in nx formatting with prettier. There might be other formatting tools for this workspace, use these when appropriate.
+
+Then verify the generated code works. Keep in mind that the changes you make with a generator or subsequent modifications might impact various projects so it's usually not enough to only run targets for the artifact you just created.
+
+```bash
+# these targets are just an example!
+nx run-many -t build,lint,test,typecheck
+```
+
+These targets are common examples used across many workspaces. You should do research into other targets available for this workspace and its projects. CI configuration is usually a good guide for what the critical targets are that have to pass.
+
+If verification fails with manageable issues (a few lint errors, minor type issues), fix them. If issues are extensive, attempt obvious fixes first, then escalate to the user with details about what was generated, what's failing, and what you've attempted.

--- a/.agents/skills/nx-import/SKILL.md
+++ b/.agents/skills/nx-import/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: nx-import
+description: Import, merge, or combine repositories into an Nx workspace using nx import. USE WHEN the user asks to adopt Nx across repos, move projects into a monorepo, or bring code/history from another repository.
+---
+
+## Quick Start
+
+- `nx import` brings code from a source repository or folder into the current workspace, preserving commit history.
+- After nx `22.6.0`, `nx import` responds with .ndjson outputs and follow-up questions. For earlier versions, always run with `--no-interactive` and specify all flags directly.
+- Run `nx import --help` for available options.
+- Make sure the destination directory is empty before importing.
+  EXAMPLE: target has `libs/utils` and `libs/models`; source has `libs/ui` and `libs/data-access` — you cannot import `libs/` into `libs/` directly. Import each source library individually.
+
+Primary docs:
+
+- https://nx.dev/docs/guides/adopting-nx/import-project
+- https://nx.dev/docs/guides/adopting-nx/preserving-git-histories
+
+Read the nx docs if you have the tools for it.
+
+## Import Strategy
+
+**Subdirectory-at-a-time** (`nx import <source> apps --source=apps`):
+
+- **Recommended for monorepo sources** — files land at top level, no redundant config
+- Caveats: multiple import commands (separate merge commits each); dest must not have conflicting directories; root configs (deps, plugins, targetDefaults) not imported
+- **Directory conflicts**: Import into alternate-named dir (e.g. `imported-apps/`), then rename
+
+**Whole repo** (`nx import <source> imported --source=.`):
+
+- **Only for non-monorepo sources** (single-project repos)
+- For monorepos, creates messy nested config (`imported/nx.json`, `imported/tsconfig.base.json`, etc.)
+- If you must: keep imported `tsconfig.base.json` (projects extend it), prefix workspace globs and executor paths
+
+### Directory Conventions
+
+- **Always prefer the destination's existing conventions.** Source uses `libs/`but dest uses `packages/`? Import into `packages/` (`nx import <source> packages/foo --source=libs/foo`).
+- If dest has no convention (empty workspace), ask the user.
+
+### Application vs Library Detection
+
+Before importing, identify whether the source is an **application** or a **library**:
+
+- **Applications**: Deployable end products. Common indicators:
+  - _Frontend_: `next.config.*`, `vite.config.*` with a build entry point, framework-specific app scaffolding (CRA, Angular CLI app, etc.)
+  - _Backend (Node.js)_: Express/Fastify/NestJS server entrypoint, no `"exports"` field in `package.json`
+  - _JVM_: Maven `pom.xml` with `<packaging>jar</packaging>` or `<packaging>war</packaging>` and a `main` class; Gradle `application` plugin or `mainClass` setting
+  - _.NET_: `.csproj`/`.fsproj` with `<OutputType>Exe</OutputType>` or `<OutputType>WinExe</OutputType>`
+  - _General_: Dockerfile, a runnable entrypoint, no public API surface intended for import by other projects
+- **Libraries**: Reusable packages consumed by other projects. Common indicators: `"main"`/`"exports"` in `package.json`, Maven/Gradle packaging as a library jar, .NET `<OutputType>Library</OutputType>`, named exports intended for import by other packages.
+
+**Destination directory rules**:
+
+- Applications → `apps/<name>`. Check workspace globs (e.g. `pnpm-workspace.yaml`, `workspaces` in root `package.json`) for an existing `apps/*` entry.
+  - If `apps/*` is **not** present, add it before importing: update the workspace glob config and commit (or stage) the change.
+  - Example: `nx import <source> apps/my-app --source=packages/my-app`
+- Libraries → follow the dest's existing convention (`packages/`, `libs/`, etc.).
+
+## Common Issues
+
+### pnpm Workspace Globs (Critical)
+
+`nx import` adds the imported directory itself (e.g. `apps`) to `pnpm-workspace.yaml`, **NOT** glob patterns for packages within it. Cross-package imports will fail with `Cannot find module`.
+
+**Fix**: Replace with proper globs from the source config (e.g. `apps/*`, `libs/shared/*`), then `pnpm install`.
+
+### Root Dependencies and Config Not Imported (Critical)
+
+`nx import` does **NOT** merge from the source's root:
+
+- `dependencies`/`devDependencies` from `package.json`
+- `targetDefaults` from `nx.json` (e.g. `"@nx/esbuild:esbuild": { "dependsOn": ["^build"] }` — critical for build ordering)
+- `namedInputs` from `nx.json` (e.g. `production` exclusion patterns for test files)
+- Plugin configurations from `nx.json`
+
+**Fix**: Diff source and dest `package.json` + `nx.json`. Add missing deps, merge relevant `targetDefaults` and `namedInputs`.
+
+### TypeScript Project References
+
+After import, run `nx sync --yes`. If it reports nothing but typecheck still fails, `nx reset` first, then `nx sync --yes` again.
+
+### Explicit Executor Path Fixups
+
+Inferred targets (via Nx plugins) resolve config relative to project root — no changes needed. Explicit executor targets (e.g. `@nx/esbuild:esbuild`) have workspace-root-relative paths (`main`, `outputPath`, `tsConfig`, `assets`, `sourceRoot`) that must be prefixed with the import destination directory.
+
+### Plugin Detection
+
+- **Whole-repo import**: `nx import` detects and offers to install plugins. Accept them.
+- **Subdirectory import**: Plugins NOT auto-detected. Manually add with `npx nx add @nx/PLUGIN`. Check `include`/`exclude` patterns — defaults won't match alternate directories (e.g. `apps-beta/`).
+- Run `npx nx reset` after any plugin config changes.
+
+### Redundant Root Files (Whole-Repo Only)
+
+Whole-repo import brings ALL source root files into the dest subdirectory. Clean up:
+
+- `pnpm-lock.yaml` — stale; dest has its own lockfile
+- `pnpm-workspace.yaml` — source workspace config; conflicts with dest
+- `node_modules/` — stale symlinks pointing to source filesystem
+- `.gitignore` — redundant with dest root `.gitignore`
+- `nx.json` — source Nx config; dest has its own
+- `README.md` — optional; keep or remove
+
+**Don't blindly delete** `tsconfig.base.json` — imported projects may extend it via relative paths.
+
+### Root ESLint Config Missing (Subdirectory Import)
+
+Subdirectory import doesn't bring the source's root `eslint.config.mjs`, but project configs reference `../../eslint.config.mjs`.
+
+**Fix order**:
+
+1. Install ESLint deps first: `pnpm add -wD eslint@^9 @nx/eslint-plugin typescript-eslint` (plus framework-specific plugins)
+2. Create root `eslint.config.mjs` (copy from source or create with `@nx/eslint-plugin` base rules)
+3. Then `npx nx add @nx/eslint` to register the plugin in `nx.json`
+
+Install `typescript-eslint` explicitly — pnpm's strict hoisting won't auto-resolve this transitive dep of `@nx/eslint-plugin`.
+
+### ESLint Version Pinning (Critical)
+
+**Pin ESLint to v9** (`eslint@^9.0.0`). ESLint 10 breaks `@nx/eslint` and many plugins with cryptic errors like `Cannot read properties of undefined (reading 'version')`.
+
+`@nx/eslint` may peer-depend on ESLint 8, causing the wrong version to resolve. If lint fails with `Cannot read properties of undefined (reading 'allow')`, add `pnpm.overrides`:
+
+```json
+{ "pnpm": { "overrides": { "eslint": "^9.0.0" } } }
+```
+
+### Dependency Version Conflicts
+
+After import, compare key deps (`typescript`, `eslint`, framework-specific). If dest uses newer versions, upgrade imported packages to match (usually safe). If source is newer, may need to upgrade dest first. Use `pnpm.overrides` to enforce single-version policy if desired.
+
+### Module Boundaries
+
+Imported projects may lack `tags`. Add tags or update `@nx/enforce-module-boundaries` rules.
+
+### Project Name Collisions (Multi-Import)
+
+Same `name` in `package.json` across source and dest causes `MultipleProjectsWithSameNameError`. **Fix**: Rename conflicting names (e.g. `@org/api` → `@org/teama-api`), update all dep references and import statements, `pnpm install`. The root `package.json` of each imported repo also becomes a project — rename those too.
+
+### Workspace Dep Import Ordering
+
+`pnpm install` fails during `nx import` if a `"workspace:*"` dependency hasn't been imported yet. File operations still succeed. **Fix**: Import all projects first, then `pnpm install --no-frozen-lockfile`.
+
+### `.gitkeep` Blocking Subdirectory Import
+
+The TS preset creates `packages/.gitkeep`. Remove it and commit before importing.
+
+### Frontend tsconfig Base Settings (Critical)
+
+The TS preset defaults (`module: "nodenext"`, `moduleResolution: "nodenext"`, `lib: ["es2022"]`) are incompatible with frontend frameworks (React, Next.js, Vue, Vite). After importing frontend projects, verify the dest root `tsconfig.base.json`:
+
+- **`moduleResolution`**: Must be `"bundler"` (not `"nodenext"`)
+- **`module`**: Must be `"esnext"` (not `"nodenext"`)
+- **`lib`**: Must include `"dom"` and `"dom.iterable"` (frontend projects need these)
+- **`jsx`**: `"react-jsx"` for React-only workspaces, per-project for mixed frameworks
+
+For **subdirectory imports**, the dest root tsconfig is authoritative — update it. For **whole-repo imports**, imported projects may extend their own nested `tsconfig.base.json`, making this less critical.
+
+If the dest also has backend projects needing `nodenext`, use per-project overrides instead of changing the root.
+
+**Gotcha**: TypeScript does NOT merge `lib` arrays — a project-level override **replaces** the base array entirely. Always include all needed entries (e.g. `es2022`, `dom`, `dom.iterable`) in any project-level `lib`.
+
+### `@nx/react` Typings for Libraries
+
+React libraries generated with `@nx/react:library` reference `@nx/react/typings/cssmodule.d.ts` and `@nx/react/typings/image.d.ts` in their tsconfig `types`. These fail with `Cannot find type definition file` unless `@nx/react` is installed in the dest workspace.
+
+**Fix**: `pnpm add -wD @nx/react`
+
+### Jest Preset Missing (Subdirectory Import)
+
+Nx presets create `jest.preset.js` at the workspace root, and project jest configs reference it (e.g. `../../jest.preset.js`). Subdirectory import does NOT bring this file.
+
+**Fix**:
+
+1. Run `npx nx add @nx/jest` — registers `@nx/jest/plugin` in `nx.json` and updates `namedInputs`
+2. Create `jest.preset.js` at workspace root (see `references/JEST.md` for content) — `nx add` only creates this when a generator runs, not on bare `nx add`
+3. Install test runner deps: `pnpm add -wD jest jest-environment-jsdom ts-jest @types/jest`
+4. Install framework-specific test deps as needed (see `references/JEST.md`)
+
+For deeper Jest issues (tsconfig.spec.json, Babel transforms, CI atomization, Jest vs Vitest coexistence), see `references/JEST.md`.
+
+### Target Name Prefixing (Whole-Repo Import)
+
+When importing a project with existing npm scripts (`build`, `dev`, `start`, `lint`), Nx plugins auto-prefix inferred target names to avoid conflicts: e.g. `next:build`, `vite:build`, `eslint:lint`.
+
+**Fix**: Remove the Nx-rewritten npm scripts from the imported `package.json`, then either:
+
+- Accept the prefixed names (e.g. `nx run app:next:build`)
+- Rename plugin target names in `nx.json` to use unprefixed names
+
+## Non-Nx Source Issues
+
+When the source is a plain pnpm/npm workspace without `nx.json`.
+
+### npm Script Rewriting (Critical)
+
+Nx rewrites `package.json` scripts during init, creating broken commands (e.g. `vitest run` → `nx test run`). **Fix**: Remove all rewritten scripts — Nx plugins infer targets from config files.
+
+### `noEmit` → `composite` + `emitDeclarationOnly` (Critical)
+
+Plain TS projects use `"noEmit": true`, incompatible with Nx project references.
+
+**Symptoms**: "typecheck target is disabled because one or more project references set 'noEmit: true'" or TS6310.
+
+**Fix** in **all** imported tsconfigs:
+
+1. Remove `"noEmit": true`. If inherited via extends chain, set `"noEmit": false` explicitly.
+2. Add `"composite": true`, `"emitDeclarationOnly": true`, `"declarationMap": true`
+3. Add `"outDir": "dist"` and `"tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"`
+4. Add `"extends": "../../tsconfig.base.json"` if missing. Remove settings now inherited from base.
+
+### Stale node_modules and Lockfiles
+
+`nx import` may bring `node_modules/` (pnpm symlinks pointing to the source filesystem) and `pnpm-lock.yaml` from the source. Both are stale.
+
+**Fix**: `rm -rf imported/node_modules imported/pnpm-lock.yaml imported/pnpm-workspace.yaml imported/.gitignore`, then `pnpm install`.
+
+### ESLint Config Handling
+
+- **Legacy `.eslintrc.json` (ESLint 8)**: Delete all `.eslintrc.*`, remove v8 deps, create flat `eslint.config.mjs`.
+- **Flat config (`eslint.config.js`)**: Self-contained configs can often be left as-is.
+- **No ESLint**: Create both root and project-level configs from scratch.
+
+### TypeScript `paths` Aliases
+
+Nx uses `package.json` `"exports"` + pnpm workspace linking instead of tsconfig `"paths"`. If packages have proper `"exports"`, paths are redundant. Otherwise, update paths for the new directory structure.
+
+## Technology-specific Guidance
+
+Identify technologies in the source repo, then read and apply the matching reference file(s).
+
+Available references:
+
+- `references/ESLINT.md` — ESLint projects: duplicate `lint`/`eslint:lint` targets, legacy `.eslintrc.*` linting generated files, flat config `.cjs` self-linting, `typescript-eslint` v7/v9 peer dep conflict, mixed ESLint v8+v9 in one workspace.
+- `references/GRADLE.md`
+- `references/JEST.md` — Jest testing: `@nx/jest/plugin` setup, jest.preset.js, testing deps by framework, tsconfig.spec.json, Jest vs Vitest coexistence, Babel transforms, CI atomization.
+- `references/NEXT.md` — Next.js projects: `@nx/next/plugin` targets, `withNx`, Next.js TS config (`noEmit`, `jsx: "preserve"`), auto-installing deps via wrong PM, non-Nx `create-next-app` imports, mixed Next.js+Vite coexistence.
+- `references/TURBOREPO.md`
+- `references/VITE.md` — Vite projects (React, Vue, or both): `@nx/vite/plugin` typecheck target, `resolve.alias`/`__dirname` fixes, framework deps, Vue-specific setup, mixed React+Vue coexistence.

--- a/.agents/skills/nx-import/references/ESLINT.md
+++ b/.agents/skills/nx-import/references/ESLINT.md
@@ -1,0 +1,109 @@
+## ESLint
+
+ESLint-specific guidance for `nx import`. For generic import issues (root deps, pnpm globs, project references), see `SKILL.md`.
+
+---
+
+### How `@nx/eslint/plugin` Works
+
+`@nx/eslint/plugin` scans for ESLint config files and creates a lint target for each project. It detects **both** flat config files (`eslint.config.{js,mjs,cjs,ts,mts,cts}`) and legacy config files (`.eslintrc.{json,js,cjs,mjs,yml,yaml}`).
+
+**Plugin options (set during `nx add @nx/eslint`):**
+
+```json
+{
+  "plugin": "@nx/eslint/plugin",
+  "options": {
+    "targetName": "eslint:lint"
+  }
+}
+```
+
+**Auto-installation**: `nx import` auto-detects ESLint config files and offers to install `@nx/eslint`. Accept the offer — it registers the plugin and updates `namedInputs.production` to exclude ESLint config files.
+
+---
+
+### Duplicate `lint` and `eslint:lint` Targets
+
+After import, projects will have **two** lint-related targets if the source `package.json` has a `"lint"` npm script:
+
+- `eslint:lint` — inferred by `@nx/eslint/plugin`; has proper caching and input/output tracking
+- `lint` — created by Nx from the npm script via `nx:run-script`; no caching intelligence, just wraps `npm run lint`
+
+**Fix**: Remove the `"lint"` script from each project's `package.json`. Keep `"lint:fix"` if present — there is no plugin-inferred equivalent for auto-fixing.
+
+---
+
+### Legacy `.eslintrc.*` Configs Linting Generated Files
+
+When `@nx/eslint/plugin` runs `eslint .` on a project with a legacy `.eslintrc.*` config that uses `parserOptions.project`, it tries to lint **all** files in the project directory including:
+
+- Generated `dist/**/*.d.ts` files (not in tsconfig `include`)
+- The `.eslintrc.js` config file itself (not in tsconfig `include`)
+
+This causes `Parsing error: ESLint was configured to run on X using parserOptions.project, however that TSConfig does not include this file`.
+
+**Fix**: Add `ignorePatterns` to the `.eslintrc.*` config:
+
+```json
+// .eslintrc.json
+{
+  "ignorePatterns": ["dist/**"]
+}
+```
+
+```js
+// .eslintrc.js — also ignore the config file itself since module.exports isn't in tsconfig
+module.exports = {
+  ignorePatterns: ['dist/**', '.eslintrc.js'],
+  // ...
+};
+```
+
+---
+
+### Flat Config `.cjs` Files Self-Linting
+
+When a project uses `eslint.config.cjs` (CJS flat config), `eslint .` lints the config file itself. The `require()` call on line 1 triggers `@typescript-eslint/no-require-imports`.
+
+**Fix**: Add the config filename to the top-level `ignores` array:
+
+```js
+module.exports = tseslint.config(
+  {
+    ignores: ['dist/**', 'node_modules/**', 'eslint.config.cjs'],
+  },
+  // ...
+);
+```
+
+The same applies to `eslint.config.js` in a CJS project (no `"type": "module"`) if it uses `require()`.
+
+---
+
+### `typescript-eslint` Version Conflict With ESLint 9
+
+`typescript-eslint@7.x` declares `peerDependencies: { "eslint": "^8.56.0" }`, but it is commonly used alongside `"eslint": "^9.0.0"`. npm treats this as a hard peer dep conflict and refuses to install.
+
+**Root cause**: `@nx/eslint` init adds `eslint@~8.57.0` at the workspace root (for its own peer deps). Workspace packages that request `eslint@^9.0.0` + `typescript-eslint@^7.0.0` trigger the conflict when npm resolves their deps.
+
+**Fix**: Upgrade `typescript-eslint` from `^7.0.0` to `^8.0.0` directly in the affected workspace package's `package.json`. The `tseslint.config()` API and `tseslint.configs.recommended` are identical between v7 and v8 — no config changes needed.
+
+```json
+// packages/my-package/package.json
+{
+  "devDependencies": {
+    "typescript-eslint": "^8.0.0"
+  }
+}
+```
+
+**Note**: npm's root-level `"overrides"` field does not force versions for workspace packages' direct dependencies — update each package.json individually.
+
+---
+
+### Mixed ESLint v8 and v9 in One Workspace
+
+Legacy v8 and flat-config v9 packages can coexist in the same workspace. Each package resolves its own `eslint` version. The root `eslint@~8.57.0` (added by `@nx/eslint` init) is used by legacy v8 packages; v9 packages get their own hoisted `eslint@9`.
+
+`@nx/eslint/plugin` infers `eslint:lint` targets for **both** config formats. Legacy packages run ESLint v8 with `.eslintrc.*`; flat-config packages run ESLint v9 with `eslint.config.*`. No special nx.json configuration is needed to support both simultaneously.

--- a/.agents/skills/nx-import/references/GRADLE.md
+++ b/.agents/skills/nx-import/references/GRADLE.md
@@ -1,0 +1,12 @@
+## Gradle
+
+- If you import an entire Gradle repository into a subfolder, files like `gradlew`, `gradlew.bat`, and `gradle/wrapper` will end up inside that imported subfolder.
+- The `@nx/gradle` plugin expects those files at the workspace root to infer Gradle projects/tasks automatically.
+- If the target workspace has no Gradle setup yet, consider moving those files to the root (especially when using `@nx/gradle`).
+- If the target workspace already has Gradle configured, avoid duplicate wrappers: remove imported duplicates from the subfolder or merge carefully.
+- Because the import lands in a subfolder, Gradle project references can break; review settings and project path references, then fix any errors.
+- If `@nx/gradle` is installed, run `nx show projects` to verify that Gradle projects are being inferred.
+
+Helpful docs:
+
+- https://nx.dev/docs/technologies/java/gradle/introduction

--- a/.agents/skills/nx-import/references/JEST.md
+++ b/.agents/skills/nx-import/references/JEST.md
@@ -1,0 +1,228 @@
+## Jest
+
+Jest-specific guidance for `nx import`. For the basic "Jest Preset Missing" fix (create `jest.preset.js`, install deps), see `SKILL.md`. This file covers deeper Jest integration issues.
+
+---
+
+### How `@nx/jest` Works
+
+`@nx/jest/plugin` scans for `jest.config.{ts,js,cjs,mjs,cts,mts}` and creates a `test` target for each project.
+
+**Plugin options:**
+
+```json
+{
+  "plugin": "@nx/jest/plugin",
+  "options": {
+    "targetName": "test"
+  }
+}
+```
+
+`npx nx add @nx/jest` does two things:
+
+1. **Registers `@nx/jest/plugin` in `nx.json`** — without this, no `test` targets are inferred
+2. Updates `namedInputs.production` to exclude test files
+
+**Gotcha**: `nx add @nx/jest` does NOT create `jest.preset.js` — that file is only generated when you run a generator (e.g. `@nx/jest:configuration`). For imports, you must create it manually (see "Jest Preset" section below).
+
+**Other gotcha**: If you create `jest.preset.js` manually but skip `npx nx add @nx/jest`, the plugin won't be registered and `nx run PROJECT:test` will fail with "Cannot find target 'test'". You need both.
+
+---
+
+### Jest Preset
+
+The preset provides shared Jest configuration (test patterns, ts-jest transform, resolver, jsdom environment).
+
+**Root `jest.preset.js`:**
+
+```js
+const nxPreset = require('@nx/jest/preset').default;
+module.exports = { ...nxPreset };
+```
+
+**Project `jest.config.ts`:**
+
+```ts
+export default {
+  displayName: 'my-lib',
+  preset: '../../jest.preset.js',
+  // project-specific overrides
+};
+```
+
+The `preset` path is relative from the project root to the workspace root. Subdirectory imports preserve the original relative path (e.g. `../../jest.preset.js`), which resolves correctly if the import destination matches the source directory depth.
+
+---
+
+### Testing Dependencies
+
+#### Core (always needed)
+
+```
+pnpm add -wD jest ts-jest @types/jest @nx/jest
+```
+
+#### Environment-specific
+
+- **DOM testing** (React, Vue, browser libs): `jest-environment-jsdom`
+- **Node testing** (APIs, CLIs): no extra deps (Jest defaults to `node` env, but Nx preset defaults to `jsdom`)
+
+#### React testing
+
+```
+pnpm add -wD @testing-library/react @testing-library/jest-dom
+```
+
+#### React with Babel (non-ts-jest transform)
+
+Some React projects use Babel instead of ts-jest for JSX transformation:
+
+```
+pnpm add -wD babel-jest @babel/core @babel/preset-env @babel/preset-react @babel/preset-typescript
+```
+
+**When**: Project `jest.config` has `transform` using `babel-jest` instead of `ts-jest`. Common in older Nx workspaces and CRA migrations.
+
+#### Vue testing
+
+```
+pnpm add -wD @vue/test-utils
+```
+
+Vue projects typically use Vitest (not Jest) — see VITE.md.
+
+---
+
+### `tsconfig.spec.json`
+
+Jest projects need a `tsconfig.spec.json` that includes test files:
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}
+```
+
+**Common issues after import:**
+
+- Missing `"types": ["jest", "node"]` — causes `describe`/`it`/`expect` to be unrecognized
+- Missing `"module": "commonjs"` — Jest doesn't support ESM by default (ts-jest transpiles to CJS)
+- `include` array missing test patterns — TypeScript won't check test files
+
+---
+
+### Jest vs Vitest Coexistence
+
+Workspaces can have both:
+
+- **Jest**: Next.js apps, older React libs, Node libraries
+- **Vitest**: Vite-based React/Vue apps and libs
+
+Both `@nx/jest/plugin` and `@nx/vite/plugin` (which infers Vitest targets) coexist without conflicts — they detect different config files (`jest.config.*` vs `vite.config.*`).
+
+**Target naming**: Both default to `test`. If a project somehow has both config files, rename one:
+
+```json
+{
+  "plugin": "@nx/jest/plugin",
+  "options": { "targetName": "jest-test" }
+}
+```
+
+---
+
+### `@testing-library/jest-dom` — Jest vs Vitest
+
+Projects migrating from Jest to Vitest (or workspaces with both) need different imports:
+
+**Jest** (in `test-setup.ts`):
+
+```ts
+import '@testing-library/jest-dom';
+```
+
+**Vitest** (in `test-setup.ts`):
+
+```ts
+import '@testing-library/jest-dom/vitest';
+```
+
+If the source used Jest but the dest workspace uses Vitest for that project type, update the import path. Also add `@testing-library/jest-dom` to tsconfig `types` array.
+
+---
+
+### Non-Nx Source: Test Script Rewriting
+
+Nx rewrites `package.json` scripts during init. Test scripts get broken:
+
+- `"test": "jest"` → `"test": "nx test"` (circular if no executor configured)
+- `"test": "vitest run"` → `"test": "nx test run"` (broken — `run` becomes an argument)
+
+**Fix**: Remove all rewritten test scripts. `@nx/jest/plugin` and `@nx/vite/plugin` infer test targets from config files.
+
+---
+
+### CI Atomization
+
+`@nx/jest/plugin` supports splitting tests per-file for CI parallelism:
+
+```json
+{
+  "plugin": "@nx/jest/plugin",
+  "options": {
+    "targetName": "test",
+    "ciTargetName": "test-ci"
+  }
+}
+```
+
+This creates `test-ci--src/lib/foo.spec.ts` targets for each test file, enabling Nx Cloud distribution. Not relevant during import, but useful for post-import CI setup.
+
+---
+
+### Common Post-Import Issues
+
+1. **"Cannot find target 'test'"**: `@nx/jest/plugin` not registered in `nx.json`. Run `npx nx add @nx/jest` or manually add the plugin entry.
+
+2. **"Cannot find module 'jest-preset'"**: `jest.preset.js` missing at workspace root. Create it (see SKILL.md).
+
+3. **"Cannot find type definition file for 'jest'"**: Missing `@types/jest` or `tsconfig.spec.json` doesn't have `"types": ["jest", "node"]`.
+
+4. **Tests fail with "Cannot use import statement outside a module"**: `ts-jest` not installed or not configured as transform. Check `jest.config.ts` transform section.
+
+5. **Snapshot path mismatches**: After import, `__snapshots__` directories may have paths baked in. Run tests once with `--updateSnapshot` to regenerate.
+
+---
+
+## Fix Order
+
+### Subdirectory Import (Nx Source)
+
+1. `npx nx add @nx/jest` — registers plugin in `nx.json` (does NOT create `jest.preset.js`)
+2. Create `jest.preset.js` manually (see "Jest Preset" section above)
+3. Install deps: `pnpm add -wD jest jest-environment-jsdom ts-jest @types/jest`
+4. Install framework test deps: `@testing-library/react @testing-library/jest-dom` (React), `@vue/test-utils` (Vue)
+5. Verify `tsconfig.spec.json` has `"types": ["jest", "node"]`
+6. `nx run-many -t test`
+
+### Whole-Repo Import (Non-Nx Source)
+
+1. Remove rewritten test scripts from `package.json`
+2. `npx nx add @nx/jest` — registers plugin (does NOT create preset)
+3. Create `jest.preset.js` manually
+4. Install deps (same as above)
+5. Verify/fix `jest.config.*` — ensure `preset` path points to root `jest.preset.js`
+6. Verify/fix `tsconfig.spec.json` — add `types`, `module`, `include` if missing
+7. `nx run-many -t test`

--- a/.agents/skills/nx-import/references/NEXT.md
+++ b/.agents/skills/nx-import/references/NEXT.md
@@ -1,0 +1,214 @@
+## Next.js
+
+Next.js-specific guidance for `nx import`. For generic import issues (pnpm globs, root deps, project references, name collisions, ESLint, frontend tsconfig base settings, `@nx/react` typings, Jest preset, target name prefixing, non-Nx source handling), see `SKILL.md`.
+
+---
+
+### `@nx/next/plugin` Inferred Targets
+
+`@nx/next/plugin` detects `next.config.{ts,js,cjs,mjs}` and creates these targets:
+
+- `build` → `next build` (with `dependsOn: ['^build']`)
+- `dev` → `next dev`
+- `start` → `next start` (depends on `build`)
+- `serve-static` → same as `start`
+- `build-deps` / `watch-deps` — for TS solution setup
+
+**No separate typecheck target** — Next.js runs TypeScript checking as part of `next build`. The `@nx/js/typescript` plugin provides a standalone `typecheck` target for non-Next libraries in the workspace.
+
+**Build target conflict**: Both `@nx/next/plugin` and `@nx/js/typescript` define a `build` target. `@nx/next/plugin` wins for Next.js projects (it detects `next.config.*`), while `@nx/js/typescript` handles libraries with `tsconfig.lib.json`. No rename needed — they coexist.
+
+### `withNx` in `next.config.js`
+
+Nx-generated Next.js projects use `composePlugins(withNx)` from `@nx/next`. This wrapper is optional for `next build` via the inferred plugin (which just runs `next build`), but it provides Nx-specific configuration. Keep it if present.
+
+### Root Dependencies for Next.js
+
+Beyond the generic root deps issue (see SKILL.md), Next.js projects typically need:
+
+**Core**: `react`, `react-dom`, `@types/react`, `@types/react-dom`, `@types/node`, `@nx/react` (see SKILL.md for `@nx/react` typings)
+**Nx plugins**: `@nx/next` (auto-installed by import), `@nx/eslint`, `@nx/jest`
+**Testing**: see SKILL.md "Jest Preset Missing" section
+**ESLint**: `@next/eslint-plugin-next` (in addition to generic ESLint deps from SKILL.md)
+
+### Next.js Auto-Installing Dependencies via Wrong Package Manager
+
+Next.js detects missing `@types/react` during `next build` and tries to install it using `yarn add` regardless of the actual package manager. In a pnpm workspace, this fails with a "nearest package directory isn't part of the project" error.
+
+**Root cause**: `@types/react` is missing from root devDependencies.
+**Fix**: Install deps at the root before building: `pnpm add -wD @types/react @types/react-dom`
+
+### Next.js TypeScript Config Specifics
+
+Next.js app tsconfigs have unique patterns compared to Vite:
+
+- **`noEmit: true`** with `emitDeclarationOnly: false` — Next.js handles emit, TS just checks types. This conflicts with `composite: true` from the TS solution setup.
+- **`"types": ["jest", "node"]`** — includes test types in the main tsconfig (no separate `tsconfig.app.json`)
+- **`"plugins": [{ "name": "next" }]`** — for IDE integration
+- **`include`** references `.next/types/**/*.ts` for Next.js auto-generated types
+- **`"jsx": "preserve"`** — Next.js uses its own JSX transform, not React's
+
+**Gotcha**: The Next.js tsconfig sets `"noEmit": true` which disables `composite` mode. This is fine because Next.js projects use `next build` for building, not `tsc`. The `@nx/js/typescript` plugin's `typecheck` target is not needed for Next.js apps.
+
+### `next.config.js` Lint Warning
+
+Imported Next.js configs may have `// eslint-disable-next-line @typescript-eslint/no-var-requires` but the project ESLint config enables different rule sets. This produces `Unused eslint-disable directive` warnings. Harmless — remove the comment or ignore.
+
+### `@nx/next:init` Rewrites All npm Scripts (Whole-Repo Import)
+
+When `@nx/next:init` runs during a whole-repo import, it rewrites the project's `package.json` scripts to prefixed `nx` calls:
+
+```json
+{
+  "dev": "nx next:dev",
+  "build": "nx next:build",
+  "start": "nx next:start"
+}
+```
+
+This is the standard "npm Script Rewriting" issue from SKILL.md, but triggered by `@nx/next:init` rather than Nx init. **Fix**: Remove all rewritten scripts from `package.json` — `@nx/next/plugin` infers all targets from `next.config.*`.
+
+---
+
+## Non-Nx Source (create-next-app)
+
+### Whole-Repo Import Recommended
+
+For single-project `create-next-app` repos, use whole-repo import into a subdirectory:
+
+```bash
+nx import /path/to/source apps/web --ref=main --source=. --no-interactive
+```
+
+### `next-env.d.ts`
+
+`next build` auto-generates `next-env.d.ts` at the project root. Add `next-env.d.ts` to the dest root `.gitignore` — it is framework-generated and should not be committed.
+
+### ESLint: Self-Contained `eslint-config-next`
+
+`create-next-app` generates a flat ESLint config using `eslint-config-next` (which bundles its own plugins). This is **self-contained** — no root `eslint.config.mjs` needed, no `@nx/eslint-plugin` dependency. The `@nx/eslint/plugin` detects it and creates a lint target.
+
+### TypeScript: No Changes Needed
+
+Non-Nx Next.js projects have self-contained tsconfigs with `noEmit: true`, their own `lib`, `module`, `moduleResolution`, and `jsx` settings. Since `next build` handles type checking internally, no tsconfig modifications are needed. The project does NOT need to extend `tsconfig.base.json`.
+
+**Gotcha**: The `@nx/js/typescript` plugin won't create a `typecheck` target because there's no `tsconfig.lib.json`. This is fine — use `next:build` for type checking.
+
+### `noEmit: true` and TS Solution Setup
+
+Non-Nx Next.js projects use `noEmit: true`, which conflicts with Nx's TS solution setup (`composite: true`). If the dest workspace uses project references and you want the Next.js app to participate:
+
+1. Remove `noEmit: true`, add `composite: true`, `emitDeclarationOnly: true`
+2. Add `extends: "../../tsconfig.base.json"`
+3. Add `outDir` and `tsBuildInfoFile`
+
+**However**, this is optional for standalone Next.js apps that don't export types consumed by other workspace projects.
+
+### Tailwind / PostCSS
+
+`create-next-app` with Tailwind generates `postcss.config.mjs`. This works as-is after import — no path changes needed since PostCSS resolves relative to the project root.
+
+---
+
+## Mixed Next.js + Vite Coexistence
+
+When both Next.js and Vite projects exist in the same workspace.
+
+### Plugin Coexistence
+
+Both `@nx/next/plugin` and `@nx/vite/plugin` can coexist in `nx.json`. They detect different config files (`next.config.*` vs `vite.config.*`) so there are no conflicts. The `@nx/js/typescript` plugin handles libraries.
+
+### Vite Standalone Project tsconfig Fixes
+
+Vite standalone projects (imported as whole-repo) have self-contained tsconfigs without `composite: true`. The `@nx/js/typescript` plugin's typecheck target runs `tsc --build --emitDeclarationOnly` which requires `composite`.
+
+**Fix**:
+
+1. Add `extends: "../../tsconfig.base.json"` to the root project tsconfig
+2. Add `composite: true`, `declaration: true`, `declarationMap: true`, `tsBuildInfoFile` to `tsconfig.app.json` and `tsconfig.spec.json`
+3. Set `moduleResolution: "bundler"` (replace `"node"`)
+4. Add source files to `tsconfig.spec.json` `include` — specs import app code, and `composite` mode requires all files to be listed
+
+### Typecheck Target Names
+
+- `@nx/vite/plugin` defaults `typecheckTargetName` to `"vite:typecheck"`
+- `@nx/js/typescript` uses `"typecheck"`
+- Next.js projects have NO standalone typecheck target — Next.js runs type checking during `next build`
+
+No naming conflicts between frameworks.
+
+---
+
+## Fix Order — Nx Source (Subdirectory Import)
+
+1. Import Next.js apps into `apps/<name>` (see SKILL.md: "Application vs Library Detection")
+2. Generic fixes from SKILL.md (pnpm globs, root deps, `.gitkeep` removal, frontend tsconfig base settings, `@nx/react` typings)
+3. Install Next.js-specific deps: `pnpm add -wD @next/eslint-plugin-next`
+4. ESLint setup (see SKILL.md: "Root ESLint Config Missing")
+5. Jest setup (see SKILL.md: "Jest Preset Missing")
+6. `nx reset && nx sync --yes && nx run-many -t typecheck,build,test,lint`
+
+## Fix Order — Non-Nx Source (create-next-app)
+
+1. Import into `apps/<name>` (see SKILL.md: "Application vs Library Detection")
+2. Generic fixes from SKILL.md (pnpm globs, stale files cleanup, script rewriting, target name prefixing)
+3. (Optional) If app needs to export types for other workspace projects: fix `noEmit` → `composite` (see SKILL.md)
+4. `nx reset && nx run-many -t next:build,eslint:lint` (or unprefixed names if renamed)
+
+---
+
+## Iteration Log
+
+### Scenario 1: Basic Nx Next.js App Router + Shared Lib → TS preset (PASS)
+
+- Source: CNW next preset (Next.js 16, App Router) + `@nx/react:library` shared-ui
+- Dest: CNW ts preset (Nx 23)
+- Import: subdirectory-at-a-time (apps, libs separately)
+- Errors found & fixed:
+  1. pnpm-workspace.yaml: `apps`/`libs` → `apps/*`/`libs/*`
+  2. Root tsconfig: `nodenext` → `bundler`, add `dom`/`dom.iterable` to `lib`, add `jsx: react-jsx`
+  3. Missing `@nx/react` (for CSS module/image type defs in lib)
+  4. Missing `@types/react`, `@types/react-dom`, `@types/node`
+  5. Next.js trying `yarn add @types/react` — fixed by installing at root
+  6. Missing `@nx/eslint`, root `eslint.config.mjs`, ESLint plugins
+  7. Missing `@nx/jest`, `jest.preset.js`, `jest-environment-jsdom`, `ts-jest`
+- All targets green: typecheck, build, test, lint
+
+### Scenario 3: Non-Nx create-next-app (App Router + Tailwind) → TS preset (PASS)
+
+- Source: `create-next-app@latest` (Next.js 16.1.6, App Router, Tailwind v4, flat ESLint config)
+- Dest: CNW ts preset (Nx 23)
+- Import: whole-repo into `apps/web`
+- Errors found & fixed:
+  1. pnpm-workspace.yaml: `apps/web` → `apps/*`
+  2. Stale files: `node_modules/`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.gitignore` — deleted
+  3. Nx-rewritten npm scripts (`"build": "nx next:build"`, etc.) — removed
+- No tsconfig changes needed — self-contained config with `noEmit: true`
+- ESLint self-contained via `eslint-config-next` — no root config needed
+- No test setup (create-next-app doesn't include tests)
+- All targets green: next:build, eslint:lint
+
+### Scenario 4: Non-Nx create-next-app (alongside Vite, React Router 7, TanStack, CRA) → TS preset (PASS)
+
+- See VITE.md Scenario 6 for the full multi-import scenario
+- Next.js-specific findings:
+  1. `@nx/next:init` rewrote all scripts to `nx next:*` format — removed all rewritten scripts
+  2. Stale files: `node_modules/`, `package-lock.json`, `.gitignore` — deleted (npm workspace, no pnpm files)
+  3. ESLint self-contained via `eslint-config-next` — no root config needed
+  4. No tsconfig changes needed — `noEmit: true` stays; `next build` handles type checking
+- Targets: `next:build`, `next:dev`, `next:start`, `eslint:lint`
+
+### Scenario 5: Mixed Next.js (Nx) + Vite React (standalone) → TS preset (PASS)
+
+- Source A: CNW next preset (Next.js 16, App Router) — subdirectory import of `apps/`
+- Source B: CNW react-standalone preset (Vite 7, React 19) — whole-repo import into `apps/vite-app`
+- Dest: CNW ts preset (Nx 23)
+- Errors found & fixed:
+  1. All Scenario 1 fixes for the Next.js app
+  2. Stale files from Vite source: `node_modules/`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.gitignore`, `nx.json`
+  3. Removed rewritten scripts from Vite app's `package.json`
+  4. ESLint 8 vs 9 conflict — `@nx/eslint` peer on ESLint 8 resolved wrong version. Fixed with `pnpm.overrides`
+  5. Vite tsconfigs missing `composite: true`, `declaration: true` — needed for `tsc --build --emitDeclarationOnly`
+  6. Vite `tsconfig.spec.json` `include` missing source files — specs import app code
+  7. Vite tsconfig `moduleResolution: "node"` → `"bundler"`, added `extends: "../../tsconfig.base.json"`
+- All targets green: typecheck, build, test, lint for both projects

--- a/.agents/skills/nx-import/references/TURBOREPO.md
+++ b/.agents/skills/nx-import/references/TURBOREPO.md
@@ -1,0 +1,62 @@
+## Turborepo
+
+- Nx replaces Turborepo task orchestration, but a clean migration requires handling Turborepo's config packages.
+- Migration guide: https://nx.dev/docs/guides/adopting-nx/from-turborepo#easy-automated-migration-example
+- Since Nx replaces Turborepo, all turbo config files and config packages become dead code and should be removed.
+
+## The Config-as-Package Pattern
+
+Turborepo monorepos ship with internal workspace packages that share configuration:
+
+- **`@repo/typescript-config`** (or similar) — tsconfig files (`base.json`, `nextjs.json`, `react-library.json`, etc.)
+- **`@repo/eslint-config`** (or similar) — ESLint config files and all ESLint plugin dependencies
+
+These are not code libraries. They distribute config via Node module resolution (e.g., `"extends": "@repo/typescript-config/nextjs.json"`). This is the **default** Turborepo pattern — expect it in virtually every Turborepo import. Package names vary — check `package.json` files to identify the actual names.
+
+## Check for Root Config Files First
+
+**Before doing any config merging, check whether the destination workspace uses shared root configuration.** This decides how to handle the config packages.
+
+- If the workspace has a root `tsconfig.base.json` and/or root `eslint.config.mjs` that projects extend, merge the config packages into these root configs (see steps below).
+- If the workspace does NOT have root config files — each project manages its own configuration independently (similar to Turborepo). In this case, **do not create root config files or merge into them**. Just remove turbo-specific parts (`turbo.json`, `eslint-plugin-turbo`) and leave the config packages in place, or ask the user how they want to handle them.
+
+If unclear, check for the presence of `tsconfig.base.json` at the root or ask the user.
+
+## Merging TypeScript Config (Only When Root tsconfig.base.json Exists)
+
+The config package contains a hierarchy of tsconfig files. Each project extends one via package name.
+
+1. **Read the config package** — trace the full inheritance chain (e.g., `nextjs.json` extends `base.json`).
+2. **Update root `tsconfig.base.json`** — absorb `compilerOptions` from the base config. Add Nx `paths` for cross-project imports (Turborepo doesn't use path aliases, Nx relies on them).
+3. **Update each project's `tsconfig.json`**:
+   - Change `"extends"` from `"@repo/typescript-config/<variant>.json"` to the relative path to root `tsconfig.base.json`.
+   - Inline variant-specific overrides from the intermediate config (e.g., Next.js: `"module": "ESNext"`, `"moduleResolution": "Bundler"`, `"jsx": "preserve"`, `"noEmit": true`; React library: `"jsx": "react-jsx"`).
+   - Preserve project-specific settings (`outDir`, `include`, `exclude`, etc.).
+4. **Delete the config package** and remove it from all `devDependencies`.
+
+## Merging ESLint Config (Only When Root eslint.config Exists)
+
+The config package centralizes ESLint plugin dependencies and exports composable flat configs.
+
+1. **Read the config package** — identify exported configs, plugin dependencies, and inheritance.
+2. **Update root `eslint.config.mjs`** — absorb base rules (JS recommended, TypeScript-ESLint, Prettier, etc.). Drop `eslint-plugin-turbo`.
+3. **Update each project's `eslint.config.mjs`** — switch from importing `@repo/eslint-config/<variant>` to extending the root config, adding framework-specific plugins inline.
+4. **Move ESLint plugin dependencies** from the config package to root `devDependencies`.
+5. If `@nx/eslint` plugin is configured with inferred targets, remove `"lint"` scripts from project `package.json` files.
+6. **Delete the config package** and remove it from all `devDependencies`.
+
+## General Cleanup
+
+- Remove turbo-specific dependencies: `turbo`, `eslint-plugin-turbo`.
+- Delete all `turbo.json` files (root and per-package).
+- Run workspace validation (`nx run-many -t build lint test typecheck`) to confirm nothing broke.
+
+## Key Pitfalls
+
+- **Trace the full inheritance chain** before inlining — check what each variant inherits from the base.
+- **Module resolution changes** — from Node package resolution (`@repo/...`) to relative paths (`../../tsconfig.base.json`).
+- **ESLint configs are JavaScript, not JSON** — handle JS imports, array spreading, and plugin objects when merging.
+
+Helpful docs:
+
+- https://nx.dev/docs/guides/adopting-nx/from-turborepo

--- a/.agents/skills/nx-import/references/VITE.md
+++ b/.agents/skills/nx-import/references/VITE.md
@@ -1,0 +1,397 @@
+## Vite
+
+Vite-specific guidance for `nx import`. For generic import issues (pnpm globs, root deps, project references, name collisions, ESLint, frontend tsconfig base settings, `@nx/react` typings, Jest preset, non-Nx source handling), see `SKILL.md`.
+
+---
+
+### `@nx/vite/plugin` Typecheck Target
+
+`@nx/vite/plugin` defaults `typecheckTargetName` to `"vite:typecheck"`. If the workspace expects `"typecheck"`, set it explicitly in `nx.json`. If `@nx/js/typescript` is also registered, rename one target to avoid conflicts (e.g. `"tsc-typecheck"` for the JS plugin).
+
+Keep both plugins only if the workspace has non-Vite pure TS libraries — `@nx/js/typescript` handles those while `@nx/vite/plugin` handles Vite projects.
+
+### @nx/vite Plugin Install Failure
+
+Plugin init loads `vite.config.ts` before deps are available. **Fix**: `pnpm add -wD vite @vitejs/plugin-react` (or `@vitejs/plugin-vue`) first, then `pnpm exec nx add @nx/vite`.
+
+### Vite `resolve.alias` and `__dirname` (Non-Nx Sources)
+
+**`__dirname` undefined** (CJS-only): Replace with `fileURLToPath(new URL('./src', import.meta.url))` from `'node:url'`.
+
+**`@/` path alias**: Vite's `resolve.alias` works at runtime but TS needs matching `"paths"`. Set `"baseUrl": "."` in project tsconfig.
+
+**PostCSS/Tailwind**: Verify `content` globs resolve correctly after import.
+
+### Missing TypeScript `types` (Non-Nx Sources)
+
+Non-Nx tsconfigs may not declare all needed types. Ensure Vite projects include `"types": ["node", "vite/client"]` in their tsconfig.
+
+### `noEmit` Fix: Vite-Specific Notes
+
+See SKILL.md for the generic noEmit→composite fix. Vite-specific additions:
+
+- Non-Nx Vite projects often have **both** `tsconfig.app.json` and `tsconfig.node.json` with `noEmit` — fix both
+- Solution-style tsconfigs (`"files": [], "references": [...]`) may lack `extends`. Add `extends` pointing to the dest root `tsconfig.base.json` so base settings (`moduleResolution`, `lib`) apply.
+- This is safe — Vite/Vitest ignore TypeScript emit settings.
+
+### Dependency Version Conflicts
+
+**Shared Vite deps (both frameworks):** `vite`, `vitest`, `jsdom`, `@types/node`, `typescript` (dev)
+
+**Vite 6→7**: Typecheck fails (`Plugin<any>` type mismatch); build/serve still works. Fix: align versions.
+**Vitest 3→4**: Usually works; type conflicts may surface in shared test utils.
+
+---
+
+## React Router 7 (Vite-Based)
+
+React Router 7 (`@react-router/dev`) uses Vite under the hood with a `vite.config.ts` and a `react-router.config.ts`. The `@nx/vite/plugin` detects `vite.config.ts` and creates inferred targets.
+
+### Targets
+
+`@nx/vite/plugin` creates `build`, `dev`, `serve` targets. The `build` target invokes the script defined in `package.json` (usually `react-router build`), not `vite build` directly.
+
+**No separate typecheck target from `@nx/vite/plugin`** — React Router 7 typegen is run as part of `typecheck` (e.g. `react-router typegen && tsc`). The `typecheck` target is inferred from the tsconfig. Keep the `typecheck` script in `package.json` if present; it is not rewritten.
+
+### tsconfig Notes
+
+React Router 7 uses a single `tsconfig.json` (no `tsconfig.app.json`/`tsconfig.node.json` split). It includes:
+
+- `"rootDirs": [".", "./.react-router/types"]` — for generated type files; keep as-is
+- `"paths": { "~/*": ["./app/*"] }` — self-referential alias; keep as-is
+- `"noEmit": true` — replace with composite settings per SKILL.md
+
+### Build Output
+
+React Router 7 outputs to `build/` (not `dist/`). Add `build` to the dest root `.gitignore`.
+
+### Generated Types Directory
+
+React Router 7 generates `.react-router/` at the project root for route type generation. Add `.react-router` to the dest root `.gitignore`.
+
+---
+
+## TanStack Start (Vite-Based)
+
+TanStack Start uses Vinxi under the hood, which wraps Vite. Projects have a standard `vite.config.ts` that `@nx/vite/plugin` detects normally.
+
+### Targets
+
+`@nx/vite/plugin` creates `build`, `dev`, `preview`, `serve-static`, `typecheck` targets. The `build` target runs `vite build` which invokes the TanStack Start Vinxi pipeline (produces both client and SSR bundles).
+
+### tsconfig Notes
+
+TanStack Start uses a single `tsconfig.json` with `"allowImportingTsExtensions": true` and `"noEmit": true`. Apply the standard noEmit → composite fix. `allowImportingTsExtensions` is compatible with `emitDeclarationOnly: true` — no change needed.
+
+### `paths` Aliases
+
+TanStack Start commonly uses `"#/*": ["./src/*"]` and `"@/*": ["./src/*"]`. These are self-referential — keep as-is for a single-project app.
+
+### Uncommitted Source Repo
+
+`create-tan-stack` initializes a git repo but does NOT make an initial commit. Before importing, commit first:
+
+```bash
+git -C /path/to/source add . && git -C /path/to/source commit -m "Initial commit"
+```
+
+### Generated and Build Directories
+
+TanStack Start / Vinxi / Nitro generate several directories that must be added to the dest root `.gitignore`:
+
+- `.vinxi` — Vinxi build cache
+- `.tanstack` — TanStack generated files
+- `.nitro` — Nitro build artifacts
+- `.output` — server-side build output (SSR/edge)
+
+These are not covered by `dist` or `build`.
+
+---
+
+## React-Specific
+
+### React Dependencies
+
+**Production:** `react`, `react-dom`
+**Dev:** `@types/react`, `@types/react-dom`, `@vitejs/plugin-react`, `@testing-library/react`, `@testing-library/jest-dom`, `jsdom`
+**ESLint (Nx sources):** `eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, `eslint-plugin-react-hooks`
+**ESLint (`create-vite`):** `eslint-plugin-react-refresh`, `eslint-plugin-react-hooks` — self-contained flat configs can be left as-is
+**Nx plugins:** `@nx/react` (generators), `@nx/vite`, `@nx/vitest`, `@nx/eslint`
+
+### React TypeScript Configuration
+
+Add `"jsx": "react-jsx"` — in `tsconfig.base.json` for single-framework workspaces, per-project for mixed (see Mixed section).
+
+### React ESLint Config
+
+```js
+import nx from '@nx/eslint-plugin';
+import baseConfig from '../../eslint.config.mjs';
+export default [
+  ...baseConfig,
+  ...nx.configs['flat/react'],
+  { files: ['**/*.ts', '**/*.tsx'], rules: {} },
+];
+```
+
+### React Version Conflicts
+
+React 18 (source) + React 19 (dest): pnpm may hoist mismatched `react-dom`, causing `TypeError: Cannot read properties of undefined (reading 'S')`. **Fix**: Align versions with `pnpm.overrides`.
+
+### `@testing-library/jest-dom` with Vitest
+
+If source used Jest: change import to `@testing-library/jest-dom/vitest` in test-setup.ts, add to tsconfig `types`.
+
+---
+
+## Vue-Specific
+
+### Vue Dependencies
+
+**Production:** `vue` (plus `vue-router`, `pinia` if used)
+**Dev:** `@vitejs/plugin-vue`, `vue-tsc`, `@vue/test-utils`, `jsdom`
+**ESLint:** `eslint-plugin-vue`, `vue-eslint-parser`, `@vue/eslint-config-typescript`, `@vue/eslint-config-prettier`
+**Nx plugins:** `@nx/vue` (generators), `@nx/vite`, `@nx/vitest`, `@nx/eslint` (install AFTER deps — see below)
+
+### Vue TypeScript Configuration
+
+Add to `tsconfig.base.json` (single-framework) or per-project (mixed):
+
+```json
+{ "jsx": "preserve", "jsxImportSource": "vue", "resolveJsonModule": true }
+```
+
+### `vue-shims.d.ts`
+
+Vue SFC files need a type declaration. Usually exists in each project's `src/` and imports cleanly. If missing:
+
+```ts
+declare module '*.vue' {
+  import { defineComponent } from 'vue';
+  const component: ReturnType<typeof defineComponent>;
+  export default component;
+}
+```
+
+### `vue-tsc` Auto-Detection
+
+Both `@nx/js/typescript` and `@nx/vite/plugin` auto-detect `vue-tsc` when installed — no manual config needed. Remove source scripts like `"typecheck": "vue-tsc --noEmit"`.
+
+### ESLint Plugin Installation Order (Critical)
+
+`@nx/eslint` init **crashes** if Vue ESLint deps aren't installed first (it loads all config files).
+
+**Correct order:**
+
+1. `pnpm add -wD eslint@^9 eslint-plugin-vue vue-eslint-parser @vue/eslint-config-typescript @typescript-eslint/parser @nx/eslint-plugin typescript-eslint`
+2. Create root `eslint.config.mjs`
+3. Then `npx nx add @nx/eslint`
+
+### Vue ESLint Config Pattern
+
+```js
+import vue from 'eslint-plugin-vue';
+import vueParser from 'vue-eslint-parser';
+import tsParser from '@typescript-eslint/parser';
+import baseConfig from '../../eslint.config.mjs';
+export default [
+  ...baseConfig,
+  ...vue.configs['flat/recommended'],
+  {
+    files: ['**/*.vue'],
+    languageOptions: { parser: vueParser, parserOptions: { parser: tsParser } },
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.vue'],
+    rules: { 'vue/multi-word-component-names': 'off' },
+  },
+];
+```
+
+**Important**: `vue-eslint-parser` override must come **AFTER** base config — `flat/typescript` sets the TS parser globally without a `files` filter, breaking `.vue` parsing.
+
+`vue-eslint-parser` must be an explicit pnpm dependency (strict resolution prevents transitive import).
+
+**Known issue**: Some generated Vue ESLint configs omit `vue-eslint-parser`. Use the pattern above instead.
+
+---
+
+## Mixed React + Vue
+
+When both frameworks coexist, several settings become per-project.
+
+### tsconfig `jsx` — Per-Project Only
+
+- React: `"jsx": "react-jsx"` in project tsconfig
+- Vue: `"jsx": "preserve"`, `"jsxImportSource": "vue"` in project tsconfig
+- Root: **NO** `jsx` setting
+
+### Typecheck — Auto-Detects Framework
+
+`@nx/vite/plugin` uses `vue-tsc` for Vue projects and `tsc` for React automatically.
+
+```json
+{
+  "plugins": [
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "typecheckTargetName": "typecheck",
+        "testTargetName": "test"
+      }
+    }
+  ]
+}
+```
+
+Remove `@nx/js/typescript` if all projects use Vite. Keep it (renamed to `"tsc-typecheck"`) only for non-Vite pure TS libs.
+
+### ESLint — Three-Tier Config
+
+1. **Root**: Base rules only, no framework-specific rules
+2. **React projects**: Extend root + `nx.configs['flat/react']`
+3. **Vue projects**: Extend root + `vue.configs['flat/recommended']` + `vue-eslint-parser`
+
+**Required packages**: Shared (`eslint@^9`, `@nx/eslint-plugin`, `typescript-eslint`, `@typescript-eslint/parser`), React (`eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, `eslint-plugin-react-hooks`), Vue (`eslint-plugin-vue`, `vue-eslint-parser`)
+
+`@nx/react`/`@nx/vue` are for generators only — no target conflicts.
+
+---
+
+## Redundant npm Scripts After Import
+
+`nx import` copies `package.json` verbatim, so npm scripts come along. For Vite-based projects `@nx/vite/plugin` already infers the same targets from `vite.config.ts` — the npm scripts just shadow the plugin with weaker `nx:run-script` wrappers (no first-class caching inputs/outputs). Remove them after import.
+
+### Standalone Vite App (`create-vite`)
+
+Remove the following scripts — every one is redundant:
+
+| Script                        | Plugin replacement                                                           |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `dev: vite`                   | `@nx/vite/plugin` → `dev`                                                    |
+| `build: tsc -b && vite build` | `@nx/vite/plugin` → `build`; `typecheck` via `@nx/js/typescript` handles tsc |
+| `preview: vite preview`       | `@nx/vite/plugin` → `preview`                                                |
+| `lint: eslint .`              | `@nx/eslint/plugin` → `eslint:lint`                                          |
+
+### TanStack Start
+
+Remove `build`, `dev`, `preview`, and `test` scripts, but move any hardcoded `--port` flag to `vite.config.ts` first:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  server: { port: 3000 },  // replaces `vite dev --port 3000`
+  ...
+})
+```
+
+### React Router 7 — Keep ALL scripts
+
+Do **not** remove React Router 7 scripts. They use the framework CLI (`react-router build`, `react-router dev`, `react-router-serve`) which is not interchangeable with plain `vite`:
+
+- `typecheck` runs `react-router typegen && tsc` — typegen must precede `tsc` or it fails on missing route types
+- `start` serves the SSR bundle — no plugin equivalent
+
+---
+
+## Fix Orders
+
+### Nx Source
+
+1. Generic fixes from SKILL.md (pnpm globs, root deps, executor paths, frontend tsconfig base settings, `@nx/react` typings)
+2. Configure `@nx/vite/plugin` typecheck target
+3. **React**: `jsx: "react-jsx"` (root or per-project)
+4. **Vue**: `jsx: "preserve"` + `jsxImportSource: "vue"`; verify `vue-shims.d.ts`; install ESLint deps before `@nx/eslint`
+5. **Mixed**: `jsx` per-project; remove/rename `@nx/js/typescript`
+6. `nx sync --yes && nx reset && nx run-many -t typecheck,build,test,lint`
+
+### Non-Nx Source (additional steps)
+
+0. Import into `apps/<name>` (see SKILL.md: "Application vs Library Detection")
+1. Generic fixes from SKILL.md (stale files cleanup, pnpm globs, rewritten scripts, target name prefixing, noEmit→composite, ESLint handling)
+2. Fix `noEmit` in **all** tsconfigs (app, node, etc. — non-Nx projects often have multiple)
+3. Add `extends` to solution-style tsconfigs so root settings apply
+4. Fix `resolve.alias` / `__dirname` / `baseUrl`
+5. Ensure `types` include `vite/client` and `node`
+6. Install `@nx/vite` manually if it failed during import
+7. Remove redundant npm scripts so `@nx/vite/plugin` infers them natively (see "Redundant npm Scripts" section)
+8. **Vue**: Add `outDir` + `**/*.vue.d.ts` to ESLint ignores
+9. Full verification
+
+### Multiple-Source Imports
+
+See SKILL.md for generic multi-import (name collisions, dep refs). Vite-specific: fix tsconfig `references` paths for alternate directories (`../../libs/` → `../../libs-beta/`).
+
+### Non-Nx Source: React Router 7
+
+1. Ensure source has at least one commit (see SKILL.md: "Source Repo Has No Commits")
+2. `nx import` whole-repo into `apps/<name>` (see SKILL.md: "Application vs Library Detection") → auto-installs `@nx/vite`, `@nx/react`
+3. Stale file cleanup: `node_modules/`, `package-lock.json`, `.gitignore`
+4. Fix `tsconfig.json`: `noEmit` → `composite + emitDeclarationOnly + outDir + tsBuildInfoFile`
+5. Add `build` and `.react-router` to dest root `.gitignore`
+6. **Keep all npm scripts** — React Router 7 uses framework CLI (`react-router build/dev`), not plain vite (see "Redundant npm Scripts" above)
+7. `npm install && nx reset && nx sync --yes`
+
+### Non-Nx Source: TanStack Start
+
+1. Ensure source has at least one commit — `create-tan-stack` does NOT auto-commit (see SKILL.md)
+2. `nx import` whole-repo into `apps/<name>` (see SKILL.md: "Application vs Library Detection") → auto-installs `@nx/vite`, `@nx/vitest`
+3. Stale file cleanup: `node_modules/`, `package-lock.json`, `.gitignore`
+4. Fix `tsconfig.json`: `noEmit` → `composite + emitDeclarationOnly + outDir + tsBuildInfoFile`
+5. Keep `allowImportingTsExtensions` — compatible with `emitDeclarationOnly: true`
+6. Add `.vinxi`, `.tanstack`, `.nitro`, `.output` to dest root `.gitignore`
+7. Move hardcoded `--port` from `dev` script into `vite.config.ts` (`server: { port: N }`)
+8. Remove redundant npm scripts — `@nx/vite/plugin` infers `build`, `dev`, `preview`, `test` (see "Redundant npm Scripts" above)
+9. `npm install && nx reset && nx sync --yes`
+
+### Quick Reference: React vs Vue
+
+| Aspect        | React                    | Vue                                       |
+| ------------- | ------------------------ | ----------------------------------------- |
+| Vite plugin   | `@vitejs/plugin-react`   | `@vitejs/plugin-vue`                      |
+| Type checker  | `tsc`                    | `vue-tsc` (auto-detected)                 |
+| SFC support   | N/A                      | `vue-shims.d.ts` needed                   |
+| tsconfig jsx  | `"react-jsx"`            | `"preserve"` + `"jsxImportSource": "vue"` |
+| ESLint parser | Standard TS              | `vue-eslint-parser` + TS sub-parser       |
+| ESLint setup  | Straightforward          | Must install deps before `@nx/eslint`     |
+| Test utils    | `@testing-library/react` | `@vue/test-utils`                         |
+
+### Quick Reference: Vite-Based React Frameworks
+
+| Aspect             | Vite (standalone) | React Router 7          | TanStack Start           |
+| ------------------ | ----------------- | ----------------------- | ------------------------ |
+| Build config       | `vite.config.ts`  | `vite.config.ts`        | `vite.config.ts`         |
+| Build output       | `dist/`           | `build/`                | `dist/`                  |
+| SSR bundle         | No                | Yes (`build/server/`)   | Yes (`dist/server/`)     |
+| tsconfig layout    | app + node split  | Single tsconfig         | Single tsconfig          |
+| Auto-committed     | Depends on tool   | Usually yes             | **No — commit first**    |
+| `nx import` plugin | `@nx/vite`        | `@nx/vite`, `@nx/react` | `@nx/vite`, `@nx/vitest` |
+
+---
+
+## Iteration Log
+
+### Scenario 6: Multiple non-Nx React apps (CRA, Next.js, React Router 7, TanStack Start, Vite) → TS preset (PASS)
+
+- Sources: 5 standalone non-Nx repos with different build tools
+- Dest: CNW ts preset (Nx 22.5.1), npm workspaces, `packages/*`
+- Import: whole-repo for each, sequential into `packages/<name>`
+- Pre-import fixes:
+  1. Removed `packages/.gitkeep` and committed
+  2. `git init && git add . && git commit` in Vite app (no git at all)
+  3. `git add . && git commit` in TanStack app (git init'd but no commits)
+- Import: `npm exec nx -- import <source> packages/<name> --source=. --ref=main --no-interactive`
+  - Next.js import auto-installed `@nx/eslint`, `@nx/next`
+  - React Router 7 import auto-installed `@nx/vite`, `@nx/react`, `@nx/docker` (Dockerfile present)
+  - TanStack import auto-installed `@nx/vitest`
+- Post-import fixes:
+  1. Removed stale `node_modules/`, `package-lock.json`, `.gitignore` from each package
+  2. Removed Nx-rewritten scripts from `board-games-nextjs/package.json` (had `"build": "nx next:build"`, etc.)
+  3. Updated root `tsconfig.base.json`: `nodenext` → `bundler`, added `dom`/`dom.iterable` to lib, added `jsx: react-jsx`
+  4. Added `build` to dest root `.gitignore` (CRA and React Router 7 output there)
+  5. Fixed `noEmit` → `composite + emitDeclarationOnly` in: `board-games-vite/tsconfig.app.json`, `board-games-vite/tsconfig.node.json`, `board-games-react-router/tsconfig.json`, `board-games-tanstack/tsconfig.json`
+  6. Fixed `tsBuildInfoFile` paths from `./node_modules/.tmp/...` to `./dist/...`
+  7. Installed root `@types/react`, `@types/react-dom`, `@types/node`
+- All targets green: `build` for all 5 projects; `typecheck` for Vite/React Router/TanStack; `next:build` for Next.js

--- a/.agents/skills/nx-plugins/SKILL.md
+++ b/.agents/skills/nx-plugins/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: nx-plugins
+description: Find and add Nx plugins. USE WHEN user wants to discover available plugins, install a new plugin, or add support for a specific framework or technology to the workspace.
+---
+
+## Finding and Installing new plugins
+
+- List plugins: `pnpm nx list`
+- Install plugins `pnpm nx add <plugin>`. Example: `pnpm nx add @nx/react`.

--- a/.agents/skills/nx-run-tasks/SKILL.md
+++ b/.agents/skills/nx-run-tasks/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: nx-run-tasks
+description: Helps with running tasks in an Nx workspace. USE WHEN the user wants to execute build, test, lint, serve, or run any other tasks defined in the workspace.
+---
+
+You can run tasks with Nx in the following way.
+
+Keep in mind that you might have to prefix things with npx/pnpx/yarn if the user doesn't have nx installed globally. Look at the package.json or lockfile to determine which package manager is in use.
+
+For more details on any command, run it with `--help` (e.g. `nx run-many --help`, `nx affected --help`).
+
+## Understand which tasks can be run
+
+You can check those via `nx show project <projectname> --json`, for example `nx show project myapp --json`. It contains a `targets` section which has information about targets that can be run. You can also just look at the `package.json` scripts or `project.json` targets, but you might miss out on inferred tasks by Nx plugins.
+
+## Run a single task
+
+```
+nx run <project>:<task>
+```
+
+where `project` is the project name defined in `package.json` or `project.json` (if present).
+
+## Run multiple tasks
+
+```
+nx run-many -t build test lint typecheck
+```
+
+You can pass a `-p` flag to filter to specific projects, otherwise it runs on all projects. You can also use `--exclude` to exclude projects, and `--parallel` to control the number of parallel processes (default is 3).
+
+Examples:
+
+- `nx run-many -t test -p proj1 proj2` — test specific projects
+- `nx run-many -t test --projects=*-app --exclude=excluded-app` — test projects matching a pattern
+- `nx run-many -t test --projects=tag:api-*` — test projects by tag
+
+## Run tasks for affected projects
+
+Use `nx affected` to only run tasks on projects that have been changed and projects that depend on changed projects. This is especially useful in CI and for large workspaces.
+
+```
+nx affected -t build test lint
+```
+
+By default it compares against the base branch. You can customize this:
+
+- `nx affected -t test --base=main --head=HEAD` — compare against a specific base and head
+- `nx affected -t test --files=libs/mylib/src/index.ts` — specify changed files directly
+
+## Useful flags
+
+These flags work with `run`, `run-many`, and `affected`:
+
+- `--skipNxCache` — rerun tasks even when results are cached
+- `--verbose` — print additional information such as stack traces
+- `--nxBail` — stop execution after the first failed task
+- `--configuration=<name>` — use a specific configuration (e.g. `production`)

--- a/.agents/skills/nx-workspace/SKILL.md
+++ b/.agents/skills/nx-workspace/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: nx-workspace
+description: "Explore and understand Nx workspaces. USE WHEN answering questions about the workspace, projects, or tasks. ALSO USE WHEN an nx command fails or you need to check available targets/configuration before running a task. EXAMPLES: 'What projects are in this workspace?', 'How is project X configured?', 'What depends on library Y?', 'What targets can I run?', 'Cannot find configuration for task', 'debug nx task failure'."
+---
+
+# Nx Workspace Exploration
+
+This skill provides read-only exploration of Nx workspaces. Use it to understand workspace structure, project configuration, available targets, and dependencies.
+
+Keep in mind that you might have to prefix commands with `npx`/`pnpx`/`yarn` if nx isn't installed globally. Check the lockfile to determine the package manager in use.
+
+## Listing Projects
+
+Use `nx show projects` to list projects in the workspace.
+
+The project filtering syntax (`-p`/`--projects`) works across many Nx commands including `nx run-many`, `nx release`, `nx show projects`, and more. Filters support explicit names, glob patterns, tag references (e.g. `tag:name`), directories, and negation (e.g. `!project-name`).
+
+```bash
+# List all projects
+nx show projects
+
+# Filter by pattern (glob)
+nx show projects --projects "apps/*"
+nx show projects --projects "shared-*"
+
+# Filter by tag
+nx show projects --projects "tag:publishable"
+nx show projects -p 'tag:publishable,!tag:internal'
+
+# Filter by target (projects that have a specific target)
+nx show projects --withTarget build
+
+# Combine filters
+nx show projects --type lib --withTarget test
+nx show projects --affected --exclude="*-e2e"
+nx show projects -p "tag:scope:client,packages/*"
+
+# Negate patterns
+nx show projects -p '!tag:private'
+nx show projects -p '!*-e2e'
+
+# Output as JSON
+nx show projects --json
+```
+
+## Project Configuration
+
+Use `nx show project <name> --json` to get the full resolved configuration for a project.
+
+**Important**: Do NOT read `project.json` directly - it only contains partial configuration. The `nx show project --json` command returns the full resolved config including inferred targets from plugins.
+
+You can read the full project schema at `node_modules/nx/schemas/project-schema.json` to understand nx project configuration options.
+
+```bash
+# Get full project configuration
+nx show project my-app --json
+
+# Extract specific parts from the JSON
+nx show project my-app --json | jq '.targets'
+nx show project my-app --json | jq '.targets.build'
+nx show project my-app --json | jq '.targets | keys'
+
+# Check project metadata
+nx show project my-app --json | jq '{name, root, sourceRoot, projectType, tags}'
+```
+
+## Target Information
+
+Targets define what tasks can be run on a project.
+
+```bash
+# List all targets for a project
+nx show project my-app --json | jq '.targets | keys'
+
+# Get full target configuration
+nx show project my-app --json | jq '.targets.build'
+
+# Check target executor/command
+nx show project my-app --json | jq '.targets.build.executor'
+nx show project my-app --json | jq '.targets.build.command'
+
+# View target options
+nx show project my-app --json | jq '.targets.build.options'
+
+# Check target inputs/outputs (for caching)
+nx show project my-app --json | jq '.targets.build.inputs'
+nx show project my-app --json | jq '.targets.build.outputs'
+
+# Find projects with a specific target
+nx show projects --withTarget serve
+nx show projects --withTarget e2e
+```
+
+## Workspace Configuration
+
+Read `nx.json` directly for workspace-level configuration.
+You can read the full project schema at `node_modules/nx/schemas/nx-schema.json` to understand nx project configuration options.
+
+```bash
+# Read the full nx.json
+cat nx.json
+
+# Or use jq for specific sections
+cat nx.json | jq '.targetDefaults'
+cat nx.json | jq '.namedInputs'
+cat nx.json | jq '.plugins'
+cat nx.json | jq '.generators'
+```
+
+Key nx.json sections:
+
+- `targetDefaults` - Default configuration applied to all targets of a given name
+- `namedInputs` - Reusable input definitions for caching
+- `plugins` - Nx plugins and their configuration
+- ...and much more, read the schema or nx.json for details
+
+## Affected Projects
+
+If the user is asking about affected projects, read the [affected projects reference](references/AFFECTED.md) for detailed commands and examples.
+
+## Common Exploration Patterns
+
+### "What's in this workspace?"
+
+```bash
+nx show projects
+nx show projects --type app
+nx show projects --type lib
+```
+
+### "How do I build/test/lint project X?"
+
+```bash
+nx show project X --json | jq '.targets | keys'
+nx show project X --json | jq '.targets.build'
+```
+
+### "What depends on library Y?"
+
+```bash
+# Use the project graph to find dependents
+nx graph --print | jq '.graph.dependencies | to_entries[] | select(.value[].target == "Y") | .key'
+```
+
+## Programmatic Answers
+
+When processing nx CLI results, use command-line tools to compute the answer programmatically rather than counting or parsing output manually. Always use `--json` flags to get structured output that can be processed with `jq`, `grep`, or other tools you have installed locally.
+
+### Listing Projects
+
+```bash
+nx show projects --json
+```
+
+Example output:
+
+```json
+["my-app", "my-app-e2e", "shared-ui", "shared-utils", "api"]
+```
+
+Common operations:
+
+```bash
+# Count projects
+nx show projects --json | jq 'length'
+
+# Filter by pattern
+nx show projects --json | jq '.[] | select(startswith("shared-"))'
+
+# Get affected projects as array
+nx show projects --affected --json | jq '.'
+```
+
+### Project Details
+
+```bash
+nx show project my-app --json
+```
+
+Example output:
+
+```json
+{
+  "root": "apps/my-app",
+  "name": "my-app",
+  "sourceRoot": "apps/my-app/src",
+  "projectType": "application",
+  "tags": ["type:app", "scope:client"],
+  "targets": {
+    "build": {
+      "executor": "@nx/vite:build",
+      "options": { "outputPath": "dist/apps/my-app" }
+    },
+    "serve": {
+      "executor": "@nx/vite:dev-server",
+      "options": { "buildTarget": "my-app:build" }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "options": {}
+    }
+  },
+  "implicitDependencies": []
+}
+```
+
+Common operations:
+
+```bash
+# Get target names
+nx show project my-app --json | jq '.targets | keys'
+
+# Get specific target config
+nx show project my-app --json | jq '.targets.build'
+
+# Get tags
+nx show project my-app --json | jq '.tags'
+
+# Get project root
+nx show project my-app --json | jq -r '.root'
+```
+
+### Project Graph
+
+```bash
+nx graph --print
+```
+
+Example output:
+
+```json
+{
+  "graph": {
+    "nodes": {
+      "my-app": {
+        "name": "my-app",
+        "type": "app",
+        "data": { "root": "apps/my-app", "tags": ["type:app"] }
+      },
+      "shared-ui": {
+        "name": "shared-ui",
+        "type": "lib",
+        "data": { "root": "libs/shared-ui", "tags": ["type:ui"] }
+      }
+    },
+    "dependencies": {
+      "my-app": [
+        { "source": "my-app", "target": "shared-ui", "type": "static" }
+      ],
+      "shared-ui": []
+    }
+  }
+}
+```
+
+Common operations:
+
+```bash
+# Get all project names from graph
+nx graph --print | jq '.graph.nodes | keys'
+
+# Find dependencies of a project
+nx graph --print | jq '.graph.dependencies["my-app"]'
+
+# Find projects that depend on a library
+nx graph --print | jq '.graph.dependencies | to_entries[] | select(.value[].target == "shared-ui") | .key'
+```
+
+## Troubleshooting
+
+### "Cannot find configuration for task X:target"
+
+```bash
+# Check what targets exist on the project
+nx show project X --json | jq '.targets | keys'
+
+# Check if any projects have that target
+nx show projects --withTarget target
+```
+
+### "The workspace is out of sync"
+
+```bash
+nx sync
+nx reset  # if sync doesn't fix stale cache
+```

--- a/.agents/skills/nx-workspace/references/AFFECTED.md
+++ b/.agents/skills/nx-workspace/references/AFFECTED.md
@@ -1,0 +1,27 @@
+## Affected Projects
+
+Find projects affected by changes in the current branch.
+
+```bash
+# Affected since base branch (auto-detected)
+nx show projects --affected
+
+# Affected with explicit base
+nx show projects --affected --base=main
+nx show projects --affected --base=origin/main
+
+# Affected between two commits
+nx show projects --affected --base=abc123 --head=def456
+
+# Affected apps only
+nx show projects --affected --type app
+
+# Affected excluding e2e projects
+nx show projects --affected --exclude="*-e2e"
+
+# Affected by uncommitted changes
+nx show projects --affected --uncommitted
+
+# Affected by untracked files
+nx show projects --affected --untracked
+```

--- a/.cursor/agents/ci-monitor-subagent.md
+++ b/.cursor/agents/ci-monitor-subagent.md
@@ -1,0 +1,51 @@
+---
+name: ci-monitor-subagent
+description: CI helper for /monitor-ci. Fetches CI status, retrieves fix details, or updates self-healing fixes. Executes one MCP tool call and returns the result.
+model: fast
+---
+
+# CI Monitor Subagent
+
+You are a CI helper. You call ONE MCP tool per invocation and return the result. Do not loop, poll, or sleep.
+
+## Commands
+
+The main agent tells you which command to run:
+
+### FETCH_STATUS
+
+Call `ci_information` with the provided branch and select fields. Return a JSON object with ONLY these fields:
+`{ cipeStatus, selfHealingStatus, verificationStatus, selfHealingEnabled, selfHealingSkippedReason, failureClassification, failedTaskIds, verifiedTaskIds, couldAutoApplyTasks, autoApplySkipped, autoApplySkipReason, userAction, cipeUrl, commitSha, shortLink }`
+
+### FETCH_HEAVY
+
+Call `ci_information` with heavy select fields. Summarize the heavy content and return:
+
+```json
+{
+  "shortLink": "...",
+  "failedTaskIds": ["..."],
+  "verifiedTaskIds": ["..."],
+  "suggestedFixDescription": "...",
+  "suggestedFixSummary": "...",
+  "selfHealingSkipMessage": "...",
+  "taskFailureSummaries": [{ "taskId": "...", "summary": "..." }]
+}
+```
+
+Do NOT return raw suggestedFix diffs or raw taskOutputSummary — summarize them.
+The main agent uses these summaries to understand what failed and attempt local fixes.
+
+### UPDATE_FIX
+
+Call `update_self_healing_fix` with the provided shortLink and action (APPLY/REJECT/RERUN_ENVIRONMENT_STATE). Return the result message (success/failure string).
+
+### FETCH_THROTTLE_INFO
+
+Call `ci_information` with the provided URL. Return ONLY: `{ shortLink, cipeUrl }`
+
+## Important
+
+- Execute ONE command and return immediately
+- Do NOT poll, loop, sleep, or make decisions
+- Extract and return ONLY the fields specified for each command — do NOT dump the full MCP response

--- a/.cursor/rules/angular/00-angular-core.mdc
+++ b/.cursor/rules/angular/00-angular-core.mdc
@@ -1,0 +1,19 @@
+---
+description: Angular project baseline rules.
+globs:
+  - "**/*.ts"
+  - "**/*.html"
+  - "**/*.scss"
+alwaysApply: false
+---
+
+# Angular Core Rules
+
+- Prefer standalone components.
+- Prefer Angular Signals for local state.
+- Use RxJS for async streams.
+- Keep components thin.
+- Move business logic outside components.
+- Follow existing folder structure.
+- Avoid introducing new architecture without checking current patterns.
+- Run lint/test/typecheck after edits.

--- a/.cursor/rules/angular/10-angular-signals.mdc
+++ b/.cursor/rules/angular/10-angular-signals.mdc
@@ -1,0 +1,15 @@
+---
+description: Angular Signals rules.
+globs:
+  - "**/*.ts"
+alwaysApply: false
+---
+
+# Angular Signals Rules
+
+- Use signal for local mutable state.
+- Use computed for derived state.
+- Avoid effect for ordinary propagation.
+- Do not mutate signal values directly.
+- Shared state belongs in services/stores.
+- Avoid unnecessary RxJS → Signal conversions.

--- a/.cursor/rules/angular/20-angular-components.mdc
+++ b/.cursor/rules/angular/20-angular-components.mdc
@@ -1,0 +1,17 @@
+---
+description: Angular component rules.
+globs:
+  - "**/*.component.ts"
+  - "**/*.component.html"
+  - "**/*.component.scss"
+alwaysApply: false
+---
+
+# Angular Component Rules
+
+- Keep components focused.
+- Avoid orchestration in components.
+- Keep templates simple.
+- Prefer semantic HTML.
+- Extract large templates/components.
+- Avoid deeply nested conditionals.

--- a/.cursor/rules/angular/30-angular-testing.mdc
+++ b/.cursor/rules/angular/30-angular-testing.mdc
@@ -1,0 +1,13 @@
+---
+description: Angular testing rules.
+globs:
+  - "**/*.spec.ts"
+alwaysApply: false
+---
+
+# Angular Testing Rules
+
+- Test behavior, not implementation details.
+- Keep mocks minimal.
+- Add regression tests for bug fixes.
+- Avoid testing private fields.

--- a/.cursor/rules/nx/00-nx-workspace.mdc
+++ b/.cursor/rules/nx/00-nx-workspace.mdc
@@ -1,0 +1,19 @@
+---
+description: Nx workspace baseline rules.
+globs:
+  - "nx.json"
+  - "project.json"
+  - "package.json"
+  - "apps/**"
+  - "libs/**"
+alwaysApply: false
+---
+
+# Nx Workspace Rules
+
+- Understand the workspace structure before editing.
+- Prefer Nx commands for project discovery.
+- Use existing project boundaries.
+- Do not move files across apps/libs without clear reason.
+- Follow existing naming conventions.
+- Prefer small, incremental changes.

--- a/.cursor/rules/nx/10-nx-generators.mdc
+++ b/.cursor/rules/nx/10-nx-generators.mdc
@@ -1,0 +1,14 @@
+---
+description: Nx generator rules.
+globs:
+  - "apps/**"
+  - "libs/**"
+alwaysApply: false
+---
+
+# Nx Generator Rules
+
+- Prefer Nx generators when creating projects, libraries, components, or services.
+- Check existing generator conventions before adding files manually.
+- Keep generated code aligned with the existing workspace structure.
+- Do not introduce new folder conventions without explicit reason.

--- a/.cursor/rules/nx/20-nx-tasks.mdc
+++ b/.cursor/rules/nx/20-nx-tasks.mdc
@@ -1,0 +1,17 @@
+---
+description: Nx task execution rules.
+globs:
+  - "nx.json"
+  - "project.json"
+  - "package.json"
+  - "pnpm-lock.yaml"
+alwaysApply: false
+---
+
+# Nx Task Rules
+
+- Use pnpm for package management.
+- Use Nx for build, test, lint, and affected commands.
+- Prefer running the smallest relevant task.
+- Run tests or type checks after meaningful code changes.
+- Avoid changing lockfiles unless dependency changes are required.

--- a/.cursor/rules/workflow/90-ai-workflow.mdc
+++ b/.cursor/rules/workflow/90-ai-workflow.mdc
@@ -1,0 +1,15 @@
+---
+description: AI workflow rules.
+globs:
+  - "**/*"
+alwaysApply: false
+---
+
+# AI Workflow Rules
+
+- Inspect nearby files before editing.
+- Follow existing naming conventions.
+- Prefer incremental refactoring.
+- Avoid unrelated changes.
+- Keep diffs small.
+- Preserve existing architecture unless explicitly refactoring.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+<!-- nx configuration start-->
+<!-- Leave the start & end comments to automatically receive updates. -->
+
+# General Guidelines for working with Nx
+
+- For navigating/exploring the workspace, invoke the `nx-workspace` skill first - it has patterns for querying projects, targets, and dependencies
+- When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
+- Prefix nx commands with the workspace's package manager (e.g., `pnpm nx build`, `npm exec nx test`) - avoids using globally installed CLI
+- You have access to the Nx MCP server and its tools, use them to help the user
+- For Nx plugin best practices, check `node_modules/@nx/<plugin>/PLUGIN.md`. Not all plugins have this file - proceed without it if unavailable.
+- NEVER guess CLI flags - always check nx_docs or `--help` first when unsure
+
+## Scaffolding & Generators
+
+- For scaffolding tasks (creating apps, libs, project structure, setup), ALWAYS invoke the `nx-generate` skill FIRST before exploring or calling MCP tools
+
+## When to use nx_docs
+
+- USE for: advanced config options, unfamiliar flags, migration guides, plugin configuration, edge cases
+- DON'T USE for: basic generator syntax (`nx g @nx/react:app`), standard commands, things you already know
+- The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
+
+<!-- nx configuration end-->

--- a/README.md
+++ b/README.md
@@ -144,6 +144,74 @@ pnpm test:all      # 全プロジェクトのテスト
 - Vitest 拡張機能をインストールし、Jest 拡張機能は無効化またはアンインストールしてください
 - ターミナルで `pnpm test` を実行するか、タスク「Run Tests (web)」を使用してください
 
+## AI エージェント向け設定（Cursor Skills / Rules）
+
+本プロジェクトは Cursor などの AI コーディングエージェントが Angular / Nx Workspace の構造とベストプラクティスを理解できるよう、Skills と Cursor Rules を導入しています（Issue #165）。
+
+### Angular Skills
+
+Angular 公式 Skills を `.agents/skills/` 配下に導入しています。
+
+- `angular-developer` — Angular の一般的な開発知識（Standalone Components / Signals / DI / ルーティング / フォーム / テスト など）
+- `angular-new-app` — Angular 新規アプリ作成のガイダンス
+
+再導入する場合は以下を実行してください。
+
+```bash
+npx skills add https://github.com/angular/skills
+```
+
+### Nx AI Agent 設定
+
+Nx AI Agents により、Nx Workspace 構造を AI に理解させるための Skills (`nx-workspace` / `nx-generate` / `nx-run-tasks` ほか)、Nx Console (MCP) 連携、ルート `AGENTS.md`、`.cursor/agents/` 配下のサブエージェント定義を導入しています。
+
+再設定する場合は以下を実行してください。
+
+```bash
+pnpm nx configure-ai-agents --agents cursor --no-interactive
+```
+
+### Cursor Rules (`.mdc`)
+
+`.cursor/rules/` 配下に責務別の Rules を配置しています。
+
+```text
+.cursor/rules/
+├── angular/
+│   ├── 00-angular-core.mdc       # Angular ベースライン
+│   ├── 10-angular-signals.mdc    # Signals の使い分け
+│   ├── 20-angular-components.mdc # Component 設計
+│   └── 30-angular-testing.mdc    # テスト方針
+├── nx/
+│   ├── 00-nx-workspace.mdc       # Workspace 全体ルール
+│   ├── 10-nx-generators.mdc      # Nx Generator 利用方針
+│   └── 20-nx-tasks.mdc           # Nx タスク実行方針
+└── workflow/
+    └── 90-ai-workflow.mdc        # AI 編集時の共通ルール
+```
+
+各 `.mdc` は `globs` で対象ファイルを限定しているため、対象ファイルを Cursor で開くと自動でルールが参照されます。
+
+### 役割分離
+
+| 種類           | 役割                              | 配置                |
+| -------------- | --------------------------------- | ------------------- |
+| Angular Skills | Angular の一般知識                | `.agents/skills/`   |
+| Nx AI Agent    | Nx Workspace 理解                 | `.agents/skills/` ほか |
+| Cursor Rules   | Workspace の設計ルール (責務別)   | `.cursor/rules/`    |
+| AI Workflow    | AI 編集時の共通ルール             | `.cursor/rules/workflow/` |
+
+### 将来的な拡張候補
+
+以下は今回の対象外（Issue #165 のスコープに記載）。将来別 Issue / PR で導入を検討します。
+
+- `chirimen-device-dashboard` 固有ルール用 mdc
+- NgRx 用 mdc
+- Storybook 用 mdc
+- CI/CD 用 mdc
+- Conventional Commits 用 mdc / Skill
+- ADR / Architecture 用 mdc
+
 ## Learn More
 
 - [Nx Documentation](https://nx.dev/getting-started/intro)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "angular-developer": {
+      "source": "angular/skills",
+      "sourceType": "github",
+      "skillPath": "angular-developer/SKILL.md",
+      "computedHash": "36f7f57e1485c994de62eae5b00f54c12f81d1d16661afa6d3c214dd9bcf7269"
+    },
+    "angular-new-app": {
+      "source": "angular/skills",
+      "sourceType": "github",
+      "skillPath": "angular-new-app/SKILL.md",
+      "computedHash": "49bd84ab08bd3498c52f476bed48fbb942dc6dbc0925607e84549adbed34bccf"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Issue #165 に基づき、Cursor などの AI コーディングエージェントが本 Angular / Nx Workspace の構造とベストプラクティスを理解できるよう、以下を導入します。

- Angular 公式 Skills (`angular-developer` / `angular-new-app`) を `.agents/skills/` に追加
- `pnpm nx configure-ai-agents --agents cursor --no-interactive` で Nx AI Agent 設定（Nx 由来の Skills / `.cursor/agents/` / ルート `AGENTS.md`）を導入
- `.cursor/rules/` 配下に責務別 Cursor Rules (`.mdc`) を追加（angular / nx / workflow）
- README に「AI エージェント向け設定（Cursor Skills / Rules）」セクションを追記

姉妹リポジトリ [chirimen-lite-console](https://github.com/gurezo/chirimen-lite-console) と同じ全体構成に揃えています（Conventional Commits 固有 mdc / Skill は Issue #165 のスコープ外のため別途対応予定）。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #165

## What changed?

- `.agents/skills/angular-developer/`, `.agents/skills/angular-new-app/`, `skills-lock.json` を追加（Angular 公式 Skills）
- `.agents/skills/nx-workspace/`, `nx-generate/`, `nx-run-tasks/`, `nx-import/`, `nx-plugins/`, `link-workspace-packages/`, `monitor-ci/` を追加（Nx AI Agent）
- `.cursor/agents/ci-monitor-subagent.md` を追加（Cursor サブエージェント）
- ルート `AGENTS.md` を追加（Nx 由来の AI エージェント向け共通ガイドライン）
- `.cursor/rules/angular/` 配下 4 ファイル（`00-angular-core` / `10-angular-signals` / `20-angular-components` / `30-angular-testing`）
- `.cursor/rules/nx/` 配下 3 ファイル（`00-nx-workspace` / `10-nx-generators` / `20-nx-tasks`）
- `.cursor/rules/workflow/90-ai-workflow.mdc`
- `README.md` に Cursor Skills / Rules セクションを追記

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

本変更は AI エージェント向け設定の追加のみで、アプリ・ライブラリのコードや公開 API には一切影響しません。

## How to test

1. ブランチをチェックアウトし、`pnpm install` 済みであることを確認する
2. `.cursor/rules/` 配下の各 `.mdc` を Cursor で開き、`globs` 通りに対象ファイルでルールが読み込まれることを確認する（例: `*.component.ts` を開いて `20-angular-components.mdc` が参照されること）
3. `pnpm nx configure-ai-agents --agents cursor --check` でドリフトが無いことを確認する
4. 既存タスクが壊れていないことを確認: `pnpm lint:all` / `pnpm test:all` / `pnpm build:all`

## Environment (if relevant)

- Browser: -
- OS: macOS / Windows / Linux
- Node version: `.nvmrc` 準拠
- pnpm version: 10.28.0（`package.json` の `packageManager` 準拠）

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)