### PR TITLE
feat(sync-example-upstreams): add upstream example sync tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ functions/lib
 firebase-debug.log
 firebase-debug.*.log
 
+generated/upstreams/_repos/
+
 vitest.config.*.timestamp*
 
 .claude/worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,8 @@ functions/lib
 firebase-debug.log
 firebase-debug.*.log
 
-generated/upstreams/_repos/
+generated/
+data/platform-examples/platform-examples.generated.json
 
 vitest.config.*.timestamp*
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -15,6 +15,7 @@ module.exports = {
         'libs-card-list',
         'libs-device-detail',
         'sync-devices',
+        'sync-example-upstreams',
         'ci',
         'mcp',
       ],

--- a/data/example-upstreams/README.md
+++ b/data/example-upstreams/README.md
@@ -1,0 +1,40 @@
+# Upstream Example Sources
+
+`sync-example-upstreams` が参照する upstream repository 定義です。
+
+`chirimen-example-catalog` には runtime dependency しません。
+
+## ファイル
+
+| ファイル | 説明 |
+| --- | --- |
+| `sources.yaml` | upstream repository 一覧（コミット対象） |
+| `device-id-overrides.yaml` | example device id → dashboard device id の手動 override |
+
+## sources.yaml スキーマ
+
+各 `sources` エントリは以下のフィールドを持ちます。
+
+| フィールド | 必須 | 説明 |
+| --- | --- | --- |
+| `id` | はい | ソース識別子（`generated/upstreams/{id}` に mirror） |
+| `repo` | はい | GitHub リポジトリ（例: `chirimen-oh/chirimen.org`） |
+| `branch` | はい | clone / fetch 対象ブランチ |
+| `path` | はい | リポジトリ内の examples ルートパス |
+| `platform` | はい | Platform 識別子（`ExampleInfo.platform` に対応） |
+| `priority` | はい | 状態（`primary` / `legacy` / `archive` / `special` / `incubator`） |
+| `description` | はい | 人間向け説明 |
+
+## 対象 upstream
+
+- `chirimen-oh/chirimen.org`
+- `chirimen-oh/chirimen-drivers`
+- `chirimen-oh/chirimen`
+- `chirimen-oh/chirimen-micro-bit`
+- `chirimen-oh/remote-connection`
+- `chirimen-oh/pre-arrangement-contributions`
+
+## 関連 issue
+
+- 親: [#177](https://github.com/gurezo/chirimen-device-dashboard/issues/177)
+- [#181](https://github.com/gurezo/chirimen-device-dashboard/issues/181) — sync-upstreams 移植

--- a/data/example-upstreams/device-id-overrides.yaml
+++ b/data/example-upstreams/device-id-overrides.yaml
@@ -1,0 +1,8 @@
+# example device id → dashboard device id の手動 override
+#
+# 自動推定で曖昧・未解決の場合に使用します。
+# key: exampleDeviceId（例: adt7410）
+# value: dashboardDeviceId（例: i2c-adt7410）
+
+overrides:
+  adt7410: i2c-adt7410

--- a/data/example-upstreams/sources.yaml
+++ b/data/example-upstreams/sources.yaml
@@ -1,0 +1,72 @@
+sources:
+  - id: chirimen-org-pizero-esm
+    repo: chirimen-oh/chirimen.org
+    branch: master
+    path: pizero/src/esm-examples
+    platform: pizero-esm
+    priority: primary
+    description: CHIRIMEN Pi Zero 向けの現行 ESM examples
+
+  - id: chirimen-drivers-raspi
+    repo: chirimen-oh/chirimen-drivers
+    branch: master
+    path: raspi-examples
+    platform: raspi-node
+    priority: legacy
+    description: Raspberry Pi / Node.js 向け examples
+
+  - id: chirimen-drivers-node
+    repo: chirimen-oh/chirimen-drivers
+    branch: master
+    path: node-examples
+    platform: node
+    priority: legacy
+    description: Node.js 向け examples
+
+  - id: chirimen-drivers-microbit
+    repo: chirimen-oh/chirimen-drivers
+    branch: master
+    path: microbit-examples
+    platform: microbit-driver
+    priority: legacy
+    description: chirimen-drivers 側の micro:bit examples
+
+  - id: chirimen-gc-gpio
+    repo: chirimen-oh/chirimen
+    branch: master
+    path: gc/gpio
+    platform: legacy-gc-gpio
+    priority: archive
+    description: 旧 CHIRIMEN GPIO examples
+
+  - id: chirimen-gc-i2c
+    repo: chirimen-oh/chirimen
+    branch: master
+    path: gc/i2c
+    platform: legacy-gc-i2c
+    priority: archive
+    description: 旧 CHIRIMEN I2C examples
+
+  - id: pre-arrangement-contributions
+    repo: chirimen-oh/pre-arrangement-contributions
+    branch: main
+    path: .
+    platform: pre-arranged
+    priority: incubator
+    description: 整理前のコントリビューション候補
+
+  - id: remote-connection-examples
+    repo: chirimen-oh/remote-connection
+    branch: master
+    path: examples
+    platform: remote
+    priority: special
+    description: remote-connection examples
+
+  - id: chirimen-micro-bit-examples
+    repo: chirimen-oh/chirimen-micro-bit
+    branch: master
+    path: examples
+    platform: microbit-web
+    priority: legacy
+    description: chirimen-micro-bit の examples

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:all": "nx run-many --target=lint --all",
     "serve": "nx serve web",
     "serve:all": "nx run-many --target=serve --all",
-    "e2e": "nx e2e web-e2e"
+    "e2e": "nx e2e web-e2e",
+    "sync:example-upstreams": "nx run sync-example-upstreams:sync"
   },
   "packageManager": "pnpm@11.5.0",
   "devDependencies": {
@@ -66,7 +67,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.60.0",
     "vite": "^8.0.14",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "yaml": "^2.9.0"
   },
   "dependencies": {
     "@angular/animations": "21.2.15",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prettier": "^3.8.3",
     "tailwindcss": "^3.4.9",
     "tslib": "^2.8.1",
+    "tsx": "^4.22.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.60.0",
     "vite": "^8.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,10 +47,10 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.5.2
-        version: 2.5.2(@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 2.5.2(@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(tsx@4.22.3)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@analogjs/vitest-angular':
         specifier: ~2.5.2
-        version: 2.5.2(fcaac4695556601bd261f9a068ec7973)
+        version: 2.5.2(ee97088931dbe6768639c9d4523ba7b0)
       '@angular-devkit/core':
         specifier: 21.2.13
         version: 21.2.13(chokidar@5.0.0)
@@ -59,7 +59,7 @@ importers:
         version: 21.2.13(chokidar@5.0.0)
       '@angular/build':
         specifier: 21.2.13
-        version: 21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
+        version: 21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(tsx@4.22.3)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
       '@angular/cli':
         specifier: 21.2.13
         version: 21.2.13(@types/node@25.9.1)(chokidar@5.0.0)
@@ -83,7 +83,7 @@ importers:
         version: 10.0.1(eslint@10.4.1(jiti@1.21.7))
       '@nx/angular':
         specifier: 22.7.5
-        version: 22.7.5(f6af759a19652e6b31266b58a387a10b)
+        version: 22.7.5(affaebb5166795315fbeb7f4a8d8ce07)
       '@nx/devkit':
         specifier: 22.7.5
         version: 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
@@ -104,13 +104,13 @@ importers:
         version: 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3))(@playwright/test@1.60.0)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@1.21.7))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/vite':
         specifier: 22.7.5
-        version: 22.7.5(76d59eb9bca7a4ec02481b2e99eb076f)
+        version: 22.7.5(73539e46b5079546953928f74157532c)
       '@nx/vitest':
         specifier: 22.7.5
-        version: 22.7.5(76d59eb9bca7a4ec02481b2e99eb076f)
+        version: 22.7.5(73539e46b5079546953928f74157532c)
       '@nx/web':
         specifier: 22.7.5
-        version: 22.7.5(b24a1d38ca961d17c477ba276017d3fb)
+        version: 22.7.5(1c6ea5b5b66a4b0516ac2ddf6035e750)
       '@nx/workspace':
         specifier: 22.7.5
         version: 22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))
@@ -176,10 +176,13 @@ importers:
         version: 3.8.3
       tailwindcss:
         specifier: ^3.4.9
-        version: 3.4.19(yaml@2.9.0)
+        version: 3.4.19(tsx@4.22.3)(yaml@2.9.0)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+      tsx:
+        specifier: ^4.22.3
+        version: 4.22.3
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -188,10 +191,10 @@ importers:
         version: 8.60.0(eslint@10.4.1(jiti@1.21.7))(typescript@5.9.3)
       vite:
         specifier: ^8.0.14
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -1330,8 +1333,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1342,8 +1357,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1354,8 +1381,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1366,8 +1405,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1378,8 +1429,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1390,8 +1453,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1402,8 +1477,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1414,8 +1501,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1426,8 +1525,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1438,8 +1549,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1450,8 +1573,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1462,8 +1597,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1474,8 +1621,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -5204,6 +5363,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -8699,6 +8863,11 @@ packages:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
 
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
@@ -9406,7 +9575,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.5.2(@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@analogjs/vite-plugin-angular@2.5.2(@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(tsx@4.22.3)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.1
@@ -9414,18 +9583,18 @@ snapshots:
       tinyglobby: 0.2.16
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular/build': 21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      '@angular/build': 21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(tsx@4.22.3)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@analogjs/vitest-angular@2.5.2(fcaac4695556601bd261f9a068ec7973)':
+  '@analogjs/vitest-angular@2.5.2(ee97088931dbe6768639c9d4523ba7b0)':
     dependencies:
-      '@analogjs/vite-plugin-angular': 2.5.2(@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@analogjs/vite-plugin-angular': 2.5.2(@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(tsx@4.22.3)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@angular-devkit/architect': 0.2102.13(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.13(chokidar@5.0.0)
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@angular-devkit/architect@0.2102.13(chokidar@5.0.0)':
     dependencies:
@@ -9525,7 +9694,7 @@ snapshots:
       '@angular/core': 21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)
       tslib: 2.8.1
 
-  '@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)':
+  '@angular/build@21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(tsx@4.22.3)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.13(chokidar@5.0.0)
@@ -9535,7 +9704,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
       '@inquirer/confirm': 5.1.21(@types/node@25.9.1)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0))
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       beasties: 0.4.1
       browserslist: 4.28.2
       esbuild: 0.27.3
@@ -9556,7 +9725,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
       undici: 7.24.4
-      vite: 7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
       watchpack: 2.5.1
     optionalDependencies:
       '@angular/core': 21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)
