### PR TITLE
feat(workspace): migrate adt7410 platform example data

### DIFF
--- a/data/platform-examples/README.md
+++ b/data/platform-examples/README.md
@@ -72,17 +72,41 @@
 | --- | --- | --- |
 | `i2c-adt7410` | `adt7410` | ADT7410 |
 
+## ADT7410 移行記録（#180）
+
+`chirimen-example-catalog` の `catalog/examples.json` / `metadata.md` と突合し、以下 5 platform を移行済みです。
+
+| Platform | Status | Upstream Repository | Upstream Path |
+| --- | --- | --- | --- |
+| `pizero-esm` | primary | `chirimen-oh/chirimen.org` | `pizero/src/esm-examples/adt7410` |
+| `node` | legacy | `chirimen-oh/chirimen-drivers` | `node-examples/adt7410` |
+| `raspi-node` | legacy | `chirimen-oh/chirimen-drivers` | `raspi-examples/adt7410` |
+| `microbit-driver` | legacy | `chirimen-oh/chirimen-drivers` | `microbit-examples/adt7410` |
+| `legacy-gc-i2c` | archive | `chirimen-oh/chirimen` | `gc/i2c/i2c-ADT7410` |
+
+### legacy `code` URL 対応
+
+移行過渡期の旧 `devices.json` 互換のため、以下 3 platform は `code` にチュートリアル URL を設定しています。`upstreamPathUrl` は GitHub tree URL のままです。
+
+| Platform | legacy `hardware` | `code`（チュートリアル URL） |
+| --- | --- | --- |
+| `pizero-esm` | `Pi Zero` | `https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410` |
+| `microbit-driver` | `micro:bit` | `https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410` |
+| `legacy-gc-i2c` | `chirimen` | `https://r.chirimen.org/examples/#I2C-ADT7410` |
+
+`node` / `raspi-node` は legacy `devices.json` に対応エントリがないため、`code` = `upstreamPathUrl` です。
+
 ## 編集フロー
 
 1. `platform-examples.json` を編集する
 2. JSON がパース可能であることを確認する
 3. （#183 以降）`pnpm nx run sync-devices:sync` で `devices.json` を再生成し、`product.example` が洗い替えされる
 
-現時点（#179）では `devices.json` / `sync-devices` は変更していません。元データの追加のみです。
+現時点（#180 完了）では `devices.json` / `sync-devices` は変更していません。元データの追加・移行のみです。
 
 ## 関連 issue
 
 - 親: [#177](https://github.com/gurezo/chirimen-device-dashboard/issues/177) — Example 管理機能の移植
-- 本 issue: [#179](https://github.com/gurezo/chirimen-device-dashboard/issues/179) — 元データ置き場の追加
-- [#180](https://github.com/gurezo/chirimen-device-dashboard/issues/180) — ADT7410 データの catalog 突合
+- [#179](https://github.com/gurezo/chirimen-device-dashboard/issues/179) — 元データ置き場の追加
+- [#180](https://github.com/gurezo/chirimen-device-dashboard/issues/180) — ADT7410 データの catalog 突合・移行
 - [#183](https://github.com/gurezo/chirimen-device-dashboard/issues/183) — `devices.json` 生成時の洗い替え

--- a/data/platform-examples/platform-examples.json
+++ b/data/platform-examples/platform-examples.json
@@ -5,7 +5,7 @@
     "examples": [
       {
         "hardware": "Pi Zero",
-        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410",
         "deviceId": "adt7410",
         "platform": "pizero-esm",
         "localPath": "examples/devices/adt7410/platforms/pizero-esm",
@@ -47,7 +47,7 @@
       },
       {
         "hardware": "micro:bit",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/adt7410",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410",
         "deviceId": "adt7410",
         "platform": "microbit-driver",
         "localPath": "examples/devices/adt7410/platforms/microbit-driver",
@@ -61,7 +61,7 @@
       },
       {
         "hardware": "chirimen",
-        "code": "https://github.com/chirimen-oh/chirimen/tree/master/gc/i2c/i2c-ADT7410",
+        "code": "https://r.chirimen.org/examples/#I2C-ADT7410",
         "deviceId": "adt7410",
         "platform": "legacy-gc-i2c",
         "localPath": "examples/devices/adt7410/platforms/legacy-gc-i2c",


### PR DESCRIPTION
## Summary

- `chirimen-example-catalog` の ADT7410 5 platform 情報を `data/platform-examples/platform-examples.json` へ正式移行した
- catalog `examples.json` / `metadata.md` と突合し、Platform 別フィールドの一致を確認した
- 移行過渡期互換のため、legacy `devices.json` に存在した 3 platform の `code` をチュートリアル URL に設定した

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #180
- 親: #177

## What changed?

- `data/platform-examples/platform-examples.json` — ADT7410 5 platform の `hardware` / `code` を確定（legacy 3 件の `code` をチュートリアル URL に更新）
- `data/platform-examples/README.md` — ADT7410 移行記録（platform 一覧・legacy `code` 対応表）を追記

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `node -e "JSON.parse(require('fs').readFileSync('data/platform-examples/platform-examples.json'))"` で JSON パースを確認
2. `data/platform-examples/platform-examples.json` の `i2c-adt7410` エントリに 5 platform が含まれることを確認
3. 各 example が `platform`, `upstreamRepository`, `upstreamPath`, `upstreamPathUrl`, `status` を持つことを確認
4. `circuitUrl` / `upstreamRepositoryUrl` / `upstreamPathUrl` がブラウザで開けることを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)