### PR TITLE
feat(sync-devices): merge platform examples into devices.json generation

### DIFF
--- a/apps/web/public/devices.json
+++ b/apps/web/public/devices.json
@@ -79,16 +79,74 @@
       "url": "https://akizukidenshi.com/catalog/g/g106675/",
       "example": [
         {
+          "hardware": "Pi Zero",
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410",
+          "deviceId": "adt7410",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/adt7410/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples/adt7410",
+          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410",
+          "status": "primary",
+          "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png",
+          "verified": false
+        },
+        {
+          "hardware": "Raspberry Pi",
+          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
+          "deviceId": "adt7410",
+          "platform": "node",
+          "localPath": "examples/devices/adt7410/platforms/node",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "node-examples/adt7410",
+          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
+          "status": "legacy",
+          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png",
+          "verified": false
+        },
+        {
+          "hardware": "Raspberry Pi",
+          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
+          "deviceId": "adt7410",
+          "platform": "raspi-node",
+          "localPath": "examples/devices/adt7410/platforms/raspi-node",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "raspi-examples/adt7410",
+          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
+          "status": "legacy",
+          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png",
+          "verified": false
+        },
+        {
+          "hardware": "micro:bit",
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410",
+          "deviceId": "adt7410",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/adt7410/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples/adt7410",
+          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/adt7410",
+          "status": "legacy",
+          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/adt7410/imgs/pinbit_adt7410.png",
+          "verified": false
+        },
+        {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#I2C-ADT7410"
-        },
-        {
-          "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410"
-        },
-        {
-          "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410"
+          "code": "https://r.chirimen.org/examples/#I2C-ADT7410",
+          "deviceId": "adt7410",
+          "platform": "legacy-gc-i2c",
+          "localPath": "examples/devices/adt7410/platforms/legacy-gc-i2c",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/i2c/i2c-ADT7410",
+          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen/tree/master/gc/i2c/i2c-ADT7410",
+          "status": "archive",
+          "circuitUrl": "https://github.com/chirimen-oh/chirimen/blob/master/gc/i2c/i2c-ADT7410/schematic.png",
+          "verified": false
         }
       ],
       "circuit": "https://github.com/adafruit/ADS1X15-Breakout-Board-PCBs",

--- a/data/platform-examples/README.md
+++ b/data/platform-examples/README.md
@@ -112,14 +112,15 @@ pnpm generate:platform-examples
 
 1. `platform-examples.generated.json` を正本と比較する
 2. 問題なければ必要部分を `platform-examples.json` へ手動マージする
-3. （#183 以降）`pnpm nx run sync-devices:sync` で `devices.json` を再生成し、`product.example` が洗い替えされる
+3. `pnpm nx run sync-devices:sync` で `devices.json` を再生成し、`product.example` が洗い替えされる
 
 ### 手動編集
 
 1. `platform-examples.json` を直接編集する
 2. JSON がパース可能であることを確認する
+3. `pnpm nx run sync-devices:sync` で `devices.json` を再生成する
 
-現時点（#183 未完了）では `devices.json` / `sync-devices` は `platform-examples.json` を参照していません。
+`sync-devices` は `platform-examples.json` を読み込み、`dashboardDeviceId` が一致する device の `product.example` を洗い替えます。
 
 ## 関連 issue
 

--- a/tools/scripts/generate-platform-examples/README.md
+++ b/tools/scripts/generate-platform-examples/README.md
@@ -32,4 +32,4 @@ pnpm generate:platform-examples
 2. `pnpm generate:platform-examples` を実行
 3. `platform-examples.generated.json` と正本を比較
 4. 問題なければ必要部分を `platform-examples.json` へ手動マージ
-5. （#183 以降）`pnpm nx run sync-devices:sync` で `devices.json` を再生成
+5. `pnpm nx run sync-devices:sync` で `devices.json` を再生成