@@ -9564,8 +9733,8 @@ snapshots:
       less: 4.5.1
       lmdb: 3.5.1
       postcss: 8.5.15
-      tailwindcss: 3.4.19(yaml@2.9.0)
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      tailwindcss: 3.4.19(tsx@4.22.3)(yaml@2.9.0)
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -10752,79 +10921,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@1.21.7))':
@@ -11506,7 +11753,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@module-federation/enhanced@2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)
@@ -11524,7 +11771,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -11559,16 +11806,16 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@module-federation/node@2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
       tapable: 2.3.0
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -11841,17 +12088,17 @@ snapshots:
       node-gyp: 12.3.0
       proc-log: 6.1.0
 
-  '@nx/angular@22.7.5(f6af759a19652e6b31266b58a387a10b)':
+  '@nx/angular@22.7.5(affaebb5166795315fbeb7f4a8d8ce07)':
     dependencies:
       '@angular-devkit/core': 21.2.13(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.13(chokidar@5.0.0)
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@1.21.7))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      '@nx/module-federation': 22.7.5(1e9003821b4d83dd503a64391a8aee7c)
-      '@nx/rspack': 22.7.5(fead26cd9bda663293485997691a19b3)
-      '@nx/web': 22.7.5(b24a1d38ca961d17c477ba276017d3fb)
-      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3)
+      '@nx/module-federation': 22.7.5(1fb3d352c9f0e23bcce93357fa8fcc35)
+      '@nx/rspack': 22.7.5(9642bd54cc24e44a0f7fddc6d5427e8f)
+      '@nx/web': 22.7.5(1c6ea5b5b66a4b0516ac2ddf6035e750)
+      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3)
       '@nx/workspace': 22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@schematics/angular': 21.2.13(chokidar@5.0.0)
@@ -11865,7 +12112,7 @@ snapshots:
       tslib: 2.8.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular/build': 21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
+      '@angular/build': 21.2.13(@angular/compiler-cli@21.2.15(@angular/compiler@21.2.15)(typescript@5.9.3))(@angular/compiler@21.2.15)(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(@angular/platform-browser@21.2.15(@angular/animations@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@angular/common@21.2.15(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@21.2.15(@angular/compiler@21.2.15)(rxjs@7.8.2)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.1)(chokidar@5.0.0)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(postcss@8.5.15)(sass-embedded@1.100.0)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0))(terser@5.48.0)(tslib@2.8.1)(tsx@4.22.3)(typescript@5.9.3)(vitest@4.1.7)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@minify-html/node'
@@ -12042,20 +12289,20 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.7.5(1e9003821b4d83dd503a64391a8aee7c)':
+  '@nx/module-federation@22.7.5(1fb3d352c9f0e23bcce93357fa8fcc35)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      '@module-federation/node': 2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@module-federation/node': 2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      '@nx/web': 22.7.5(b24a1d38ca961d17c477ba276017d3fb)
+      '@nx/web': 22.7.5(1c6ea5b5b66a4b0516ac2ddf6035e750)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       express: 4.22.2
       http-proxy-middleware: 3.0.5
       picocolors: 1.1.1
       tslib: 2.8.1
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@minify-html/node'
@@ -12167,40 +12414,40 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/rspack@22.7.5(fead26cd9bda663293485997691a19b3)':
+  '@nx/rspack@22.7.5(9642bd54cc24e44a0f7fddc6d5427e8f)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      '@module-federation/node': 2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@module-federation/node': 2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      '@nx/module-federation': 22.7.5(1e9003821b4d83dd503a64391a8aee7c)
-      '@nx/web': 22.7.5(b24a1d38ca961d17c477ba276017d3fb)
+      '@nx/module-federation': 22.7.5(1fb3d352c9f0e23bcce93357fa8fcc35)
+      '@nx/web': 22.7.5(1c6ea5b5b66a4b0516ac2ddf6035e750)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      '@rspack/dev-server': 1.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      '@rspack/dev-server': 1.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@rspack/plugin-react-refresh': 1.6.2(react-refresh@0.18.0)
       autoprefixer: 10.5.0(postcss@8.5.15)
       browserslist: 4.28.2
-      css-loader: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      css-loader: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       enquirer: 2.3.6
       express: 4.22.2
       http-proxy-middleware: 3.0.5
-      less-loader: 12.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.5.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      license-webpack-plugin: 4.0.2(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      less-loader: 12.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.5.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      license-webpack-plugin: 4.0.2(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       loader-utils: 2.0.4
       parse5: 4.0.0
       picocolors: 1.1.1
       postcss: 8.5.15
       postcss-import: 14.1.0(postcss@8.5.15)
-      postcss-loader: 8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      postcss-loader: 8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       sass: 1.100.0
       sass-embedded: 1.100.0
-      sass-loader: 16.0.8(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      source-map-loader: 5.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      style-loader: 3.3.4(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      sass-loader: 16.0.8(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      source-map-loader: 5.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      style-loader: 3.3.4(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       ts-checker-rspack-plugin: 1.3.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.9.3)
       tslib: 2.8.1
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
       webpack-node-externals: 3.0.0
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -12238,11 +12485,11 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@nx/vite@22.7.5(76d59eb9bca7a4ec02481b2e99eb076f)':
+  '@nx/vite@22.7.5(73539e46b5079546953928f74157532c)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      '@nx/vitest': 22.7.5(76d59eb9bca7a4ec02481b2e99eb076f)
+      '@nx/vitest': 22.7.5(73539e46b5079546953928f74157532c)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       ajv: 8.20.0
       enquirer: 2.3.6
@@ -12250,8 +12497,8 @@ snapshots:
       semver: 7.8.1
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/eslint'
@@ -12263,7 +12510,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.7.5(76d59eb9bca7a4ec02481b2e99eb076f)':
+  '@nx/vitest@22.7.5(73539e46b5079546953928f74157532c)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
@@ -12272,8 +12519,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@1.21.7))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12284,7 +12531,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@22.7.5(b24a1d38ca961d17c477ba276017d3fb)':
+  '@nx/web@22.7.5(1c6ea5b5b66a4b0516ac2ddf6035e750)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
@@ -12296,8 +12543,8 @@ snapshots:
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@1.21.7))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
       '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3)
       '@nx/playwright': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3))(@playwright/test@1.60.0)(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@1.21.7))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
