### PR TITLE
feat(libs-device-detail): replace sample section with platform examples

### DIFF
--- a/libs/devices/device-detail/src/lib/product-info/product-info.component.html
+++ b/libs/devices/device-detail/src/lib/product-info/product-info.component.html
@@ -26,13 +26,9 @@
       <h3
         class="text-sm font-semibold mb-3 pb-2 border-b border-black/8 text-black/87 dark:border-white/10 dark:text-white/87"
       >
-        サンプル
+        Platform 別 Example
       </h3>
-      <div class="flex flex-col gap-3">
-        @for (item of product().example; track item.hardware) {
-          <choh-example-info [example]="item" />
-        }
-      </div>
+      <choh-platform-specific-examples [examples]="product().example" />
     </div>
   }
 

--- a/libs/devices/device-detail/src/lib/product-info/product-info.component.spec.ts
+++ b/libs/devices/device-detail/src/lib/product-info/product-info.component.spec.ts
@@ -1,6 +1,34 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { ExampleInfo, ProductInfo } from '@chirimen-device-dashboard/shared-types';
 import { ProductInfoComponent } from './product-info.component';
-import type { ProductInfo } from '@chirimen-device-dashboard/shared-types';
+
+const adt7410PlatformExample: ExampleInfo = {
+  hardware: 'Pi Zero',
+  code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410',
+  deviceId: 'adt7410',
+  platform: 'pizero-esm',
+  localPath: 'examples/devices/adt7410/platforms/pizero-esm',
+  upstreamRepository: 'chirimen-oh/chirimen.org',
+  upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen.org',
+  upstreamPath: 'pizero/src/esm-examples/adt7410',
+  upstreamPathUrl:
+    'https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410',
+  status: 'primary',
+  circuitUrl:
+    'https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png',
+  verified: false,
+};
+
+const legacyOnlyExamples: ExampleInfo[] = [
+  {
+    hardware: 'chirimen',
+    code: 'https://r.chirimen.org/examples/#I2C-ADS1015',
+  },
+  {
+    hardware: 'piZero',
+    code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1015',
+  },
+];
 
 describe('ProductInfoComponent', () => {
   let component: ProductInfoComponent;
@@ -34,5 +62,48 @@ describe('ProductInfoComponent', () => {
     );
     expect(link).toBeTruthy();
     expect(link?.textContent?.trim()).toBe('商品ページを見る');
+  });
+
+  it('should display Platform 別 Example heading for platform-specific examples', () => {
+    fixture.componentRef.setInput('product', {
+      url: 'https://example.com/product',
+      example: [adt7410PlatformExample],
+    });
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const headings = Array.from(compiled.querySelectorAll('h3')).map((h3) =>
+      h3.textContent?.trim(),
+    );
+    expect(headings).toContain('Platform 別 Example');
+    expect(compiled.textContent).toContain('pizero-esm');
+    expect(compiled.querySelector('table')).toBeTruthy();
+  });
+
+  it('should show empty state when only legacy examples are provided', () => {
+    fixture.componentRef.setInput('product', {
+      url: 'https://example.com/product',
+      example: legacyOnlyExamples,
+    });
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Platform 別 Example');
+    expect(compiled.textContent).toContain('Platform 別 Example はありません');
+    expect(compiled.textContent).not.toContain('サンプル');
+    expect(compiled.querySelector('table')).toBeFalsy();
+  });
+
+  it('should filter out legacy examples from mixed input', () => {
+    fixture.componentRef.setInput('product', {
+      url: 'https://example.com/product',
+      example: [...legacyOnlyExamples, adt7410PlatformExample],
+    });
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('pizero-esm');
+    expect(compiled.textContent).not.toContain('I2C-ADS1015');
+    expect(compiled.querySelector('table')).toBeTruthy();
   });
 });

--- a/libs/devices/device-detail/src/lib/product-info/product-info.component.ts
+++ b/libs/devices/device-detail/src/lib/product-info/product-info.component.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
+import { PlatformSpecificExamplesComponent } from '@chirimen-device-dashboard/libs-platform-specific-examples';
 import type { ProductInfo } from '@chirimen-device-dashboard/shared-types';
-import { ExampleInfoComponent } from '../example-info/example-info.component';
 
 @Component({
   selector: 'choh-product-info',
   standalone: true,
-  imports: [MatIconModule, MatListModule, ExampleInfoComponent],
+  imports: [MatIconModule, MatListModule, PlatformSpecificExamplesComponent],
   templateUrl: './product-info.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/libs/devices/device-detail/src/lib/product-info/product-info.component.ts
+++ b/libs/devices/device-detail/src/lib/product-info/product-info.component.ts
@@ -1,13 +1,11 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { MatIconModule } from '@angular/material/icon';
-import { MatListModule } from '@angular/material/list';
 import { PlatformSpecificExamplesComponent } from '@chirimen-device-dashboard/libs-platform-specific-examples';
 import type { ProductInfo } from '@chirimen-device-dashboard/shared-types';
 
 @Component({
   selector: 'choh-product-info',
   standalone: true,
-  imports: [MatIconModule, MatListModule, PlatformSpecificExamplesComponent],
+  imports: [PlatformSpecificExamplesComponent],
   templateUrl: './product-info.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/libs/devices/platform-specific-examples/project.json
+++ b/libs/devices/platform-specific-examples/project.json
@@ -2,7 +2,7 @@
   "name": "libs-platform-specific-examples",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/devices/platform-specific-examples/src",
-  "prefix": "chirimen",
+  "prefix": "choh",
   "projectType": "library",
   "tags": [],
   "targets": {


### PR DESCRIPTION
## Summary

- デバイス詳細の「サンプル」エリアを「Platform 別 Example」に置き換えた
- `DeviceInfo.product.example` を `PlatformSpecificExamplesComponent` に渡し、別 JSON は fetch しない
- Platform 別 Example がない場合は empty state を表示する

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #185
- Parent: #177

## What changed?

- `ProductInfoComponent` の「サンプル」セクションを削除し、「Platform 別 Example」セクションを追加
- `PlatformSpecificExamplesComponent` を `@chirimen-device-dashboard/libs-platform-specific-examples` から import して利用
- `product-info` のテストに platform / legacy / mixed の表示ケースを追加
- 未使用の Material import を `ProductInfoComponent` から削除
- `libs-platform-specific-examples` の project prefix を `choh` に統一

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx test libs-device-detail` を実行し、テストが通ることを確認
2. `pnpm nx serve web` で起動し、`/devices/i2c-adt7410` で 5 Platform の表/カードが表示されることを確認
3. `/devices/i2c-amg8833` で「Platform 別 Example はありません」が表示され、UI が壊れないことを確認
4. DevTools で別 JSON fetch が発生していないことを確認

## Environment (if relevant)

- Browser: Chrome / Safari
- OS: macOS
- Node version: v24.16.0
- pnpm version: 11.5.0

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)