--- a/tools/scripts/sync-devices/README.md
+++ b/tools/scripts/sync-devices/README.md
@@ -1,0 +1,34 @@
+# sync-devices
+
+`partslist.csv` から `apps/web/public/devices.json` を生成するツールです。
+
+## 実行
+
+```bash
+pnpm nx run sync-devices:sync
+```
+
+## 入力
+
+- [`partslist.csv`](https://github.com/chirimen-oh/chirimen.org/blob/master/_data/partslist.csv) — CHIRIMEN 公式パーツリスト（リモート取得）
+- [`data/platform-examples/platform-examples.json`](../../../data/platform-examples/platform-examples.json) — Platform 別 Example 正本（`product.example` 洗い替え用）
+
+## 出力
+
+- [`apps/web/public/devices.json`](../../../apps/web/public/devices.json)
+
+## 処理フロー
+
+1. `partslist.csv` を取得・パースして `DeviceInfo[]` を生成
+2. `platform-examples.json` を読み込む
+3. `dashboardDeviceId` が一致する device の `product.example` を Platform 別 Example で洗い替え
+4. 洗い替え対象外 device の既存 `product.example` は維持
+5. `devices.json` を出力
+
+`platform-specific-examples.json` のような別 JSON は生成しません。
+
+## テスト
+
+```bash
+pnpm nx run sync-devices:test
+```

--- a/tools/scripts/sync-devices/project.json
+++ b/tools/scripts/sync-devices/project.json
@@ -43,7 +43,7 @@
         "{workspaceRoot}/apps/web/public/devices.json"
       ],
       "options": {
-        "command": "node -r @swc-node/register/register tools/scripts/sync-devices/src/sync-devices.ts",
+        "command": "pnpm exec tsx tools/scripts/sync-devices/src/sync-devices.ts",
         "cwd": "{workspaceRoot}"
       },
       "configurations": {}