-      '@nx/vite': 22.7.5(76d59eb9bca7a4ec02481b2e99eb076f)
-      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3)
+      '@nx/vite': 22.7.5(73539e46b5079546953928f74157532c)
+      '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -12307,7 +12554,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/webpack@22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3)':
+  '@nx/webpack@22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.29.7
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.3))(@swc/core@1.15.40(@swc/helpers@0.5.23)))
@@ -12315,36 +12562,36 @@ snapshots:
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       ajv: 8.20.0
       autoprefixer: 10.5.0(postcss@8.5.15)
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       browserslist: 4.28.2
-      copy-webpack-plugin: 14.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      css-loader: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      css-minimizer-webpack-plugin: 8.0.0(esbuild@0.27.3)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      copy-webpack-plugin: 14.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      css-loader: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      css-minimizer-webpack-plugin: 8.0.0(esbuild@0.28.0)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       less: 4.5.1
-      less-loader: 12.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.5.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      license-webpack-plugin: 4.0.2(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      less-loader: 12.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.5.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      license-webpack-plugin: 4.0.2(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       loader-utils: 2.0.4
-      mini-css-extract-plugin: 2.4.7(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      mini-css-extract-plugin: 2.4.7(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       parse5: 4.0.0
       picocolors: 1.1.1
       postcss: 8.5.15
       postcss-import: 14.1.0(postcss@8.5.15)
-      postcss-loader: 8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      postcss-loader: 8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       rxjs: 7.8.2
       sass: 1.100.0
       sass-embedded: 1.100.0
-      sass-loader: 16.0.8(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      source-map-loader: 5.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      style-loader: 3.3.4(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
-      ts-loader: 9.6.0(loader-utils@2.0.4)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      sass-loader: 16.0.8(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      source-map-loader: 5.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      style-loader: 3.3.4(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
+      ts-loader: 9.6.0(loader-utils@2.0.4)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       tsconfig-paths-webpack-plugin: 4.2.0
       tslib: 2.8.1
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       webpack-node-externals: 3.0.0
-      webpack-subresource-integrity: 5.1.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      webpack-subresource-integrity: 5.1.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@minify-html/node'
@@ -12962,7 +13209,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/dev-server@1.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@rspack/dev-server@1.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       '@types/bonjour': 3.5.13
@@ -12991,7 +13238,7 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -13498,9 +13745,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitejs/plugin-basic-ssl@2.1.4(vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      vite: 7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
     dependencies:
@@ -13514,7 +13761,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -13525,13 +13772,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -13560,7 +13807,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -13915,12 +14162,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@babel/core': 7.29.7
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.29.7):
     dependencies:
@@ -14497,14 +14744,14 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@14.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  copy-webpack-plugin@14.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       tinyglobby: 0.2.16
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -14579,7 +14826,7 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  css-loader@6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  css-loader@6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -14591,9 +14838,9 @@ snapshots:
       semver: 7.8.1
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
-  css-minimizer-webpack-plugin@8.0.0(esbuild@0.27.3)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  css-minimizer-webpack-plugin@8.0.0(esbuild@0.28.0)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.9(postcss@8.5.15)
@@ -14601,9 +14848,9 @@ snapshots:
       postcss: 8.5.15
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
-      esbuild: 0.27.3
+      esbuild: 0.28.0
       lightningcss: 1.32.0
 
   css-select@5.2.2:
@@ -14940,6 +15187,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -15430,7 +15706,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -15445,7 +15721,7 @@ snapshots:
       semver: 7.8.1
       tapable: 2.3.3
       typescript: 5.9.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   form-data@4.0.5:
     dependencies:
@@ -16522,12 +16798,12 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.5.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  less-loader@12.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.5.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       less: 4.5.1
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   less@4.5.1:
     dependencies:
@@ -16556,11 +16832,11 @@ snapshots:
 
   libsodium@0.7.16: {}
 
-  license-webpack-plugin@4.0.2(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  license-webpack-plugin@4.0.2(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       webpack-sources: 3.5.0
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -16867,10 +17143,10 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mini-css-extract-plugin@2.4.7(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  mini-css-extract-plugin@2.4.7(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       schema-utils: 4.3.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   minimalistic-assert@1.0.1: {}
 
@@ -17707,15 +17983,16 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.15
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.15
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  postcss-loader@8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  postcss-loader@8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.7.0
@@ -17723,7 +18000,7 @@ snapshots:
       semver: 7.8.1
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
 
@@ -18357,14 +18634,14 @@ snapshots:
       sass-embedded-win32-arm64: 1.100.0
       sass-embedded-win32-x64: 1.100.0
 
-  sass-loader@16.0.8(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  sass-loader@16.0.8(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       sass: 1.100.0
       sass-embedded: 1.100.0
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   sass@1.100.0:
     dependencies:
@@ -18615,11 +18892,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  source-map-loader@5.0.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   source-map-support@0.5.13:
     dependencies:
@@ -18776,9 +19053,9 @@ snapshots:
 
   stubs@3.0.0: {}
 
-  style-loader@3.3.4(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  style-loader@3.3.4(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   stylehacks@7.0.11(postcss@8.5.15):
     dependencies:
@@ -18858,7 +19135,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.3.6
 
-  tailwindcss@3.4.19(yaml@2.9.0):
+  tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -18877,7 +19154,7 @@ snapshots:
       postcss: 8.5.15
       postcss-import: 15.1.0(postcss@8.5.15)
       postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.3)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.15)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -18940,16 +19217,16 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.40(@swc/helpers@0.5.23)
-      esbuild: 0.27.3
+      esbuild: 0.28.0
       lightningcss: 1.32.0
       postcss: 8.5.15
 
@@ -19064,7 +19341,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.6.0(loader-utils@2.0.4)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  ts-loader@9.6.0(loader-utils@2.0.4)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.22.1
@@ -19072,7 +19349,7 @@ snapshots:
       semver: 7.8.1
       source-map: 0.7.6
       typescript: 5.9.3
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       loader-utils: 2.0.4
 
@@ -19099,6 +19376,12 @@ snapshots:
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tsyringe@4.10.0:
     dependencies:
@@ -19286,7 +19569,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0):
+  vite@7.3.2(@types/node@25.9.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -19303,9 +19586,10 @@ snapshots:
       sass: 1.97.3
       sass-embedded: 1.100.0
       terser: 5.48.0
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
+  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -19314,19 +19598,20 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.9.1
-      esbuild: 0.27.3
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 1.21.7
       less: 4.5.1
       sass: 1.100.0
       sass-embedded: 1.100.0
       terser: 5.48.0
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -19343,7 +19628,7 @@ snapshots:
       tinyexec: 1.2.3
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@1.21.7)(less@4.5.1)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -19384,7 +19669,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.57.3(tslib@2.8.1)
@@ -19393,11 +19678,11 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19425,10 +19710,10 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -19446,12 +19731,12 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)):
+  webpack-subresource-integrity@5.1.0(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
-  webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15):
+  webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -19473,7 +19758,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.107.2(@swc/core@1.15.40(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/tools/scripts/sync-example-upstreams/README.md
+++ b/tools/scripts/sync-example-upstreams/README.md
@@ -1,0 +1,35 @@
+# sync-example-upstreams
+
+upstream CHIRIMEN example repositories を同期し、Platform 別 Example 候補を生成するツールです。
+
+## 実行
+
+```bash
+pnpm sync:example-upstreams
+```
+
+## 入力
+
+- [`data/example-upstreams/sources.yaml`](../../../data/example-upstreams/sources.yaml)
+- [`apps/web/public/devices.json`](../../../apps/web/public/devices.json)（dashboard device id 推定用）
+- 任意: [`data/example-upstreams/device-id-overrides.yaml`](../../../data/example-upstreams/device-id-overrides.yaml)
+
+## 出力
+
+- `generated/upstreams/**` — upstream mirror
+- `generated/reports/example-sync-summary.md` — 同期サマリー
+- `generated/reports/example-candidates.md` — 候補一覧・要 review 項目
+- `data/platform-examples/platform-examples.generated.json` — review 用候補 JSON
+
+正本 [`data/platform-examples/platform-examples.json`](../../../data/platform-examples/platform-examples.json) は**自動上書きしません**。
+
+## Review フロー（手動）
+
+1. `pnpm sync:example-upstreams` を実行
+2. `generated/reports/example-sync-summary.md` と `example-candidates.md` を確認
+3. 問題なければ `platform-examples.generated.json` から必要部分を `platform-examples.json` へ手動マージ
+4. （#183 以降）`pnpm nx run sync-devices:sync` で `devices.json` を再生成
+
+## 要件
+
+- `git` CLI（upstream clone / fetch に使用）

--- a/tools/scripts/sync-example-upstreams/project.json
+++ b/tools/scripts/sync-example-upstreams/project.json
@@ -24,7 +24,8 @@
       "executor": "@nx/vitest:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "reportsDirectory": "{projectRoot}/../../../coverage/tools/scripts/sync-example-upstreams"
+        "reportsDirectory": "{projectRoot}/../../../coverage/tools/scripts/sync-example-upstreams",
+        "configFile": "{projectRoot}/vitest.config.ts"
       },
       "configurations": {
         "ci": {

--- a/tools/scripts/sync-example-upstreams/project.json
+++ b/tools/scripts/sync-example-upstreams/project.json
@@ -1,0 +1,49 @@
+{
+  "name": "sync-example-upstreams",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "tools/scripts/sync-example-upstreams/src",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/tools/scripts/sync-example-upstreams",
+        "main": "tools/scripts/sync-example-upstreams/src/main.ts",
+        "tsConfig": "tools/scripts/sync-example-upstreams/tsconfig.lib.json",
+        "assets": [],
+        "generatePackageJson": false,
+        "rootDir": "."
+      },
+      "configurations": {
+        "production": {},
+        "development": {}
+      }
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{options.reportsDirectory}"],
+      "options": {
+        "reportsDirectory": "{projectRoot}/../../../coverage/tools/scripts/sync-example-upstreams"
+      },
+      "configurations": {
+        "ci": {
+          "watch": false
+        }
+      }
+    },
+    "sync": {
+      "executor": "nx:run-commands",
+      "outputs": [
+        "{workspaceRoot}/generated/upstreams",
+        "{workspaceRoot}/generated/reports",
+        "{workspaceRoot}/data/platform-examples/platform-examples.generated.json"
+      ],
+      "options": {
+        "command": "node -r @swc-node/register/register tools/scripts/sync-example-upstreams/src/main.ts",
+        "cwd": "{workspaceRoot}"
+      },
+      "configurations": {}
+    }
+  }
+}

--- a/tools/scripts/sync-example-upstreams/project.json
+++ b/tools/scripts/sync-example-upstreams/project.json
@@ -41,7 +41,7 @@
         "{workspaceRoot}/data/platform-examples/platform-examples.generated.json"
       ],
       "options": {
-        "command": "node -r @swc-node/register/register tools/scripts/sync-example-upstreams/src/main.ts",
+        "command": "pnpm exec tsx tools/scripts/sync-example-upstreams/src/main.ts",
         "cwd": "{workspaceRoot}"
       },
       "configurations": {}

--- a/tools/scripts/sync-example-upstreams/src/build-example-urls.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/build-example-urls.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCircuitBlobUrl,
+  buildExampleUrls,
+  buildLocalPath,
+  buildUpstreamPath,
+  buildUpstreamPathUrl,
+  buildUpstreamRepositoryUrl,
+  defaultHardwareForPlatform,
+  mapPriorityToStatus,
+} from './build-example-urls';
+
+describe('buildExampleUrls', () => {
+  it('builds repository and path urls', () => {
+    expect(buildUpstreamRepositoryUrl('chirimen-oh/chirimen.org')).toBe(
+      'https://github.com/chirimen-oh/chirimen.org'
+    );
+    expect(
+      buildUpstreamPathUrl(
+        'chirimen-oh/chirimen.org',
+        'pizero/src/esm-examples/adt7410'
+      )
+    ).toBe(
+      'https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410'
+    );
+  });
+
+  it('builds circuit blob url when filename provided', () => {
+    expect(
+      buildCircuitBlobUrl(
+        'chirimen-oh/chirimen-drivers',
+        'node-examples/adt7410',
+        'schematic.png'
+      )
+    ).toBe(
+      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png'
+    );
+  });
+
+  it('builds full example urls object', () => {
+    const urls = buildExampleUrls(
+      'chirimen-oh/chirimen-drivers',
+      'node-examples/adt7410',
+      'master',
+      'schematic.png'
+    );
+    expect(urls.upstreamRepositoryUrl).toContain('chirimen-drivers');
+    expect(urls.upstreamPathUrl).toContain('/tree/master/');
+    expect(urls.circuitUrl).toContain('/blob/master/');
+  });
+
+  it('leaves circuitUrl empty when no filename', () => {
+    const urls = buildExampleUrls(
+      'chirimen-oh/chirimen',
+      'gc/i2c/i2c-adt7410',
+      'master'
+    );
+    expect(urls.circuitUrl).toBe('');
+  });
+});
+
+describe('buildUpstreamPath', () => {
+  it('joins source path and dir name', () => {
+    expect(buildUpstreamPath('node-examples', 'adt7410')).toBe(
+      'node-examples/adt7410'
+    );
+  });
+
+  it('uses dir name only when source path is root', () => {
+    expect(buildUpstreamPath('.', 'some-device')).toBe('some-device');
+  });
+});
+
+describe('buildLocalPath', () => {
+  it('builds catalog-compatible local path', () => {
+    expect(buildLocalPath('adt7410', 'pizero-esm')).toBe(
+      'examples/devices/adt7410/platforms/pizero-esm'
+    );
+  });
+});
+
+describe('mapPriorityToStatus', () => {
+  it('maps valid priority values', () => {
+    expect(mapPriorityToStatus('primary')).toBe('primary');
+    expect(mapPriorityToStatus('archive')).toBe('archive');
+  });
+
+  it('falls back to legacy for unknown priority', () => {
+    expect(mapPriorityToStatus('unknown')).toBe('legacy');
+  });
+});
+
+describe('defaultHardwareForPlatform', () => {
+  it('returns known hardware label', () => {
+    expect(defaultHardwareForPlatform('pizero-esm')).toBe('Pi Zero');
+  });
+
+  it('returns platform id for unknown platform', () => {
+    expect(defaultHardwareForPlatform('custom-platform')).toBe(
+      'custom-platform'
+    );
+  });
+});

--- a/tools/scripts/sync-example-upstreams/src/build-example-urls.ts
+++ b/tools/scripts/sync-example-upstreams/src/build-example-urls.ts
@@ -1,0 +1,96 @@
+import type { ExampleStatus } from '@chirimen-device-dashboard/shared-types';
+
+export type ExampleUrls = {
+  upstreamRepositoryUrl: string;
+  upstreamPathUrl: string;
+  circuitUrl: string;
+};
+
+const PLATFORM_HARDWARE: Record<string, string> = {
+  'pizero-esm': 'Pi Zero',
+  node: 'Raspberry Pi',
+  'raspi-node': 'Raspberry Pi',
+  'microbit-driver': 'micro:bit',
+  'microbit-web': 'micro:bit',
+  'legacy-gc-gpio': 'chirimen',
+  'legacy-gc-i2c': 'chirimen',
+  remote: 'remote',
+  'pre-arranged': 'pre-arranged',
+};
+
+export function buildUpstreamRepositoryUrl(upstreamRepository: string): string {
+  return `https://github.com/${upstreamRepository}`;
+}
+
+export function buildUpstreamPathUrl(
+  upstreamRepository: string,
+  upstreamPath: string,
+  branch = 'master'
+): string {
+  return `https://github.com/${upstreamRepository}/tree/${branch}/${upstreamPath}`;
+}
+
+export function buildCircuitBlobUrl(
+  upstreamRepository: string,
+  upstreamPath: string,
+  filename: string,
+  branch = 'master'
+): string {
+  return `https://github.com/${upstreamRepository}/blob/${branch}/${upstreamPath}/${filename}`;
+}
+
+export function buildExampleUrls(
+  upstreamRepository: string,
+  upstreamPath: string,
+  branch: string,
+  circuitFilename?: string
+): ExampleUrls {
+  return {
+    upstreamRepositoryUrl: buildUpstreamRepositoryUrl(upstreamRepository),
+    upstreamPathUrl: buildUpstreamPathUrl(
+      upstreamRepository,
+      upstreamPath,
+      branch
+    ),
+    circuitUrl: circuitFilename
+      ? buildCircuitBlobUrl(
+          upstreamRepository,
+          upstreamPath,
+          circuitFilename,
+          branch
+        )
+      : '',
+  };
+}
+
+export function defaultHardwareForPlatform(platform: string): string {
+  return PLATFORM_HARDWARE[platform] ?? platform;
+}
+
+export function mapPriorityToStatus(priority: string): ExampleStatus {
+  const valid: ExampleStatus[] = [
+    'primary',
+    'legacy',
+    'archive',
+    'special',
+    'incubator',
+  ];
+  if (valid.includes(priority as ExampleStatus)) {
+    return priority as ExampleStatus;
+  }
+  return 'legacy';
+}
+
+export function buildLocalPath(deviceId: string, platform: string): string {
+  return `examples/devices/${deviceId}/platforms/${platform}`;
+}
+
+export function buildUpstreamPath(
+  sourcePath: string,
+  upstreamDirName: string
+): string {
+  if (sourcePath === '.') {
+    return upstreamDirName;
+  }
+  return `${sourcePath}/${upstreamDirName}`;
+}

--- a/tools/scripts/sync-example-upstreams/src/build-platform-example-candidates.ts
+++ b/tools/scripts/sync-example-upstreams/src/build-platform-example-candidates.ts
@@ -113,12 +113,12 @@ export function groupCandidatesByDashboardDevice(
     const key = candidate.dashboardDeviceId;
     const existing = grouped.get(key);
     if (existing) {
-      existing.examples.push(candidate.example);
+      existing.examples.push(candidate.example as ExampleInfo);
       existing.warnings.push(...candidate.warnings);
     } else {
       grouped.set(key, {
         exampleDeviceId: candidate.exampleDeviceId ?? key,
-        examples: [candidate.example],
+        examples: [candidate.example as ExampleInfo],
         warnings: [...candidate.warnings],
       });
     }

--- a/tools/scripts/sync-example-upstreams/src/build-platform-example-candidates.ts
+++ b/tools/scripts/sync-example-upstreams/src/build-platform-example-candidates.ts
@@ -1,0 +1,128 @@
+import path from 'node:path';
+import type { ExampleInfo } from '@chirimen-device-dashboard/shared-types';
+import {
+  buildExampleUrls,
+  buildLocalPath,
+  buildUpstreamPath,
+  defaultHardwareForPlatform,
+  mapPriorityToStatus,
+} from './build-example-urls';
+import { detectCircuitFilename } from './detect-circuit-url';
+import type { DashboardDeviceMappingResult } from './resolve-dashboard-device-id';
+import { resolveExampleDeviceId } from './resolve-example-device-id';
+import type { ExampleCandidateEntry, UpstreamSource } from './types';
+
+export type BuildCandidateInput = {
+  source: UpstreamSource;
+  upstreamDirName: string;
+  mirrorPath: string;
+  dashboardMapping: DashboardDeviceMappingResult;
+};
+
+export async function buildExampleCandidate(
+  input: BuildCandidateInput
+): Promise<ExampleCandidateEntry> {
+  const { source, upstreamDirName, mirrorPath, dashboardMapping } = input;
+  const warnings: string[] = [];
+
+  const exampleDeviceId = resolveExampleDeviceId(upstreamDirName);
+  if (!exampleDeviceId) {
+    return {
+      sourceId: source.id,
+      upstreamDirName,
+      exampleDeviceId: null,
+      dashboardDeviceId: null,
+      dashboardMappingStatus: 'unresolved',
+      example: null,
+      warnings: [`Could not resolve example device id from "${upstreamDirName}"`],
+    };
+  }
+
+  if (dashboardMapping.status === 'ambiguous') {
+    warnings.push(
+      `Ambiguous dashboard device id for "${exampleDeviceId}": ${dashboardMapping.ambiguousDashboardDeviceIds?.join(', ')}`
+    );
+  } else if (dashboardMapping.status === 'unresolved') {
+    warnings.push(
+      `No dashboard device id found for example device id "${exampleDeviceId}"`
+    );
+  }
+
+  const upstreamPath = buildUpstreamPath(source.path, upstreamDirName);
+  const exampleMirrorDir = path.join(mirrorPath, upstreamDirName);
+  const circuitFilename = await detectCircuitFilename(exampleMirrorDir);
+
+  if (!circuitFilename) {
+    warnings.push(`No circuit image detected in ${upstreamDirName}`);
+  }
+
+  const urls = buildExampleUrls(
+    source.repo,
+    upstreamPath,
+    source.branch,
+    circuitFilename
+  );
+
+  const status = mapPriorityToStatus(source.priority);
+  const platform = source.platform;
+  const hardware = defaultHardwareForPlatform(platform);
+
+  const example: ExampleInfo = {
+    hardware,
+    code: urls.upstreamPathUrl,
+    deviceId: exampleDeviceId,
+    platform,
+    localPath: buildLocalPath(exampleDeviceId, platform),
+    upstreamRepository: source.repo,
+    upstreamRepositoryUrl: urls.upstreamRepositoryUrl,
+    upstreamPath,
+    upstreamPathUrl: urls.upstreamPathUrl,
+    status,
+    circuitUrl: urls.circuitUrl,
+    verified: false,
+  };
+
+  return {
+    sourceId: source.id,
+    upstreamDirName,
+    exampleDeviceId,
+    dashboardDeviceId: dashboardMapping.dashboardDeviceId,
+    dashboardMappingStatus: dashboardMapping.status,
+    ambiguousDashboardDeviceIds: dashboardMapping.ambiguousDashboardDeviceIds,
+    example,
+    warnings,
+  };
+}
+
+export function groupCandidatesByDashboardDevice(
+  candidates: ExampleCandidateEntry[]
+): Map<
+  string,
+  { exampleDeviceId: string; examples: ExampleInfo[]; warnings: string[] }
+> {
+  const grouped = new Map<
+    string,
+    { exampleDeviceId: string; examples: ExampleInfo[]; warnings: string[] }
+  >();
+
+  for (const candidate of candidates) {
+    if (!candidate.example || !candidate.dashboardDeviceId) {
+      continue;
+    }
+
+    const key = candidate.dashboardDeviceId;
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.examples.push(candidate.example);
+      existing.warnings.push(...candidate.warnings);
+    } else {
+      grouped.set(key, {
+        exampleDeviceId: candidate.exampleDeviceId ?? key,
+        examples: [candidate.example],
+        warnings: [...candidate.warnings],
+      });
+    }
+  }
+
+  return grouped;
+}

--- a/tools/scripts/sync-example-upstreams/src/clone-or-fetch-source.ts
+++ b/tools/scripts/sync-example-upstreams/src/clone-or-fetch-source.ts
@@ -1,0 +1,126 @@
+import { access, cp, mkdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { UpstreamSource } from './types';
+
+const execFileAsync = promisify(execFile);
+
+export type CloneOrFetchResult = {
+  mirrorPath: string;
+  commitSha?: string;
+};
+
+function repoCacheDirName(repo: string, branch: string): string {
+  return `${repo.replace('/', '-')}--${branch}`;
+}
+
+function repoCachePath(
+  repoRoot: string,
+  repo: string,
+  branch: string
+): string {
+  return path.join(
+    repoRoot,
+    'generated/upstreams/_repos',
+    repoCacheDirName(repo, branch)
+  );
+}
+
+function mirrorPath(repoRoot: string, sourceId: string): string {
+  return path.join(repoRoot, 'generated/upstreams', sourceId);
+}
+
+async function runGit(args: string[], cwd?: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', args, {
+      cwd,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return stdout.trim();
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      throw new Error(
+        'git is required but was not found on PATH. Install git to run sync:example-upstreams.'
+      );
+    }
+    const message =
+      err instanceof Error && 'stderr' in err
+        ? String((err as { stderr?: string }).stderr ?? err.message)
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    throw new Error(`git ${args.join(' ')} failed: ${message}`);
+  }
+}
+
+async function isGitRepo(dir: string): Promise<boolean> {
+  try {
+    await access(path.join(dir, '.git'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureRepoClone(
+  repoRoot: string,
+  repo: string,
+  branch: string
+): Promise<string> {
+  const cacheDir = repoCachePath(repoRoot, repo, branch);
+  const remoteUrl = `https://github.com/${repo}.git`;
+
+  await mkdir(path.dirname(cacheDir), { recursive: true });
+
+  if (await isGitRepo(cacheDir)) {
+    await runGit(['fetch', '--depth', '1', 'origin', branch], cacheDir);
+    await runGit(['checkout', branch], cacheDir);
+    await runGit(['reset', '--hard', `origin/${branch}`], cacheDir);
+  } else {
+    await rm(cacheDir, { recursive: true, force: true });
+    await runGit(
+      ['clone', '--depth', '1', '--branch', branch, remoteUrl, cacheDir],
+      repoRoot
+    );
+  }
+
+  return cacheDir;
+}
+
+async function getCommitSha(cacheDir: string): Promise<string | undefined> {
+  try {
+    return await runGit(['rev-parse', 'HEAD'], cacheDir);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function cloneOrFetchSource(
+  repoRoot: string,
+  source: UpstreamSource
+): Promise<CloneOrFetchResult> {
+  const cacheDir = await ensureRepoClone(
+    repoRoot,
+    source.repo,
+    source.branch
+  );
+  const commitSha = await getCommitSha(cacheDir);
+
+  const sourceSubtree = path.join(cacheDir, source.path);
+  const dest = mirrorPath(repoRoot, source.id);
+
+  await rm(dest, { recursive: true, force: true });
+  await mkdir(path.dirname(dest), { recursive: true });
+  await cp(sourceSubtree, dest, { recursive: true, force: true });
+  await rm(path.join(dest, '.git'), { recursive: true, force: true });
+
+  return {
+    mirrorPath: dest,
+    commitSha,
+  };
+}

--- a/tools/scripts/sync-example-upstreams/src/clone-or-fetch-source.ts
+++ b/tools/scripts/sync-example-upstreams/src/clone-or-fetch-source.ts
@@ -45,7 +45,8 @@ async function runGit(args: string[], cwd?: string): Promise<string> {
       (err as NodeJS.ErrnoException).code === 'ENOENT'
     ) {
       throw new Error(
-        'git is required but was not found on PATH. Install git to run sync:example-upstreams.'
+        'git is required but was not found on PATH. Install git to run sync:example-upstreams.',
+        { cause: err }
       );
     }
     const message =
@@ -54,7 +55,7 @@ async function runGit(args: string[], cwd?: string): Promise<string> {
         : err instanceof Error
           ? err.message
           : String(err);
-    throw new Error(`git ${args.join(' ')} failed: ${message}`);
+    throw new Error(`git ${args.join(' ')} failed: ${message}`, { cause: err });
   }
 }
 

--- a/tools/scripts/sync-example-upstreams/src/detect-circuit-url.ts
+++ b/tools/scripts/sync-example-upstreams/src/detect-circuit-url.ts
@@ -1,0 +1,49 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const CIRCUIT_FILENAME_CANDIDATES = [
+  'schematic.png',
+  'Schematic.png',
+  'circuit.png',
+  'Circuit.png',
+];
+
+const CIRCUIT_DIR_CANDIDATES = ['imgs', 'images', 'img'];
+
+async function findPngInDir(dir: string): Promise<string | undefined> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const pngs = entries
+      .filter((e) => e.isFile() && e.name.toLowerCase().endsWith('.png'))
+      .map((e) => e.name)
+      .sort();
+    return pngs[0];
+  } catch {
+    return undefined;
+  }
+}
+
+export async function detectCircuitFilename(
+  exampleMirrorDir: string
+): Promise<string | undefined> {
+  for (const name of CIRCUIT_FILENAME_CANDIDATES) {
+    try {
+      const { access } = await import('node:fs/promises');
+      await access(path.join(exampleMirrorDir, name));
+      return name;
+    } catch {
+      // try next candidate
+    }
+  }
+
+  for (const subdir of CIRCUIT_DIR_CANDIDATES) {
+    const subdirPath = path.join(exampleMirrorDir, subdir);
+    const png = await findPngInDir(subdirPath);
+    if (png) {
+      return `${subdir}/${png}`;
+    }
+  }
+
+  const rootPng = await findPngInDir(exampleMirrorDir);
+  return rootPng;
+}

--- a/tools/scripts/sync-example-upstreams/src/list-example-dir-names.ts
+++ b/tools/scripts/sync-example-upstreams/src/list-example-dir-names.ts
@@ -1,0 +1,8 @@
+import { readdir } from 'node:fs/promises';
+
+export async function listExampleDirNames(
+  mirrorPath: string
+): Promise<string[]> {
+  const entries = await readdir(mirrorPath, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}

--- a/tools/scripts/sync-example-upstreams/src/load-sources.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/load-sources.spec.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadSources } from './load-sources';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  const { rm } = await import('node:fs/promises');
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function createTempRepoWithSources(content: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'sync-upstreams-test-'));
+  tempDirs.push(dir);
+  const dataDir = path.join(dir, 'data/example-upstreams');
+  const { mkdir } = await import('node:fs/promises');
+  await mkdir(dataDir, { recursive: true });
+  await writeFile(path.join(dataDir, 'sources.yaml'), content, 'utf8');
+  return dir;
+}
+
+describe('loadSources', () => {
+  it('loads valid sources yaml', async () => {
+    const repoRoot = await createTempRepoWithSources(`
+sources:
+  - id: test-source
+    repo: chirimen-oh/chirimen.org
+    branch: master
+    path: pizero/src/esm-examples
+    platform: pizero-esm
+    priority: primary
+    description: test source
+`);
+    const sources = await loadSources(repoRoot);
+    expect(sources).toHaveLength(1);
+    expect(sources[0].id).toBe('test-source');
+    expect(sources[0].priority).toBe('primary');
+  });
+
+  it('throws on invalid priority', async () => {
+    const repoRoot = await createTempRepoWithSources(`
+sources:
+  - id: test-source
+    repo: chirimen-oh/chirimen.org
+    branch: master
+    path: examples
+    platform: node
+    priority: invalid
+    description: test
+`);
+    await expect(loadSources(repoRoot)).rejects.toThrow(/priority/);
+  });
+
+  it('throws when sources array is missing', async () => {
+    const repoRoot = await createTempRepoWithSources('other: value');
+    await expect(loadSources(repoRoot)).rejects.toThrow(/sources array/);
+  });
+});

--- a/tools/scripts/sync-example-upstreams/src/load-sources.ts
+++ b/tools/scripts/sync-example-upstreams/src/load-sources.ts
@@ -1,0 +1,73 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { ExampleStatus } from '@chirimen-device-dashboard/shared-types';
+import type { UpstreamSource, UpstreamSourcesFile } from './types';
+
+const REQUIRED_FIELDS = [
+  'id',
+  'repo',
+  'branch',
+  'path',
+  'platform',
+  'priority',
+  'description',
+] as const;
+
+const VALID_PRIORITIES: ExampleStatus[] = [
+  'primary',
+  'legacy',
+  'archive',
+  'special',
+  'incubator',
+];
+
+function assertSource(
+  source: unknown,
+  index: number
+): asserts source is UpstreamSource {
+  if (typeof source !== 'object' || source === null) {
+    throw new Error(
+      `data/example-upstreams/sources.yaml: sources[${index}] must be an object`
+    );
+  }
+
+  const record = source as Record<string, unknown>;
+  for (const field of REQUIRED_FIELDS) {
+    if (typeof record[field] !== 'string' || record[field] === '') {
+      throw new Error(
+        `data/example-upstreams/sources.yaml: sources[${index}].${field} must be a non-empty string`
+      );
+    }
+  }
+
+  if (!VALID_PRIORITIES.includes(record.priority as ExampleStatus)) {
+    throw new Error(
+      `data/example-upstreams/sources.yaml: sources[${index}].priority must be one of ${VALID_PRIORITIES.join(', ')}`
+    );
+  }
+}
+
+export async function loadSources(repoRoot: string): Promise<UpstreamSource[]> {
+  const filePath = path.join(
+    repoRoot,
+    'data/example-upstreams/sources.yaml'
+  );
+  const raw = await readFile(filePath, 'utf8');
+  const parsed = parseYaml(raw) as unknown;
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('sources' in parsed) ||
+    !Array.isArray((parsed as UpstreamSourcesFile).sources)
+  ) {
+    throw new Error(
+      'data/example-upstreams/sources.yaml: expected sources array'
+    );
+  }
+
+  const { sources } = parsed as UpstreamSourcesFile;
+  sources.forEach((source, index) => assertSource(source, index));
+  return sources;
+}

--- a/tools/scripts/sync-example-upstreams/src/main.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/main.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlatformExamplesJson } from './main';
+import type { ExampleCandidateEntry } from './types';
+
+describe('buildPlatformExamplesJson', () => {
+  it('groups candidates by dashboard device id', () => {
+    const candidates: ExampleCandidateEntry[] = [
+      {
+        sourceId: 'src-a',
+        upstreamDirName: 'adt7410',
+        exampleDeviceId: 'adt7410',
+        dashboardDeviceId: 'i2c-adt7410',
+        dashboardMappingStatus: 'resolved',
+        example: {
+          hardware: 'Pi Zero',
+          code: 'https://example.com/a',
+          platform: 'pizero-esm',
+          deviceId: 'adt7410',
+        },
+        warnings: [],
+      },
+      {
+        sourceId: 'src-b',
+        upstreamDirName: 'adt7410',
+        exampleDeviceId: 'adt7410',
+        dashboardDeviceId: 'i2c-adt7410',
+        dashboardMappingStatus: 'resolved',
+        example: {
+          hardware: 'Raspberry Pi',
+          code: 'https://example.com/b',
+          platform: 'node',
+          deviceId: 'adt7410',
+        },
+        warnings: [],
+      },
+    ];
+
+    const grouped = new Map([
+      [
+        'i2c-adt7410',
+        {
+          exampleDeviceId: 'adt7410',
+          examples: candidates
+            .map((c) => c.example!)
+            .sort((a, b) =>
+              (a.platform ?? '').localeCompare(b.platform ?? '')
+            ),
+          warnings: [],
+        },
+      ],
+    ]);
+
+    const result = buildPlatformExamplesJson(grouped);
+    expect(result).toHaveLength(1);
+    expect(result[0].dashboardDeviceId).toBe('i2c-adt7410');
+    expect(result[0].examples).toHaveLength(2);
+    expect(result[0].examples[0].platform).toBe('node');
+    expect(result[0].examples[1].platform).toBe('pizero-esm');
+  });
+});
+
+describe('renderSyncSummaryMarkdown', () => {
+  it('includes overview counts', async () => {
+    const { renderSyncSummaryMarkdown } = await import('./write-sync-summary');
+    const markdown = renderSyncSummaryMarkdown({
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      repoRoot: '/repo',
+      fatalErrors: [],
+      sources: [
+        {
+          sourceId: 'test',
+          repo: 'chirimen-oh/chirimen.org',
+          branch: 'master',
+          path: 'examples',
+          platform: 'pizero-esm',
+          mirrorPath: '/repo/generated/upstreams/test',
+          exampleCount: 2,
+          errors: [],
+          candidates: [
+            {
+              sourceId: 'test',
+              upstreamDirName: 'adt7410',
+              exampleDeviceId: 'adt7410',
+              dashboardDeviceId: 'i2c-adt7410',
+              dashboardMappingStatus: 'resolved',
+              example: null,
+              warnings: [],
+            },
+          ],
+        },
+      ],
+    });
+    expect(markdown).toContain('# Upstream sync summary');
+    expect(markdown).toContain('Total candidates | 1');
+  });
+});

--- a/tools/scripts/sync-example-upstreams/src/main.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/main.spec.ts
@@ -41,7 +41,7 @@ describe('buildPlatformExamplesJson', () => {
         {
           exampleDeviceId: 'adt7410',
           examples: candidates
-            .map((c) => c.example!)
+            .flatMap((c) => (c.example ? [c.example] : []))
             .sort((a, b) =>
               (a.platform ?? '').localeCompare(b.platform ?? '')
             ),

--- a/tools/scripts/sync-example-upstreams/src/main.ts
+++ b/tools/scripts/sync-example-upstreams/src/main.ts
@@ -1,0 +1,10 @@
+async function main(): Promise<void> {
+  console.log('sync-example-upstreams: not yet implemented');
+}
+
+if (!process.env.VITEST) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tools/scripts/sync-example-upstreams/src/main.ts
+++ b/tools/scripts/sync-example-upstreams/src/main.ts
@@ -1,5 +1,193 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { ExampleInfo } from '@chirimen-device-dashboard/shared-types';
+import { cloneOrFetchSource } from './clone-or-fetch-source';
+import {
+  buildExampleCandidate,
+  groupCandidatesByDashboardDevice,
+} from './build-platform-example-candidates';
+import { listExampleDirNames } from './list-example-dir-names';
+import { loadSources } from './load-sources';
+import {
+  loadDashboardDeviceIds,
+  loadDeviceIdOverrides,
+  resolveDashboardDeviceId,
+} from './resolve-dashboard-device-id';
+import { resolveExampleDeviceId } from './resolve-example-device-id';
+import type {
+  PlatformExampleDeviceEntry,
+  SourceSyncResult,
+  SyncSummary,
+  UpstreamSource,
+} from './types';
+import { writeExampleCandidatesReport } from './write-example-candidates-report';
+import { writeSyncSummary } from './write-sync-summary';
+
+function getRepoRoot(): string {
+  return process.cwd();
+}
+
+async function syncSource(
+  repoRoot: string,
+  source: UpstreamSource,
+  dashboardDeviceIds: string[],
+  overrides: Record<string, string>
+): Promise<SourceSyncResult> {
+  const result: SourceSyncResult = {
+    sourceId: source.id,
+    repo: source.repo,
+    branch: source.branch,
+    path: source.path,
+    platform: source.platform,
+    mirrorPath: path.join(repoRoot, 'generated/upstreams', source.id),
+    exampleCount: 0,
+    errors: [],
+    candidates: [],
+  };
+
+  try {
+    const { mirrorPath: mirror, commitSha } = await cloneOrFetchSource(
+      repoRoot,
+      source
+    );
+    result.mirrorPath = mirror;
+    result.commitSha = commitSha;
+
+    const dirNames = await listExampleDirNames(mirror);
+    result.exampleCount = dirNames.length;
+
+    for (const upstreamDirName of dirNames) {
+      const parsedExampleDeviceId = resolveExampleDeviceId(upstreamDirName);
+
+      const dashboardMapping = parsedExampleDeviceId
+        ? resolveDashboardDeviceId(
+            parsedExampleDeviceId,
+            dashboardDeviceIds,
+            overrides
+          )
+        : {
+            dashboardDeviceId: null,
+            status: 'unresolved' as const,
+          };
+
+      const candidate = await buildExampleCandidate({
+        source,
+        upstreamDirName,
+        mirrorPath: mirror,
+        dashboardMapping,
+      });
+
+      result.candidates.push(candidate);
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    result.errors.push(message);
+  }
+
+  return result;
+}
+
+function buildPlatformExamplesJson(
+  grouped: Map<
+    string,
+    { exampleDeviceId: string; examples: ExampleInfo[]; warnings: string[] }
+  >
+): PlatformExampleDeviceEntry[] {
+  return [...grouped.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([dashboardDeviceId, entry]) => ({
+      dashboardDeviceId,
+      exampleDeviceId: entry.exampleDeviceId,
+      examples: entry.examples.sort((a, b) =>
+        (a.platform ?? '').localeCompare(b.platform ?? '')
+      ),
+    }));
+}
+
+async function writeGeneratedPlatformExamples(
+  repoRoot: string,
+  entries: PlatformExampleDeviceEntry[]
+): Promise<string> {
+  const outPath = path.join(
+    repoRoot,
+    'data/platform-examples/platform-examples.generated.json'
+  );
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+  return outPath;
+}
+
 async function main(): Promise<void> {
-  console.log('sync-example-upstreams: not yet implemented');
+  const repoRoot = getRepoRoot();
+  console.log('Loading upstream sources...');
+  const sources = await loadSources(repoRoot);
+
+  console.log('Loading dashboard device ids...');
+  const dashboardDeviceIds = await loadDashboardDeviceIds(repoRoot);
+  const overrides = await loadDeviceIdOverrides(repoRoot);
+
+  const sourceResults: SourceSyncResult[] = [];
+  const fatalErrors: string[] = [];
+
+  for (const source of sources) {
+    console.log(`Syncing ${source.id} (${source.repo})...`);
+    const result = await syncSource(
+      repoRoot,
+      source,
+      dashboardDeviceIds,
+      overrides
+    );
+    sourceResults.push(result);
+    if (result.errors.length > 0) {
+      fatalErrors.push(`${source.id}: ${result.errors.join('; ')}`);
+    }
+  }
+
+  const allCandidates = sourceResults.flatMap((s) => s.candidates);
+  const grouped = groupCandidatesByDashboardDevice(allCandidates);
+  const platformEntries = buildPlatformExamplesJson(grouped);
+
+  const summary: SyncSummary = {
+    generatedAt: new Date().toISOString(),
+    repoRoot,
+    sources: sourceResults,
+    fatalErrors,
+  };
+
+  const summaryPath = await writeSyncSummary(repoRoot, summary);
+  const candidatesReportPath = await writeExampleCandidatesReport(
+    repoRoot,
+    summary
+  );
+  const generatedJsonPath = await writeGeneratedPlatformExamples(
+    repoRoot,
+    platformEntries
+  );
+
+  console.log(`Sync complete.`);
+  console.log(`  Summary: ${path.relative(repoRoot, summaryPath)}`);
+  console.log(
+    `  Candidates report: ${path.relative(repoRoot, candidatesReportPath)}`
+  );
+  console.log(
+    `  Generated JSON: ${path.relative(repoRoot, generatedJsonPath)} (${platformEntries.length} devices)`
+  );
+
+  for (const source of sourceResults) {
+    const relMirror = path.relative(repoRoot, source.mirrorPath);
+    const status = source.errors.length > 0 ? 'ERROR' : 'OK';
+    console.log(
+      `  [${status}] ${source.sourceId}: ${source.exampleCount} example(s) → ${relMirror}`
+    );
+  }
+
+  if (fatalErrors.length > 0) {
+    console.error('\nFatal errors:');
+    for (const err of fatalErrors) {
+      console.error(`  - ${err}`);
+    }
+    process.exit(1);
+  }
 }
 
 if (!process.env.VITEST) {
@@ -8,3 +196,5 @@ if (!process.env.VITEST) {
     process.exit(1);
   });
 }
+
+export { main, syncSource, buildPlatformExamplesJson };

--- a/tools/scripts/sync-example-upstreams/src/resolve-dashboard-device-id.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/resolve-dashboard-device-id.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDashboardDeviceId } from './resolve-dashboard-device-id';
+
+describe('resolveDashboardDeviceId', () => {
+  const dashboardDeviceIds = [
+    'i2c-adt7410',
+    'i2c-bme280',
+    'i2c-foo',
+    'gpio-foo',
+  ];
+
+  it('resolves unique suffix match', () => {
+    const result = resolveDashboardDeviceId(
+      'adt7410',
+      dashboardDeviceIds,
+      {}
+    );
+    expect(result.status).toBe('resolved');
+    expect(result.dashboardDeviceId).toBe('i2c-adt7410');
+  });
+
+  it('uses override when provided', () => {
+    const result = resolveDashboardDeviceId('foo', dashboardDeviceIds, {
+      foo: 'i2c-foo',
+    });
+    expect(result.status).toBe('override');
+    expect(result.dashboardDeviceId).toBe('i2c-foo');
+  });
+
+  it('reports ambiguous matches', () => {
+    const result = resolveDashboardDeviceId('foo', dashboardDeviceIds, {});
+    expect(result.status).toBe('ambiguous');
+    expect(result.ambiguousDashboardDeviceIds).toEqual([
+      'i2c-foo',
+      'gpio-foo',
+    ]);
+  });
+
+  it('reports unresolved when no match', () => {
+    const result = resolveDashboardDeviceId(
+      'unknown-device',
+      dashboardDeviceIds,
+      {}
+    );
+    expect(result.status).toBe('unresolved');
+    expect(result.dashboardDeviceId).toBeNull();
+  });
+});

--- a/tools/scripts/sync-example-upstreams/src/resolve-dashboard-device-id.ts
+++ b/tools/scripts/sync-example-upstreams/src/resolve-dashboard-device-id.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
+import type { DeviceIdOverridesFile } from './types';
+
+export type DashboardDeviceMappingResult = {
+  dashboardDeviceId: string | null;
+  status: 'resolved' | 'ambiguous' | 'unresolved' | 'override';
+  ambiguousDashboardDeviceIds?: string[];
+};
+
+export async function loadDeviceIdOverrides(
+  repoRoot: string
+): Promise<Record<string, string>> {
+  const filePath = path.join(
+    repoRoot,
+    'data/example-upstreams/device-id-overrides.yaml'
+  );
+
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = parseYaml(raw) as unknown;
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('overrides' in parsed)
+    ) {
+      return {};
+    }
+
+    const { overrides } = parsed as DeviceIdOverridesFile;
+    if (typeof overrides !== 'object' || overrides === null) {
+      return {};
+    }
+
+    return overrides;
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      return {};
+    }
+    throw err;
+  }
+}
+
+export async function loadDashboardDeviceIds(
+  repoRoot: string
+): Promise<string[]> {
+  const filePath = path.join(repoRoot, 'apps/web/public/devices.json');
+  const raw = await readFile(filePath, 'utf8');
+  const devices = JSON.parse(raw) as DeviceInfo[];
+  return devices.map((d) => d.id);
+}
+
+export function resolveDashboardDeviceId(
+  exampleDeviceId: string,
+  dashboardDeviceIds: string[],
+  overrides: Record<string, string>
+): DashboardDeviceMappingResult {
+  const override = overrides[exampleDeviceId];
+  if (override) {
+    return {
+      dashboardDeviceId: override,
+      status: 'override',
+    };
+  }
+
+  const suffix = `-${exampleDeviceId}`;
+  const matches = dashboardDeviceIds.filter((id) => id.endsWith(suffix));
+
+  if (matches.length === 1) {
+    return {
+      dashboardDeviceId: matches[0],
+      status: 'resolved',
+    };
+  }
+
+  if (matches.length > 1) {
+    return {
+      dashboardDeviceId: null,
+      status: 'ambiguous',
+      ambiguousDashboardDeviceIds: matches,
+    };
+  }
+
+  return {
+    dashboardDeviceId: null,
+    status: 'unresolved',
+  };
+}

--- a/tools/scripts/sync-example-upstreams/src/resolve-example-device-id.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/resolve-example-device-id.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { resolveExampleDeviceId } from './resolve-example-device-id';
+
+describe('resolveExampleDeviceId', () => {
+  it('accepts valid lowercase device ids', () => {
+    expect(resolveExampleDeviceId('adt7410')).toBe('adt7410');
+    expect(resolveExampleDeviceId('bme280')).toBe('bme280');
+  });
+
+  it('normalizes uppercase names', () => {
+    expect(resolveExampleDeviceId('ADT7410')).toBe('adt7410');
+  });
+
+  it('normalizes legacy gc i2c directory names to lowercase id', () => {
+    expect(resolveExampleDeviceId('i2c-ADT7410')).toBe('i2c-adt7410');
+  });
+
+  it('accepts gpio-prefixed directory names as device ids', () => {
+    expect(resolveExampleDeviceId('gpio-led')).toBe('gpio-led');
+  });
+
+  it('returns null for invalid ids', () => {
+    expect(resolveExampleDeviceId('i2c_ADT7410')).toBeNull();
+    expect(resolveExampleDeviceId('')).toBeNull();
+  });
+});

--- a/tools/scripts/sync-example-upstreams/src/resolve-example-device-id.ts
+++ b/tools/scripts/sync-example-upstreams/src/resolve-example-device-id.ts
@@ -1,0 +1,31 @@
+import { tryValidateExampleDeviceId } from './validate-example-device-id';
+
+const LEGACY_GC_PREFIXES = ['i2c-', 'gpio-'] as const;
+
+function normalizeLegacyGcName(dirName: string): string | null {
+  const lower = dirName.toLowerCase();
+  for (const prefix of LEGACY_GC_PREFIXES) {
+    if (lower.startsWith(prefix)) {
+      const stripped = lower.slice(prefix.length);
+      return tryValidateExampleDeviceId(stripped);
+    }
+  }
+  return null;
+}
+
+export function resolveExampleDeviceId(
+  upstreamDirName: string
+): string | null {
+  const direct = tryValidateExampleDeviceId(upstreamDirName);
+  if (direct) {
+    return direct;
+  }
+
+  const lower = upstreamDirName.toLowerCase();
+  const fromLower = tryValidateExampleDeviceId(lower);
+  if (fromLower) {
+    return fromLower;
+  }
+
+  return normalizeLegacyGcName(upstreamDirName);
+}

--- a/tools/scripts/sync-example-upstreams/src/types.ts
+++ b/tools/scripts/sync-example-upstreams/src/types.ts
@@ -1,0 +1,56 @@
+import type { ExampleInfo, ExampleStatus } from '@chirimen-device-dashboard/shared-types';
+
+export interface UpstreamSource {
+  id: string;
+  repo: string;
+  branch: string;
+  path: string;
+  platform: string;
+  priority: ExampleStatus;
+  description: string;
+}
+
+export interface UpstreamSourcesFile {
+  sources: UpstreamSource[];
+}
+
+export interface ExampleCandidateEntry {
+  sourceId: string;
+  upstreamDirName: string;
+  exampleDeviceId: string | null;
+  dashboardDeviceId: string | null;
+  dashboardMappingStatus: 'resolved' | 'ambiguous' | 'unresolved' | 'override';
+  ambiguousDashboardDeviceIds?: string[];
+  example: Partial<ExampleInfo> | null;
+  warnings: string[];
+}
+
+export interface SourceSyncResult {
+  sourceId: string;
+  repo: string;
+  branch: string;
+  path: string;
+  platform: string;
+  mirrorPath: string;
+  commitSha?: string;
+  exampleCount: number;
+  errors: string[];
+  candidates: ExampleCandidateEntry[];
+}
+
+export interface SyncSummary {
+  generatedAt: string;
+  repoRoot: string;
+  sources: SourceSyncResult[];
+  fatalErrors: string[];
+}
+
+export interface PlatformExampleDeviceEntry {
+  dashboardDeviceId: string;
+  exampleDeviceId: string;
+  examples: ExampleInfo[];
+}
+
+export interface DeviceIdOverridesFile {
+  overrides: Record<string, string>;
+}

--- a/tools/scripts/sync-example-upstreams/src/validate-example-device-id.ts
+++ b/tools/scripts/sync-example-upstreams/src/validate-example-device-id.ts
@@ -1,0 +1,28 @@
+const DEVICE_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function validateExampleDeviceId(deviceId: string): void {
+  if (!deviceId) {
+    throw new Error('deviceId is required');
+  }
+
+  if (deviceId.includes('_')) {
+    throw new Error(
+      `Invalid deviceId "${deviceId}": underscores are not allowed (e.g. use "${deviceId.replace(/_/g, '-')}" instead)`
+    );
+  }
+
+  if (!DEVICE_ID_PATTERN.test(deviceId)) {
+    throw new Error(
+      `Invalid deviceId "${deviceId}": must be lowercase alphanumeric with optional hyphens`
+    );
+  }
+}
+
+export function tryValidateExampleDeviceId(deviceId: string): string | null {
+  try {
+    validateExampleDeviceId(deviceId);
+    return deviceId;
+  } catch {
+    return null;
+  }
+}

--- a/tools/scripts/sync-example-upstreams/src/write-example-candidates-report.ts
+++ b/tools/scripts/sync-example-upstreams/src/write-example-candidates-report.ts
@@ -1,0 +1,122 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { ExampleCandidateEntry, SyncSummary } from './types';
+
+function renderUnmappedSection(candidates: ExampleCandidateEntry[]): string {
+  const unmapped = candidates.filter(
+    (c) =>
+      c.example &&
+      (!c.dashboardDeviceId ||
+        c.dashboardMappingStatus === 'ambiguous' ||
+        c.dashboardMappingStatus === 'unresolved')
+  );
+
+  if (unmapped.length === 0) {
+    return 'All candidates with valid example device ids have dashboard mappings.\n';
+  }
+
+  const lines: string[] = [
+    '## Unmapped or ambiguous candidates',
+    '',
+    '| Source | Upstream dir | Example device id | Status | Notes |',
+    '| --- | --- | --- | --- | --- |',
+  ];
+
+  for (const c of unmapped) {
+    const notes =
+      c.dashboardMappingStatus === 'ambiguous'
+        ? `Candidates: ${c.ambiguousDashboardDeviceIds?.join(', ')}`
+        : c.warnings.join('; ');
+    lines.push(
+      `| ${c.sourceId} | \`${c.upstreamDirName}\` | ${c.exampleDeviceId ?? '-'} | ${c.dashboardMappingStatus} | ${notes} |`
+    );
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderUnknownDeviceSection(candidates: ExampleCandidateEntry[]): string {
+  const unknown = candidates.filter((c) => !c.exampleDeviceId);
+
+  if (unknown.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [
+    '## Unknown example device ids',
+    '',
+    '| Source | Upstream dir |',
+    '| --- | --- |',
+  ];
+
+  for (const c of unknown) {
+    lines.push(`| ${c.sourceId} | \`${c.upstreamDirName}\` |`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderMappedPreview(candidates: ExampleCandidateEntry[]): string {
+  const mapped = candidates.filter((c) => c.dashboardDeviceId && c.example);
+
+  if (mapped.length === 0) {
+    return '';
+  }
+
+  const lines: string[] = [
+    '## Mapped candidates (preview)',
+    '',
+    '| Dashboard device id | Example device id | Platform | Upstream path |',
+    '| --- | --- | --- | --- |',
+  ];
+
+  for (const c of mapped.slice(0, 50)) {
+    lines.push(
+      `| \`${c.dashboardDeviceId}\` | ${c.exampleDeviceId} | ${c.example?.platform} | \`${c.example?.upstreamPath}\` |`
+    );
+  }
+
+  if (mapped.length > 50) {
+    lines.push('');
+    lines.push(`_... and ${mapped.length - 50} more mapped candidates._`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function renderExampleCandidatesMarkdown(
+  summary: SyncSummary
+): string {
+  const allCandidates = summary.sources.flatMap((s) => s.candidates);
+
+  const lines: string[] = [
+    '# Example candidates report',
+    '',
+    `Generated at: ${summary.generatedAt}`,
+    '',
+    'Review this report before merging `platform-examples.generated.json` into `platform-examples.json`.',
+    '',
+    renderUnmappedSection(allCandidates),
+    renderUnknownDeviceSection(allCandidates),
+    renderMappedPreview(allCandidates),
+  ];
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+export async function writeExampleCandidatesReport(
+  repoRoot: string,
+  summary: SyncSummary
+): Promise<string> {
+  const outPath = path.join(
+    repoRoot,
+    'generated/reports/example-candidates.md'
+  );
+  await mkdir(path.dirname(outPath), { recursive: true });
+  const content = renderExampleCandidatesMarkdown(summary);
+  await writeFile(outPath, content, 'utf8');
+  return outPath;
+}

--- a/tools/scripts/sync-example-upstreams/src/write-sync-summary.ts
+++ b/tools/scripts/sync-example-upstreams/src/write-sync-summary.ts
@@ -1,0 +1,112 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { SyncSummary } from './types';
+
+function renderSourceSection(summary: SyncSummary): string {
+  const lines: string[] = [];
+
+  for (const source of summary.sources) {
+    lines.push(`### ${source.sourceId}`);
+    lines.push('');
+    lines.push('| 項目 | 内容 |');
+    lines.push('| --- | --- |');
+    lines.push(`| Repository | \`${source.repo}\` |`);
+    lines.push(`| Branch | \`${source.branch}\` |`);
+    lines.push(`| Path | \`${source.path}\` |`);
+    lines.push(`| Platform | \`${source.platform}\` |`);
+    lines.push(
+      `| Mirror | \`${path.relative(summary.repoRoot, source.mirrorPath)}\` |`
+    );
+    if (source.commitSha) {
+      lines.push(`| Commit | \`${source.commitSha}\` |`);
+    }
+    lines.push(`| Examples detected | ${source.exampleCount} |`);
+    lines.push(
+      `| Candidates with dashboard mapping | ${source.candidates.filter((c) => c.dashboardDeviceId).length} |`
+    );
+    lines.push('');
+
+    if (source.errors.length > 0) {
+      lines.push('**Errors**');
+      lines.push('');
+      for (const err of source.errors) {
+        lines.push(`- ${err}`);
+      }
+      lines.push('');
+    }
+
+    const withWarnings = source.candidates.filter((c) => c.warnings.length > 0);
+    if (withWarnings.length > 0) {
+      lines.push('**Warnings**');
+      lines.push('');
+      for (const candidate of withWarnings.slice(0, 20)) {
+        for (const warning of candidate.warnings) {
+          lines.push(
+            `- \`${candidate.upstreamDirName}\` (${candidate.sourceId}): ${warning}`
+          );
+        }
+      }
+      if (withWarnings.length > 20) {
+        lines.push(`- ... and ${withWarnings.length - 20} more`);
+      }
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function renderSyncSummaryMarkdown(summary: SyncSummary): string {
+  const totalCandidates = summary.sources.reduce(
+    (sum, s) => sum + s.candidates.length,
+    0
+  );
+  const mappedCandidates = summary.sources.reduce(
+    (sum, s) => sum + s.candidates.filter((c) => c.dashboardDeviceId).length,
+    0
+  );
+
+  const lines: string[] = [
+    '# Upstream sync summary',
+    '',
+    `Generated at: ${summary.generatedAt}`,
+    '',
+    '## Overview',
+    '',
+    '| 項目 | 値 |',
+    '| --- | --- |',
+    `| Sources | ${summary.sources.length} |`,
+    `| Total candidates | ${totalCandidates} |`,
+    `| Mapped to dashboard device | ${mappedCandidates} |`,
+    '',
+  ];
+
+  if (summary.fatalErrors.length > 0) {
+    lines.push('## Fatal errors');
+    lines.push('');
+    for (const err of summary.fatalErrors) {
+      lines.push(`- ${err}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Sources');
+  lines.push('');
+  lines.push(renderSourceSection(summary));
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+export async function writeSyncSummary(
+  repoRoot: string,
+  summary: SyncSummary
+): Promise<string> {
+  const outPath = path.join(
+    repoRoot,
+    'generated/reports/example-sync-summary.md'
+  );
+  await mkdir(path.dirname(outPath), { recursive: true });
+  const content = renderSyncSummaryMarkdown(summary);
+  await writeFile(outPath, content, 'utf8');
+  return outPath;
+}

--- a/tools/scripts/sync-example-upstreams/tsconfig.app.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tools/scripts/sync-example-upstreams/tsconfig.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/tools/scripts/sync-example-upstreams/tsconfig.lib.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc/tools/scripts/sync-example-upstreams",
+    "declaration": true,
+    "declarationMap": true,
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tools/scripts/sync-example-upstreams/tsconfig.lib.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.lib.json
@@ -5,6 +5,8 @@
     "declaration": true,
     "declarationMap": true,
     "module": "commonjs",
+    "target": "es2022",
+    "lib": ["es2022"],
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],

--- a/tools/scripts/sync-example-upstreams/tsconfig.spec.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.spec.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["vitest/globals", "vitest/importMeta", "node"]
+  },
+  "include": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/tools/scripts/sync-example-upstreams/vitest.config.ts
+++ b/tools/scripts/sync-example-upstreams/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: __dirname,
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- `chirimen-example-catalog` の `sync-upstreams` 相当機能を dashboard 側に移植
- `pnpm sync:example-upstreams` で upstream examples を同期し、Platform 別 Example 候補とレポートを生成
- 正本 `platform-examples.json` は自動上書きせず、review 用の `platform-examples.generated.json` を出力

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #181
- Part of #177

## What changed?

- `data/example-upstreams/sources.yaml` — upstream repository 定義（9 sources）
- `data/example-upstreams/device-id-overrides.yaml` — dashboard device id の手動 override
- `tools/scripts/sync-example-upstreams/` — 同期ツール（clone/fetch、候補生成、レポート出力）
- `pnpm sync:example-upstreams` スクリプト追加
- commitlint scope `sync-example-upstreams` 追加
- `.gitignore` に `generated/` と `platform-examples.generated.json` を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm install`
2. `pnpm sync:example-upstreams`（git CLI と network が必要）
3. 以下が生成されることを確認:
   - `generated/upstreams/**`
   - `generated/reports/example-sync-summary.md`
   - `generated/reports/example-candidates.md`
   - `data/platform-examples/platform-examples.generated.json`
4. `pnpm nx run sync-example-upstreams:test`

## Environment (if relevant)

- Browser: N/A
- OS: macOS / Windows / Linux
- Node version: 24
- pnpm version: 11.5.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)