### PR TITLE
feat(workspace): add conventional commits cursor skills and rules

### DIFF
--- a/.cursor/rules/commits/40-conventional-commits.mdc
+++ b/.cursor/rules/commits/40-conventional-commits.mdc
@@ -1,0 +1,62 @@
+---
+description: Conventional Commits rules for commit messages.
+globs:
+  - "**/*"
+alwaysApply: true
+---
+
+# Conventional Commits Rules
+
+すべてのコミットメッセージは [Conventional Commits](https://www.conventionalcommits.org/) に準拠する。
+
+## 形式
+
+```
+<type>(<scope>): <summary>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## ルール
+
+- `type` は小文字。
+- `scope` は小文字、ハイフン区切り。プロジェクトの `commitlint.config.js` の `scope-enum` から選ぶ。
+- `summary` は簡潔な英語、命令形 (imperative mood)。
+- `summary` の先頭は小文字。
+- `summary` の末尾にピリオドを付けない。
+- `type` と変更内容を一致させる。
+- 関連性のない変更を 1 つのコミットに混在させない。
+
+## 許可される type
+
+| type | 用途 |
+| --- | --- |
+| `feat` | 新機能の追加 |
+| `fix` | バグ修正 |
+| `docs` | ドキュメントのみの変更 |
+| `style` | コードフォーマット (動作に影響しない) |
+| `refactor` | リファクタリング (機能変更なし) |
+| `perf` | パフォーマンス改善 |
+| `test` | テスト追加・修正 |
+| `build` | ビルド・依存・設定の変更 |
+| `ci` | CI 設定の変更 |
+| `chore` | その他の雑務 |
+| `revert` | 過去のコミットの取り消し |
+
+## Breaking Change
+
+破壊的変更は footer に `BREAKING CHANGE: <message>` を記載する。`type!` 表記は使わない。
+
+```
+feat(web): change device list api
+
+BREAKING CHANGE: DeviceListStore の API シグネチャが変更されました
+```
+
+## 参照
+
+- `.cursor/skills/conventional-commits/SKILL.md`
+- `commitlint.config.js`
+- `CONTRIBUTING.md`

--- a/.cursor/rules/commits/41-pull-request-title.mdc
+++ b/.cursor/rules/commits/41-pull-request-title.mdc
@@ -1,0 +1,48 @@
+---
+description: Pull request title rules (Conventional Commits).
+globs:
+  - "**/*"
+alwaysApply: false
+---
+
+# Pull Request Title Rules
+
+PR タイトルは Conventional Commits に統一する。GitHub Actions の `commitlint` ワークフローは PR に含まれる全コミットを検証するが、PR タイトル自体も同じ形式で揃える。
+
+## 形式
+
+```
+<type>(<scope>): <summary>
+```
+
+- 小文字の `type` / `scope`。
+- `summary` は英語、命令形、末尾ピリオドなし。
+- 複数の変更を含む PR では代表的な type / scope を選ぶ。
+
+## 良い例
+
+```
+feat(libs-card-list): add device card list component
+fix(libs-data-access): correct device repository fetch error
+refactor(libs-feature-list): simplify device list rendering
+docs(workspace): update readme quick start
+test(web): add device list smoke test
+ci(workspace): update commitlint workflow
+build(workspace): bump nx to 22.7.1
+```
+
+## 悪い例
+
+```
+update files
+fix issue
+WIP
+Added new component
+feat: Added New Feature.
+```
+
+## 参照
+
+- `.cursor/rules/commits/40-conventional-commits.mdc`
+- `.cursor/rules/commits/42-chirimen-device-dashboard-scope.mdc`
+- `.github/pull_request_template.md`

--- a/.cursor/rules/commits/42-chirimen-device-dashboard-scope.mdc
+++ b/.cursor/rules/commits/42-chirimen-device-dashboard-scope.mdc
@@ -1,0 +1,40 @@
+---
+description: chirimen-device-dashboard scope rules for Conventional Commits.
+globs:
+  - "**/*"
+alwaysApply: false
+---
+
+# chirimen-device-dashboard Scope Rules
+
+`scope` は Nx app / lib / tool 単位を優先する。各プロジェクトの `project.json` の `name` プロパティ、または `commitlint.config.js` の `scope-enum` に列挙された値だけを使用する。
+
+## 推奨 scope (commitlint.config.js と一致)
+
+| scope | 対象 | 説明 |
+| --- | --- | --- |
+| `web` | `apps/web` | Angular フロントエンド |
+| `web-e2e` | `apps/web-e2e` | Playwright E2E |
+| `shared-types` | `libs/shared-types` | 共有型定義 |
+| `libs-data-access` | `libs/devices/data-access` | デバイスデータアクセス |
+| `libs-state` | `libs/devices/state` | デバイス状態管理 |
+| `libs-feature-list` | `libs/devices/feature-list` | デバイス一覧 feature |
+| `libs-card-list` | `libs/devices/card-list` | デバイスカード一覧 UI |
+| `libs-device-detail` | `libs/devices/device-detail` | デバイス詳細 UI |
+| `sync-devices` | `tools/scripts/sync-devices` | デバイス JSON 同期スクリプト |
+| `workspace` | ルート設定・ツール全般 | `package.json` / `nx.json` / `.husky/` 等 |
+| `ci` | `.github/workflows/` | CI ワークフロー |
+| `mcp` | `.cursor/mcp.json` 等 | MCP 設定 |
+
+## scope 選択方針
+
+- 変更が単一プロジェクトに収まる場合は、そのプロジェクト名を scope に使う。
+- 変更が複数プロジェクトに跨る場合は、最も影響範囲の広いプロジェクト、または `workspace` を使う。
+- `apps/` `libs/` の外 (ルート設定、ドキュメント、ツール) の変更は `workspace` を使う。
+- 新しいプロジェクトを追加した場合は、`commitlint.config.js` の `scope-enum` と本ファイル、`CONTRIBUTING.md` のスコープ一覧を同時に更新する。
+
+## 参照
+
+- `commitlint.config.js`
+- `CONTRIBUTING.md`
+- `.cursor/skills/conventional-commits/scopes.md`

--- a/.cursor/skills/conventional-commits/SKILL.md
+++ b/.cursor/skills/conventional-commits/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: conventional-commits
+description: Generates Conventional Commits messages and pull request titles for chirimen-device-dashboard (Angular + Nx monorepo). Trigger when authoring commit messages, PR titles, or release notes, or when reviewing existing commit history for compliance.
+---
+
+# Conventional Commits for chirimen-device-dashboard
+
+このリポジトリ (Angular + Nx モノレポ) 向けに、Conventional Commits 準拠の commit message / PR title を生成・検証するための Skill。
+
+## 目的
+
+- commit message と PR title を [Conventional Commits](https://www.conventionalcommits.org/) に統一する。
+- Angular / Nx ワークスペースの構成 (`apps/`, `libs/devices/*`, `libs/shared-types`, `tools/scripts/*`) に整合する scope を選ぶ。
+- 将来的な changelog 自動生成 / semantic-release への接続を容易にする。
+- AI が生成するメッセージの品質を安定化させる。
+
+## 形式
+
+```
+<type>(<scope>): <summary>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## 適用ルール
+
+1. **type は小文字** で、許可された値のみを使う (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`)。
+2. **scope は小文字、ハイフン区切り**。`commitlint.config.js` の `scope-enum` または `scopes.md` から選ぶ。
+3. **summary は英語、命令形 (imperative mood)**。先頭は小文字、末尾にピリオドを付けない。
+4. **type と変更内容を一致させる**。フォーマット変更のみは `style`、依存更新は `build`、CI 設定は `ci`。
+5. **関連性のない変更を 1 つのコミットに混在させない**。
+6. **breaking change** は footer に `BREAKING CHANGE: <message>` を記載する (`type!` 表記は使わない)。
+
+## Angular / Nx を踏まえた scope 選択
+
+- Angular コンポーネント / テンプレート / スタイル変更 → 該当 lib (`libs-card-list`, `libs-feature-list`, `libs-device-detail` 等) または `web`。
+- 状態管理 (DeviceListStore 等) の変更 → `libs-state`。
+- リポジトリ層 / API 呼び出し変更 → `libs-data-access`。
+- 共有型定義 → `shared-types`。
+- ルート設定・ツール (`package.json`, `nx.json`, `.husky/`, `commitlint.config.js`) → `workspace`。
+- GitHub Actions ワークフロー → `ci`。
+- MCP 設定 (`.cursor/mcp.json`) → `mcp`。
+- E2E テスト → `web-e2e`。
+- デバイス JSON 同期スクリプト → `sync-devices`。
+
+詳細は `scopes.md` を参照。
+
+## docs / ci / build / chore の使い分け
+
+| 種別 | type | 例 |
+| --- | --- | --- |
+| README / CONTRIBUTING 等のドキュメント | `docs` | `docs(workspace): update readme quick start` |
+| GitHub Actions ワークフロー追加・変更 | `ci` | `ci(workspace): add commitlint workflow` |
+| 依存追加・更新、ビルド設定 | `build` | `build(workspace): bump nx to 22.7.1` |
+| 上記に当てはまらない雑務 | `chore` | `chore(workspace): remove unused script` |
+
+## 参照ファイル
+
+- [`examples.md`](examples.md): 良い例と悪い例
+- [`assertions.md`](assertions.md): 検証項目と Valid / Invalid サンプル
+- [`scopes.md`](scopes.md): scope 一覧と用途
+- リポジトリ側: `commitlint.config.js`, `CONTRIBUTING.md`, `.cursor/rules/commits/`

--- a/.cursor/skills/conventional-commits/assertions.md
+++ b/.cursor/skills/conventional-commits/assertions.md
@@ -1,0 +1,60 @@
+# Assertions
+
+commit message / PR title を Conventional Commits に準拠させるための検証項目。AI が生成または検証するときに使うチェックリスト。
+
+## 検証項目
+
+1. **形式**: `<type>(<scope>): <summary>` の形式になっているか。
+2. **type**: 許可された値 (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`) のいずれかで、小文字か。
+3. **scope**: `commitlint.config.js` の `scope-enum` に含まれる値か。`scopes.md` と一致するか。小文字でハイフン区切りか。
+4. **summary**: 簡潔で命令形 (imperative mood) か。
+5. **summary 先頭**: 小文字か。
+6. **summary 末尾**: ピリオドが付いていないか。
+7. **整合性**: type と変更対象が一致しているか (例: ドキュメントのみ変更で `feat` を使っていないか)。
+8. **scope と変更対象の一致**: 変更ファイルが scope に対応するディレクトリと一致しているか。
+9. **breaking change**: 破壊的変更がある場合、footer に `BREAKING CHANGE: <message>` が記載されているか (`!` 表記を使っていないか)。
+10. **混在**: 関連性のない変更を 1 つのコミットにまとめていないか。
+
+## Valid 例
+
+```
+feat(libs-card-list): add device card list component
+fix(libs-data-access): correct device repository fetch error
+refactor(libs-feature-list): simplify device list rendering
+docs(workspace): update readme quick start
+test(web): add device list smoke test
+ci(workspace): update commitlint workflow
+build(workspace): bump nx to 22.7.1
+build(sync-devices): update devices.json from partslist.csv
+```
+
+破壊的変更を含む Valid 例:
+
+```
+feat(libs-state): change device list store api
+
+BREAKING CHANGE: DeviceListStore.load() の戻り値が Observable から Signal に変更されました
+```
+
+## Invalid 例と修正案
+
+| Invalid | 違反項目 | 修正案 |
+| --- | --- | --- |
+| `fix stuff` | 1, 3, 4 | `fix(libs-data-access): correct device fetch error` |
+| `update console` | 1, 2, 3 | `refactor(web): update console output` |
+| `Added new component` | 1, 5 | `feat(libs-card-list): add new component` |
+| `WIP` | 1, 2, 3, 4 | コミットを分割し具体的なメッセージにする |
+| `feat: Added New Feature.` | 3, 5, 6 | `feat(web): add new feature` |
+| `feat(WEB): add component` | 3 | `feat(web): add component` |
+| `feat(web)!: change api` | 9 | `feat(web): change api` + footer に `BREAKING CHANGE: ...` |
+
+## 自動検証
+
+ローカル: `.husky/commit-msg` が `pnpm exec commitlint --edit "$1"` を実行する。
+CI: `.github/workflows/commitlint.yml` が PR の全コミットを検証する。
+
+## 参照
+
+- [`SKILL.md`](SKILL.md)
+- [`examples.md`](examples.md)
+- [`scopes.md`](scopes.md)

--- a/.cursor/skills/conventional-commits/examples.md
+++ b/.cursor/skills/conventional-commits/examples.md
@@ -1,0 +1,94 @@
+# Examples
+
+chirimen-device-dashboard における Conventional Commits の良い例と悪い例。
+
+## 良い例
+
+### feat
+
+```
+feat(libs-card-list): add device card list component
+feat(libs-feature-list): add device filter ui
+feat(web): add device detail route
+feat(libs-state): add device list store
+```
+
+### fix
+
+```
+fix(libs-data-access): correct device repository fetch error
+fix(libs-card-list): correct empty state rendering
+fix(web): correct device list display
+```
+
+### refactor
+
+```
+refactor(libs-feature-list): simplify device list rendering
+refactor(libs-state): extract device selectors
+refactor(libs-card-list): update device card list ui
+```
+
+### docs
+
+```
+docs(workspace): update readme quick start
+docs(workspace): document cursor skills and rules
+docs(libs-device-detail): add component readme
+```
+
+### test
+
+```
+test(web): add device list smoke test
+test(libs-data-access): add device repository unit tests
+```
+
+### ci
+
+```
+ci(workspace): add commitlint workflow
+ci(workspace): update github actions workflow
+```
+
+### build
+
+```
+build(workspace): add commitlint and husky
+build(workspace): bump nx to 22.7.1
+build(sync-devices): update devices.json from partslist.csv
+```
+
+### chore
+
+```
+chore(workspace): remove unused script
+```
+
+### breaking change
+
+```
+feat(libs-state): change device list store api
+
+BREAKING CHANGE: DeviceListStore.load() の戻り値が Observable から Signal に変更されました
+```
+
+## 悪い例
+
+| メッセージ | 理由 |
+| --- | --- |
+| `update files` | type / scope が無く、内容も曖昧 |
+| `fix issue` | scope が無く、内容も曖昧 |
+| `WIP` | 完成していない作業を表す不適切なメッセージ |
+| `Added new component` | type が無く、命令形でなく、大文字始まり |
+| `feat: Added New Feature.` | summary が大文字始まりで末尾にピリオド |
+| `feat(WEB): add component` | scope が大文字 |
+| `Refactor(web): simplify` | type が大文字 |
+| `fix(libs-web): handle error` | 存在しない scope を使用 |
+| `feat(web)!: change api` | `!` 表記は使わず footer に `BREAKING CHANGE:` を書く |
+
+## 参照
+
+- [`SKILL.md`](SKILL.md)
+- [`assertions.md`](assertions.md)
+- [`scopes.md`](scopes.md)

--- a/.cursor/skills/conventional-commits/scopes.md
+++ b/.cursor/skills/conventional-commits/scopes.md
@@ -1,0 +1,47 @@
+# Scopes
+
+chirimen-device-dashboard で使用可能な scope の一覧と用途。`commitlint.config.js` の `scope-enum` と完全に一致させる。
+
+## 一覧
+
+| scope | 対象パス | プロジェクト名 (`project.json`) | 用途 |
+| --- | --- | --- | --- |
+| `web` | `apps/web` | `web` | Angular フロントエンド (SPA, ポート 4200) |
+| `web-e2e` | `apps/web-e2e` | `web-e2e` | Playwright による Web E2E テスト |
+| `shared-types` | `libs/shared-types` | `shared-types` | `DeviceInfo`, `ProductInfo` 等の共有型定義 |
+| `libs-data-access` | `libs/devices/data-access` | `libs-data-access` | デバイスリポジトリ・データアクセス層 |
+| `libs-state` | `libs/devices/state` | `libs-state` | `DeviceListStore` 等の状態管理層 |
+| `libs-feature-list` | `libs/devices/feature-list` | `libs-feature-list` | デバイス一覧 feature コンポーネント |
+| `libs-card-list` | `libs/devices/card-list` | `libs-card-list` | デバイスカード一覧 UI |
+| `libs-device-detail` | `libs/devices/device-detail` | `libs-device-detail` | デバイス詳細 UI |
+| `sync-devices` | `tools/scripts/sync-devices` | `sync-devices` | `devices.json` の同期スクリプト |
+| `workspace` | リポジトリルート | (該当なし) | `package.json` / `nx.json` / `.husky/` / `commitlint.config.js` / `.cursor/` / `.agents/` / README / CONTRIBUTING 等 |
+| `ci` | `.github/workflows/` | (該当なし) | GitHub Actions ワークフロー |
+| `mcp` | `.cursor/mcp.json` 等 | (該当なし) | MCP 設定 |
+
+## scope 選択の考え方
+
+1. **単一プロジェクトに収まる変更**: そのプロジェクトの `name` を scope に使う。
+   - 例: `libs/devices/card-list/` 配下の変更 → `libs-card-list`
+2. **複数プロジェクトに跨る変更**: 最も影響範囲の広いプロジェクトを優先する。判断がつかない場合は `workspace`。
+3. **ルート設定・ツール変更**: `workspace`。
+4. **GitHub Actions ワークフロー**: `ci`。
+5. **MCP 設定**: `mcp`。
+
+## 新規プロジェクト追加時の手順
+
+新しい app / lib / tool を追加した場合、以下を **同時に** 更新する。
+
+1. `commitlint.config.js` の `scope-enum` に新しい scope を追加。
+2. このファイル (`scopes.md`) に新しい行を追加。
+3. `.cursor/rules/commits/42-chirimen-device-dashboard-scope.mdc` の推奨 scope 表を更新。
+4. `CONTRIBUTING.md` のスコープ一覧を更新。
+
+これらは同一 PR 内で行い、scope 一覧の単一情報源 (`commitlint.config.js`) と一致させる。
+
+## 参照
+
+- [`SKILL.md`](SKILL.md)
+- [`examples.md`](examples.md)
+- [`assertions.md`](assertions.md)
+- リポジトリ側: `commitlint.config.js`, `CONTRIBUTING.md`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+> PR タイトルは [Conventional Commits](https://www.conventionalcommits.org/) に準拠してください (例: `feat(web): add device list component`)。
+> 利用可能な scope は [CONTRIBUTING.md](../CONTRIBUTING.md#スコープ一覧) と `commitlint.config.js` を参照してください。
+
 ## Summary
 
 ## Type of change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,15 @@
 
 本プロジェクトでは [Conventional Commits](https://www.conventionalcommits.org/) に準拠したコミットメッセージを採用しています。
 
+AI エージェント (Cursor 等) 向けの Conventional Commits ルール / Skill を以下に整備しています。手動でメッセージを書く場合の参考にもなります。
+
+- Rules: [.cursor/rules/commits/](.cursor/rules/commits/)
+  - [40-conventional-commits.mdc](.cursor/rules/commits/40-conventional-commits.mdc) — 基本ルール
+  - [41-pull-request-title.mdc](.cursor/rules/commits/41-pull-request-title.mdc) — PR タイトル規約
+  - [42-chirimen-device-dashboard-scope.mdc](.cursor/rules/commits/42-chirimen-device-dashboard-scope.mdc) — 固有 scope 一覧
+- Skill: [.cursor/skills/conventional-commits/](.cursor/skills/conventional-commits/)
+  - [SKILL.md](.cursor/skills/conventional-commits/SKILL.md) / [examples.md](.cursor/skills/conventional-commits/examples.md) / [assertions.md](.cursor/skills/conventional-commits/assertions.md) / [scopes.md](.cursor/skills/conventional-commits/scopes.md)
+
 ### 形式
 
 ```

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ pnpm nx configure-ai-agents --agents cursor --no-interactive
 │   ├── 00-nx-workspace.mdc       # Workspace 全体ルール
 │   ├── 10-nx-generators.mdc      # Nx Generator 利用方針
 │   └── 20-nx-tasks.mdc           # Nx タスク実行方針
+├── commits/
+│   ├── 40-conventional-commits.mdc            # Conventional Commits 基本ルール
+│   ├── 41-pull-request-title.mdc              # PR タイトル規約
+│   └── 42-chirimen-device-dashboard-scope.mdc # 固有 scope 一覧
 └── workflow/
     └── 90-ai-workflow.mdc        # AI 編集時の共通ルール
 ```
@@ -194,22 +198,26 @@ pnpm nx configure-ai-agents --agents cursor --no-interactive
 
 ### 役割分離
 
-| 種類           | 役割                              | 配置                |
-| -------------- | --------------------------------- | ------------------- |
-| Angular Skills | Angular の一般知識                | `.agents/skills/`   |
-| Nx AI Agent    | Nx Workspace 理解                 | `.agents/skills/` ほか |
-| Cursor Rules   | Workspace の設計ルール (責務別)   | `.cursor/rules/`    |
-| AI Workflow    | AI 編集時の共通ルール             | `.cursor/rules/workflow/` |
+| 種類                       | 役割                                              | 配置                                     |
+| -------------------------- | ------------------------------------------------- | ---------------------------------------- |
+| Angular Skills             | Angular の一般知識                                | `.agents/skills/`                        |
+| Nx AI Agent                | Nx Workspace 理解                                 | `.agents/skills/` ほか                   |
+| Cursor Rules               | Workspace の設計ルール (責務別)                   | `.cursor/rules/`                         |
+| Conventional Commits Rules | commit message / PR title の規約 (Issue #167)     | `.cursor/rules/commits/`                 |
+| Conventional Commits Skill | AI 向け Conventional Commits 知識 (Issue #167)    | `.cursor/skills/conventional-commits/`   |
+| AI Workflow                | AI 編集時の共通ルール                             | `.cursor/rules/workflow/`                |
+
+### Conventional Commits
+
+commit message と PR タイトルは [Conventional Commits](https://www.conventionalcommits.org/) に統一しています。詳細は [CONTRIBUTING.md](CONTRIBUTING.md) と [.cursor/skills/conventional-commits/SKILL.md](.cursor/skills/conventional-commits/SKILL.md) を参照してください。
 
 ### 将来的な拡張候補
 
 以下は今回の対象外（Issue #165 のスコープに記載）。将来別 Issue / PR で導入を検討します。
 
-- `chirimen-device-dashboard` 固有ルール用 mdc
 - NgRx 用 mdc
 - Storybook 用 mdc
 - CI/CD 用 mdc
-- Conventional Commits 用 mdc / Skill
 - ADR / Architecture 用 mdc
 
 ## Learn More


### PR DESCRIPTION
> PR タイトルは [Conventional Commits](https://www.conventionalcommits.org/) に準拠してください (例: `feat(web): add device list component`)。
> 利用可能な scope は [CONTRIBUTING.md](../CONTRIBUTING.md#スコープ一覧) と `commitlint.config.js` を参照してください。

## Summary

issue #167 に基づき、Cursor 向けに Conventional Commits 用の Rules と Skill を導入する。AI が生成する commit message / PR title の品質を安定化させ、Angular + Nx モノレポ構成 (`apps/`, `libs/devices/*`, `libs/shared-types`, `tools/scripts/*`) に整合する scope を確実に選択できるようにする。

既存の commitlint / husky / GitHub Actions / CONTRIBUTING の構成を踏襲し、AI 向け Rules / Skill のみを追加する形で構築している。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #167

## What changed?

- `.cursor/rules/commits/` に 3 つの Cursor Rules (`.mdc`) を追加
  - `40-conventional-commits.mdc` — Conventional Commits の基本ルール (`alwaysApply: true`)
  - `41-pull-request-title.mdc` — PR タイトル規約と良/悪例
  - `42-chirimen-device-dashboard-scope.mdc` — 固有 scope 一覧と選択方針
- `.cursor/skills/conventional-commits/` に 4 つの Skill ファイルを追加
  - `SKILL.md` — 目的、Angular / Nx 前提、scope 選択方針、docs/ci/build/chore の使い分け、breaking change の扱い
  - `examples.md` — 良い例 / 悪い例
  - `assertions.md` — 検証項目 (10 項目) と Valid / Invalid サンプル
  - `scopes.md` — `project.json` 名と `commitlint.config.js` の `scope-enum` に一致する scope 一覧
- `.github/pull_request_template.md` 冒頭に PR タイトルが Conventional Commits 準拠であることと scope 一覧の参照先を追記
- `README.md` を更新
  - `.cursor/rules/` のツリーに `commits/` サブディレクトリを追記
  - 役割分離テーブルに Conventional Commits Rules / Skill を追加
  - 「将来的な拡張候補」から該当項目 (`chirimen-device-dashboard` 固有ルール用 mdc, Conventional Commits 用 mdc / Skill) を削除
- `CONTRIBUTING.md` に Rules / Skill への参照リンクを追加

### コミット履歴

```
feat(workspace): add conventional commits cursor rules
feat(workspace): add conventional commits cursor skill
docs(workspace): mention conventional commits title in pr template
docs(workspace): document conventional commits skills and rules
```

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

ソースコードの変更は無く、ドキュメント / Cursor 設定の追加のみ。既存の `commitlint.config.js` の `scope-enum` には一切変更を加えていないため、既存コミット規約との互換性は保たれている。

## How to test

1. ブランチをチェックアウト: `git checkout feat/workspace-conventional-commits-skills`
2. 直近 4 コミットを commitlint で検証: `pnpm exec commitlint --from HEAD~4 --to HEAD --verbose`
   - すべて `found 0 problems, 0 warnings` になることを確認
3. Cursor で本リポジトリを開き、`.cursor/rules/commits/40-conventional-commits.mdc` が `alwaysApply` で参照されることを確認
4. `.cursor/skills/conventional-commits/SKILL.md` を Skill として参照できることを確認
5. CI 上で `commitlint` ワークフロー (`.github/workflows/commitlint.yml`) が成功することを確認

## Environment (if relevant)

- Browser: -
- OS: macOS / Windows / Linux
- Node version: 22
- pnpm version: 10.28.0

## Checklist

- [x] I ran tests locally (if available) — `pnpm exec commitlint` で全コミットを検証
- [x] I updated docs/README if needed — `README.md` / `CONTRIBUTING.md` / `.github/pull_request_template.md` を更新
- [x] I considered error handling where relevant — ドキュメント変更のみのため該当なし

Made with [Cursor](https://cursor.com)