### PR TITLE
feat(workspace): add platform example source data location

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ pnpm nx graph
 pnpm nx build
 ```
 
+## Platform 別 Example データ
+
+Platform 別 Example の正本データは [`data/platform-examples/platform-examples.json`](data/platform-examples/platform-examples.json) に配置しています。`devices.json` 生成時に `product.example` を洗い替えるための元データです。
+
+編集方法・JSON スキーマ・ID 対応の詳細は [data/platform-examples/README.md](data/platform-examples/README.md) を参照してください。
+
 ## Running Tests
 
 ```bash

--- a/data/platform-examples/README.md
+++ b/data/platform-examples/README.md
@@ -1,0 +1,88 @@
+# Platform 別 Example 元データ
+
+`platform-examples.json` は、`devices.json` 生成時に `product.example` を洗い替えるための正本データです。
+
+`chirimen-example-catalog` には runtime dependency しません。完成後は本リポジトリ内のデータを正とします。
+
+## ファイル
+
+| ファイル | 説明 |
+| --- | --- |
+| `platform-examples.json` | Platform 別 Example の正本（コミット対象） |
+
+生成物として `apps/web/public/platform-specific-examples.json` のような別 JSON は作成しません。最終的には `apps/web/public/devices.json` の `product.example` に統合されます。
+
+## JSON スキーマ
+
+トップレベルはデバイス単位の配列です。
+
+```json
+[
+  {
+    "dashboardDeviceId": "i2c-adt7410",
+    "exampleDeviceId": "adt7410",
+    "examples": [ /* ExampleInfo 互換オブジェクト */ ]
+  }
+]
+```
+
+### デバイスエントリ
+
+| フィールド | 必須 | 説明 |
+| --- | --- | --- |
+| `dashboardDeviceId` | はい | `devices.json` の device `id`（例: `i2c-adt7410`） |
+| `exampleDeviceId` | はい | Example catalog 側の device id（例: `adt7410`） |
+| `examples` | はい | Platform 別 Example の配列 |
+
+### Example エントリ（`examples` 配列の各要素）
+
+移行過渡期のため、既存互換フィールドと Platform 別フィールドの両方を含めます。型定義は [`libs/shared-types/src/lib/device.ts`](../../libs/shared-types/src/lib/device.ts) の `ExampleInfo` を参照してください。
+
+**既存互換（必須）**
+
+| フィールド | 説明 |
+| --- | --- |
+| `hardware` | ハードウェア表示名（例: `Pi Zero`, `micro:bit`） |
+| `code` | サンプルコード URL（移行過渡期では `upstreamPathUrl` と同一でも可） |
+
+**Platform 別（必須）**
+
+| フィールド | 説明 |
+| --- | --- |
+| `deviceId` | Example catalog 側の device id |
+| `platform` | Platform 識別子（例: `pizero-esm`, `node`） |
+| `localPath` | catalog 互換のローカルパス |
+| `upstreamRepository` | GitHub リポジトリ（例: `chirimen-oh/chirimen.org`） |
+| `upstreamRepositoryUrl` | リポジトリ URL |
+| `upstreamPath` | リポジトリ内パス |
+| `upstreamPathUrl` | パスへの tree URL |
+| `status` | `primary` / `legacy` / `archive` / `special` / `incubator` |
+| `circuitUrl` | 回路図 URL |
+| `verified` | 実機確認済みか（boolean） |
+
+### URL 生成ルール
+
+- `upstreamRepositoryUrl`: `https://github.com/{upstreamRepository}`
+- `upstreamPathUrl`: `https://github.com/{upstreamRepository}/tree/master/{upstreamPath}`
+- `circuitUrl`: `https://github.com/{upstreamRepository}/blob/master/{upstreamPath}/{filename}`
+
+## ID 対応の例
+
+| dashboardDeviceId | exampleDeviceId | デバイス名 |
+| --- | --- | --- |
+| `i2c-adt7410` | `adt7410` | ADT7410 |
+
+## 編集フロー
+
+1. `platform-examples.json` を編集する
+2. JSON がパース可能であることを確認する
+3. （#183 以降）`pnpm nx run sync-devices:sync` で `devices.json` を再生成し、`product.example` が洗い替えされる
+
+現時点（#179）では `devices.json` / `sync-devices` は変更していません。元データの追加のみです。
+
+## 関連 issue
+
+- 親: [#177](https://github.com/gurezo/chirimen-device-dashboard/issues/177) — Example 管理機能の移植
+- 本 issue: [#179](https://github.com/gurezo/chirimen-device-dashboard/issues/179) — 元データ置き場の追加
+- [#180](https://github.com/gurezo/chirimen-device-dashboard/issues/180) — ADT7410 データの catalog 突合
+- [#183](https://github.com/gurezo/chirimen-device-dashboard/issues/183) — `devices.json` 生成時の洗い替え

--- a/data/platform-examples/platform-examples.json
+++ b/data/platform-examples/platform-examples.json
@@ -1,0 +1,78 @@
+[
+  {
+    "dashboardDeviceId": "i2c-adt7410",
+    "exampleDeviceId": "adt7410",
+    "examples": [
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410",
+        "deviceId": "adt7410",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/adt7410/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/adt7410",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png",
+        "verified": false
+      },
+      {
+        "hardware": "Raspberry Pi",
+        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
+        "deviceId": "adt7410",
+        "platform": "node",
+        "localPath": "examples/devices/adt7410/platforms/node",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "node-examples/adt7410",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
+        "status": "legacy",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png",
+        "verified": false
+      },
+      {
+        "hardware": "Raspberry Pi",
+        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
+        "deviceId": "adt7410",
+        "platform": "raspi-node",
+        "localPath": "examples/devices/adt7410/platforms/raspi-node",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "raspi-examples/adt7410",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
+        "status": "legacy",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png",
+        "verified": false
+      },
+      {
+        "hardware": "micro:bit",
+        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/adt7410",
+        "deviceId": "adt7410",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/adt7410/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples/adt7410",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/adt7410",
+        "status": "legacy",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/adt7410/imgs/pinbit_adt7410.png",
+        "verified": false
+      },
+      {
+        "hardware": "chirimen",
+        "code": "https://github.com/chirimen-oh/chirimen/tree/master/gc/i2c/i2c-ADT7410",
+        "deviceId": "adt7410",
+        "platform": "legacy-gc-i2c",
+        "localPath": "examples/devices/adt7410/platforms/legacy-gc-i2c",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/i2c/i2c-ADT7410",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen/tree/master/gc/i2c/i2c-ADT7410",
+        "status": "archive",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen/blob/master/gc/i2c/i2c-ADT7410/schematic.png",
+        "verified": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Platform 別 Example の正本データ置き場 `data/platform-examples/platform-examples.json` を追加し、
ADT7410（`i2c-adt7410` / `adt7410`）の初期データ 5 platform と編集ガイドを整備する。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #179
- Parent: #177

## What changed?

- `data/platform-examples/platform-examples.json` を新規追加（ADT7410 の 5 platform）
- `data/platform-examples/README.md` にスキーマと編集手順を記載
- ルート `README.md` からデータ編集ガイドへリンク

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `data/platform-examples/platform-examples.json` が JSON としてパース可能であることを確認
2. `dashboardDeviceId: "i2c-adt7410"` / `exampleDeviceId: "adt7410"` の対応を確認
3. 各 example に `hardware` / `code` と Platform 別プロパティが含まれることを確認
4. `data/platform-examples/README.md` の手順が追えることを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [ ] I considered error handling where relevant

Made with [Cursor](https://cursor.com)