### PR TITLE
ci(ci): remove push trigger from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

PR マージ時に `ci.yml` が二重実行される問題を解消するため、`push` トリガーを削除し、`pull_request` のみで CI を実行するように変更した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #173

## What changed?

- `.github/workflows/ci.yml` から `push: branches: [main]` トリガーを削除
- PR 上での lint / build / test 実行は従来どおり維持

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. 本 PR を作成し、`ci` ワークフローが PR イベントで正常に実行されることを確認
2. マージ後、同じコミットに対して `ci.yml` が再実行されないことを GitHub Actions 履歴で確認
3. `deploy.yml` がマージ後に引き続き実行されることを確認（デプロイ用ワークフローは影響なし）

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant

Made with [Cursor](https://cursor.com)