### PR TITLE
feat(shared-types): extend ExampleInfo for platform-specific examples

### DIFF
--- a/libs/shared-types/src/lib/device.ts
+++ b/libs/shared-types/src/lib/device.ts
@@ -29,6 +29,24 @@ export interface ExampleInfo {
   verified?: boolean;
 }
 
+export function isPlatformSpecificExample(
+  example: ExampleInfo,
+): example is ExampleInfo & {
+  platform: string;
+  upstreamRepository: string;
+  upstreamPath: string;
+  upstreamPathUrl: string;
+  status: ExampleStatus;
+} {
+  return Boolean(
+    example.platform &&
+      example.upstreamRepository &&
+      example.upstreamPath &&
+      example.upstreamPathUrl &&
+      example.status,
+  );
+}
+
 export interface ProductInfo {
   url: string; // 商品URL
   example: ExampleInfo[]; // サンプルコード情報配列

--- a/libs/shared-types/src/lib/device.ts
+++ b/libs/shared-types/src/lib/device.ts
@@ -6,8 +6,27 @@ export type ExampleStatus =
   | 'incubator';
 
 export interface ExampleInfo {
+  /**
+   * 既存プロパティ。
+   * 移行過渡期では削除しない。
+   */
   hardware: string; // Raspbery Pi 3/4/5, Pi Zero, microbit
   code: string; // サンプルコードURL
+
+  /**
+   * Platform 別 Example 用プロパティ。
+   * chirimen-example-catalog の ExampleEntry 相当。
+   */
+  deviceId?: string;
+  platform?: string;
+  localPath?: string;
+  upstreamRepository?: string;
+  upstreamRepositoryUrl?: string;
+  upstreamPath?: string;
+  upstreamPathUrl?: string;
+  status?: ExampleStatus;
+  circuitUrl?: string;
+  verified?: boolean;
 }
 
 export interface ProductInfo {

--- a/libs/shared-types/src/lib/device.ts
+++ b/libs/shared-types/src/lib/device.ts
@@ -1,3 +1,10 @@
+export type ExampleStatus =
+  | 'primary'
+  | 'legacy'
+  | 'archive'
+  | 'special'
+  | 'incubator';
+
 export interface ExampleInfo {
   hardware: string; // Raspbery Pi 3/4/5, Pi Zero, microbit
   code: string; // サンプルコードURL


### PR DESCRIPTION
## Summary

Platform 別 Example 移行（#177）の基盤として、`ExampleInfo` を移行過渡期対応に拡張する。既存の `hardware` / `code` は維持し、Platform 別 Example 用プロパティを optional で追加する。新形式 example を判定する `isPlatformSpecificExample` 型ガードも追加する。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #178
- 親 Issue: #177

## What changed?

- `ExampleStatus` union type を追加
- `ExampleInfo` に Platform 別 Example 用 optional プロパティを追加
- `isPlatformSpecificExample` 型ガードを追加

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `ExampleInfo` / `ExampleStatus` / `isPlatformSpecificExample` を export
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx build shared-types` が成功すること
2. `pnpm nx build web` が成功すること
3. `pnpm nx test sync-devices` / `pnpm nx test libs-device-detail` が成功すること
4. TypeScript 上で旧形式・新形式が `ProductInfo.example` 配列内に共存できること

## Environment (if relevant)

- Browser: N/A
- OS: macOS / Windows / Linux
- Node version: 24
- pnpm version: 11.5.0

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)