--- a/tools/scripts/sync-devices/project.json
+++ b/tools/scripts/sync-devices/project.json
@@ -28,6 +28,7 @@
         "{options.reportsDirectory}"
       ],
       "options": {
+        "configFile": "{projectRoot}/vitest.config.ts",
         "reportsDirectory": "{projectRoot}/../../../coverage/tools/scripts/sync-devices"
       },
       "configurations": {

--- a/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
+++ b/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
@@ -5,7 +5,7 @@ import {
   isPlatformSpecificExample,
   type DeviceInfo,
 } from '@chirimen-device-dashboard/shared-types';
-import type { PlatformExampleDeviceEntry } from '../../sync-example-upstreams/src/types';
+import type { PlatformExampleDeviceEntry } from './types';
 import { applyPlatformExamples } from './apply-platform-examples';
 
 const repoRoot = path.resolve(__dirname, '../../../..');

--- a/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
+++ b/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  isPlatformSpecificExample,
+  type DeviceInfo,
+} from '@chirimen-device-dashboard/shared-types';
+import type { PlatformExampleDeviceEntry } from '../../sync-example-upstreams/src/types';
+import { applyPlatformExamples } from './apply-platform-examples';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+const platformExamplesPath = path.join(
+  repoRoot,
+  'data/platform-examples/platform-examples.json'
+);
+
+function loadPlatformExamplesFixture(): PlatformExampleDeviceEntry[] {
+  return JSON.parse(readFileSync(platformExamplesPath, 'utf8'));
+}
+
+function createDevice(
+  id: string,
+  examples: DeviceInfo['product']['example']
+): DeviceInfo {
+  return {
+    id,
+    deviceName: id,
+    tag: 'I2C',
+    category: 'test',
+    description: 'test device',
+    image: './no_image.png',
+    product: {
+      url: 'https://example.com/',
+      example: examples,
+    },
+  };
+}
+
+describe('applyPlatformExamples', () => {
+  it('replaces i2c-adt7410 product.example with 5 platform entries', () => {
+    const platformEntries = loadPlatformExamplesFixture();
+    const devices = [
+      createDevice('i2c-adt7410', [
+        { hardware: 'chirimen', code: 'https://r.chirimen.org/examples/#I2C-ADT7410' },
+        { hardware: 'microbit', code: 'https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410' },
+        { hardware: 'piZero', code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410' },
+      ]),
+    ];
+
+    const { devices: merged, warnings } = applyPlatformExamples(
+      devices,
+      platformEntries
+    );
+
+    expect(warnings).toHaveLength(0);
+    expect(merged[0].product.example).toHaveLength(5);
+  });
+
+  it('includes all required ADT7410 platforms as platform-specific examples', () => {
+    const platformEntries = loadPlatformExamplesFixture();
+    const devices = [createDevice('i2c-adt7410', [])];
+
+    const { devices: merged } = applyPlatformExamples(devices, platformEntries);
+    const examples = merged[0].product.example;
+
+    const platforms = examples
+      .map((example) => example.platform)
+      .filter(Boolean);
+
+    expect(platforms).toEqual([
+      'pizero-esm',
+      'node',
+      'raspi-node',
+      'microbit-driver',
+      'legacy-gc-i2c',
+    ]);
+    expect(examples.every(isPlatformSpecificExample)).toBe(true);
+  });
+
+  it('preserves legacy hardware and code fields for transition compatibility', () => {
+    const platformEntries = loadPlatformExamplesFixture();
+    const devices = [createDevice('i2c-adt7410', [])];
+
+    const { devices: merged } = applyPlatformExamples(devices, platformEntries);
+
+    for (const example of merged[0].product.example) {
+      expect(example.hardware?.trim()).not.toBe('');
+      expect(example.code?.trim()).not.toBe('');
+    }
+  });
+
+  it('keeps product.example unchanged for devices not listed in platform-examples.json', () => {
+    const platformEntries = loadPlatformExamplesFixture();
+    const originalExamples = [
+      { hardware: 'chirimen', code: 'https://r.chirimen.org/examples/#I2C-ADS1015' },
+      {
+        hardware: 'piZero',
+        code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1015',
+      },
+    ];
+    const devices = [
+      createDevice('i2c-ads1015', originalExamples),
+      createDevice('i2c-adt7410', [{ hardware: 'chirimen', code: 'https://example.com' }]),
+    ];
+
+    const { devices: merged } = applyPlatformExamples(devices, platformEntries);
+
+    expect(merged[0].product.example).toEqual(originalExamples);
+    expect(merged[1].product.example).toHaveLength(5);
+  });
+
+  it('warns when platform-examples.json references an unknown dashboardDeviceId', () => {
+    const platformEntries: PlatformExampleDeviceEntry[] = [
+      {
+        dashboardDeviceId: 'i2c-unknown-device',
+        exampleDeviceId: 'unknown',
+        examples: [{ hardware: 'test', code: 'https://example.com' }],
+      },
+    ];
+    const devices = [createDevice('i2c-ads1015', [])];
+
+    const { devices: merged, warnings } = applyPlatformExamples(
+      devices,
+      platformEntries
+    );
+
+    expect(merged[0].product.example).toEqual([]);
+    expect(warnings).toEqual([
+      'platform-examples.json references unknown dashboardDeviceId: i2c-unknown-device',
+    ]);
+  });
+});

--- a/tools/scripts/sync-devices/src/apply-platform-examples.ts
+++ b/tools/scripts/sync-devices/src/apply-platform-examples.ts
@@ -1,5 +1,5 @@
 import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
-import type { PlatformExampleDeviceEntry } from '../../sync-example-upstreams/src/types';
+import type { PlatformExampleDeviceEntry } from './types';
 
 export function applyPlatformExamples(
   devices: DeviceInfo[],

--- a/tools/scripts/sync-devices/src/apply-platform-examples.ts
+++ b/tools/scripts/sync-devices/src/apply-platform-examples.ts
@@ -1,0 +1,38 @@
+import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
+import type { PlatformExampleDeviceEntry } from '../../sync-example-upstreams/src/types';
+
+export function applyPlatformExamples(
+  devices: DeviceInfo[],
+  platformEntries: PlatformExampleDeviceEntry[]
+): { devices: DeviceInfo[]; warnings: string[] } {
+  const examplesByDeviceId = new Map(
+    platformEntries.map((entry) => [entry.dashboardDeviceId, entry.examples])
+  );
+  const deviceIds = new Set(devices.map((device) => device.id));
+  const warnings: string[] = [];
+
+  for (const dashboardDeviceId of examplesByDeviceId.keys()) {
+    if (!deviceIds.has(dashboardDeviceId)) {
+      warnings.push(
+        `platform-examples.json references unknown dashboardDeviceId: ${dashboardDeviceId}`
+      );
+    }
+  }
+
+  const mergedDevices = devices.map((device) => {
+    const platformExamples = examplesByDeviceId.get(device.id);
+    if (!platformExamples) {
+      return device;
+    }
+
+    return {
+      ...device,
+      product: {
+        ...device.product,
+        example: platformExamples.map((example) => ({ ...example })),
+      },
+    };
+  });
+
+  return { devices: mergedDevices, warnings };
+}

--- a/tools/scripts/sync-devices/src/sync-devices.ts
+++ b/tools/scripts/sync-devices/src/sync-devices.ts
@@ -6,6 +6,8 @@ import type {
   ExampleInfo,
   ProductInfo,
 } from '@chirimen-device-dashboard/shared-types';
+import type { PlatformExampleDeviceEntry } from '../../sync-example-upstreams/src/types';
+import { applyPlatformExamples } from './apply-platform-examples';
 
 const PARTSLIST_CSV_URL =
   'https://raw.githubusercontent.com/chirimen-oh/chirimen.org/master/_data/partslist.csv';
@@ -17,6 +19,10 @@ const OUTPUT_PATH = path.join(
   'web',
   'public',
   'devices.json'
+);
+const PLATFORM_EXAMPLES_PATH = path.join(
+  process.cwd(),
+  'data/platform-examples/platform-examples.json'
 );
 
 type DeviceTag =
@@ -180,6 +186,13 @@ export function assignUniqueIds(devices: DeviceInfo[]): DeviceInfo[] {
   });
 }
 
+export function loadPlatformExamples(
+  filePath: string = PLATFORM_EXAMPLES_PATH
+): PlatformExampleDeviceEntry[] {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return JSON.parse(raw) as PlatformExampleDeviceEntry[];
+}
+
 async function main(): Promise<void> {
   console.log('Fetching partslist.csv...');
   const response = await axios.get<string>(PARTSLIST_CSV_URL, {
@@ -200,6 +213,16 @@ async function main(): Promise<void> {
 
   const uniqueDevices = assignUniqueIds(devices);
 
+  console.log('Loading platform-examples.json...');
+  const platformEntries = loadPlatformExamples();
+  const { devices: mergedDevices, warnings } = applyPlatformExamples(
+    uniqueDevices,
+    platformEntries
+  );
+  for (const warning of warnings) {
+    console.warn(`Warning: ${warning}`);
+  }
+
   const outputDir = path.dirname(OUTPUT_PATH);
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
@@ -207,10 +230,10 @@ async function main(): Promise<void> {
 
   fs.writeFileSync(
     OUTPUT_PATH,
-    JSON.stringify(uniqueDevices, null, 2),
+    JSON.stringify(mergedDevices, null, 2),
     'utf-8'
   );
-  console.log(`Wrote ${uniqueDevices.length} devices to ${OUTPUT_PATH}`);
+  console.log(`Wrote ${mergedDevices.length} devices to ${OUTPUT_PATH}`);
 }
 
 if (!process.env.VITEST) {

--- a/tools/scripts/sync-devices/src/sync-devices.ts
+++ b/tools/scripts/sync-devices/src/sync-devices.ts
@@ -6,7 +6,7 @@ import type {
   ExampleInfo,
   ProductInfo,
 } from '@chirimen-device-dashboard/shared-types';
-import type { PlatformExampleDeviceEntry } from '../../sync-example-upstreams/src/types';
+import type { PlatformExampleDeviceEntry } from './types';
 import { applyPlatformExamples } from './apply-platform-examples';
 
 const PARTSLIST_CSV_URL =

--- a/tools/scripts/sync-devices/src/types.ts
+++ b/tools/scripts/sync-devices/src/types.ts
@@ -1,0 +1,7 @@
+import type { ExampleInfo } from '@chirimen-device-dashboard/shared-types';
+
+export interface PlatformExampleDeviceEntry {
+  dashboardDeviceId: string;
+  exampleDeviceId: string;
+  examples: ExampleInfo[];
+}

--- a/tools/scripts/sync-devices/vitest.config.ts
+++ b/tools/scripts/sync-devices/vitest.config.ts
@@ -1,7 +1,16 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   root: __dirname,
+  resolve: {
+    alias: {
+      '@chirimen-device-dashboard/shared-types': path.resolve(
+        __dirname,
+        '../../../libs/shared-types/src/index.ts'
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/tools/scripts/sync-example-upstreams/README.md
+++ b/tools/scripts/sync-example-upstreams/README.md
@@ -32,7 +32,7 @@ Platform 別 Example JSON の生成は [`generate-platform-examples`](../generat
 2. `pnpm generate:platform-examples` を実行
 3. `generated/reports/example-sync-summary.md` と `example-candidates.md` を確認
 4. 問題なければ `platform-examples.generated.json` から必要部分を `platform-examples.json` へ手動マージ
-5. （#183 以降）`pnpm nx run sync-devices:sync` で `devices.json` を再生成
+5. `pnpm nx run sync-devices:sync` で `devices.json` を再生成
 
 ## 要件
 


### PR DESCRIPTION
## Summary

`devices.json` 生成時に `data/platform-examples/platform-examples.json` を読み込み、
`dashboardDeviceId` が一致する device の `product.example` を Platform 別 Example で洗い替える。

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #183
- Part of #177

## What changed?

- `sync-devices` に `applyPlatformExamples` 洗い替えロジックを追加
- `platform-examples.json` を sync パイプラインに統合
- `i2c-adt7410.product.example` を 5 platform の Platform 別 Example に更新
- 洗い替え対象外 device の既存 `product.example` は維持
- 単体テストで洗い替え・非洗い替え・warning を検証
- Nx モジュール境界に合わせ、`PlatformExampleDeviceEntry` を `sync-devices` 内に定義

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `apps/web/public/devices.json` の `i2c-adt7410.product.example` 構造が Platform 別形式に変わる
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx run sync-devices:test` が通ること
2. `pnpm nx run sync-devices:sync` 実行後、`apps/web/public/devices.json` の `i2c-adt7410.product.example` に 5 platform が含まれること
3. 他 device（例: `i2c-ads1015`）の `product.example` が従来形式のままであること
4. `pnpm nx affected -t lint,build,test` が通ること

## Environment (if relevant)

- Browser: N/A（スクリプト変更）
- OS: macOS / Windows / Linux
- Node version: 24
- pnpm version: workspace 準拠

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)