### PR TITLE
feat(libs-platform-specific-examples): polish responsive display and tests

### DIFF
--- a/apps/web-e2e/src/platform-examples.spec.ts
+++ b/apps/web-e2e/src/platform-examples.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Platform 別 Example', () => {
+  test('desktop shows platform examples table for i2c-adt7410', async ({
+    page,
+  }) => {
+    await page.goto('/devices/i2c-adt7410');
+
+    await expect(
+      page.getByRole('heading', { name: 'Platform 別 Example' }),
+    ).toBeVisible();
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+    await expect(table.getByRole('cell', { name: 'pizero-esm' })).toBeVisible();
+    await expect(
+      table.getByRole('cell', { name: 'legacy-gc-i2c' }),
+    ).toBeVisible();
+    await expect(
+      table.locator(
+        'a[href="https://github.com/chirimen-oh/chirimen.org"]',
+      ),
+    ).toBeVisible();
+  });
+
+  test('mobile shows platform example cards', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/devices/i2c-adt7410');
+
+    await expect(
+      page.getByRole('heading', { name: 'Platform 別 Example' }),
+    ).toBeVisible();
+
+    const card = page.locator('choh-platform-specific-example-card').first();
+    await expect(card).toBeVisible();
+    await expect(card.getByText('pizero-esm')).toBeVisible();
+    await expect(page.locator('.hidden.md\\:block table')).toBeHidden();
+  });
+});

--- a/libs/devices/device-detail/src/lib/device-detail/device-detail.component.spec.ts
+++ b/libs/devices/device-detail/src/lib/device-detail/device-detail.component.spec.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   adt7410PlatformExamples,
   legacyOnlyExamples,
-} from '../../../../platform-specific-examples/src/lib/testing/platform-examples.fixture';
+} from '../testing/platform-examples.fixture';
 import { DeviceDetailComponent } from './device-detail.component';
 
 const adt7410Device: DeviceInfo = {

--- a/libs/devices/device-detail/src/lib/device-detail/device-detail.component.spec.ts
+++ b/libs/devices/device-detail/src/lib/device-detail/device-detail.component.spec.ts
@@ -4,14 +4,50 @@ import {
   DEVICE_REPOSITORY,
   type DeviceRepository,
 } from '@chirimen-device-dashboard/libs-data-access';
+import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
 import { of } from 'rxjs';
 import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  adt7410PlatformExamples,
+  legacyOnlyExamples,
+} from '../../../../platform-specific-examples/src/lib/testing/platform-examples.fixture';
 import { DeviceDetailComponent } from './device-detail.component';
 
-const mockRepository: DeviceRepository = {
-  list: () => of([]),
-  get: () => of(null),
+const adt7410Device: DeviceInfo = {
+  id: 'i2c-adt7410',
+  deviceName: 'ADT7410',
+  tag: 'I2C',
+  category: '温度センサ',
+  description: '温度センサ',
+  image: 'https://example.com/adt7410.jpg',
+  product: {
+    url: 'https://example.com/product',
+    example: adt7410PlatformExamples,
+  },
 };
+
+const legacyOnlyDevice: DeviceInfo = {
+  id: 'i2c-ads1015',
+  deviceName: 'ADS1015',
+  tag: 'I2C',
+  category: 'ADC',
+  description: 'ADC',
+  image: 'https://example.com/ads1015.jpg',
+  product: {
+    url: 'https://example.com/product',
+    example: legacyOnlyExamples,
+  },
+};
+
+function createMockRepository(
+  device: DeviceInfo | null,
+): DeviceRepository {
+  return {
+    list: () => of([]),
+    get: (id: string) =>
+      of(device && device.id === id ? device : null),
+  };
+}
 
 describe('DeviceDetailComponent', () => {
   let component: DeviceDetailComponent;
@@ -22,17 +58,69 @@ describe('DeviceDetailComponent', () => {
       imports: [DeviceDetailComponent],
       providers: [
         provideRouter([]),
-        { provide: DEVICE_REPOSITORY, useValue: mockRepository },
+        {
+          provide: DEVICE_REPOSITORY,
+          useValue: createMockRepository(adt7410Device),
+        },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(DeviceDetailComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput('deviceId', 'test-device-1');
+    fixture.componentRef.setInput('deviceId', 'i2c-adt7410');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display Platform 別 Example section with platform names', async () => {
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const headings = Array.from(compiled.querySelectorAll('h3')).map((h3) =>
+      h3.textContent?.trim(),
+    );
+
+    expect(headings).toContain('Platform 別 Example');
+    expect(compiled.textContent).toContain('pizero-esm');
+    expect(compiled.textContent).toContain('node');
+    expect(compiled.textContent).toContain('raspi-node');
+    expect(compiled.textContent).toContain('microbit-driver');
+    expect(compiled.textContent).toContain('legacy-gc-i2c');
+    expect(compiled.querySelector('table')).toBeTruthy();
+    expect(
+      compiled.querySelector(
+        'a[href="https://github.com/chirimen-oh/chirimen.org"]',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('should show empty state when device has only legacy examples', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [DeviceDetailComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: DEVICE_REPOSITORY,
+          useValue: createMockRepository(legacyOnlyDevice),
+        },
+      ],
+    }).compileComponents();
+
+    const legacyFixture = TestBed.createComponent(DeviceDetailComponent);
+    legacyFixture.componentRef.setInput('deviceId', 'i2c-ads1015');
+    legacyFixture.detectChanges();
+    await legacyFixture.whenStable();
+    legacyFixture.detectChanges();
+
+    const compiled = legacyFixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Platform 別 Example');
+    expect(compiled.textContent).toContain('Platform 別 Example はありません');
+    expect(compiled.textContent).not.toContain('I2C-ADS1015');
+    expect(compiled.querySelector('table')).toBeFalsy();
   });
 });

--- a/libs/devices/device-detail/src/lib/testing/platform-examples.fixture.ts
+++ b/libs/devices/device-detail/src/lib/testing/platform-examples.fixture.ts
@@ -1,0 +1,95 @@
+import type { ExampleInfo } from '@chirimen-device-dashboard/shared-types';
+
+export const adt7410PlatformExamples: ExampleInfo[] = [
+  {
+    hardware: 'Pi Zero',
+    code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410',
+    deviceId: 'adt7410',
+    platform: 'pizero-esm',
+    localPath: 'examples/devices/adt7410/platforms/pizero-esm',
+    upstreamRepository: 'chirimen-oh/chirimen.org',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen.org',
+    upstreamPath: 'pizero/src/esm-examples/adt7410',
+    upstreamPathUrl:
+      'https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410',
+    status: 'primary',
+    circuitUrl:
+      'https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png',
+    verified: false,
+  },
+  {
+    hardware: 'Raspberry Pi',
+    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
+    deviceId: 'adt7410',
+    platform: 'node',
+    localPath: 'examples/devices/adt7410/platforms/node',
+    upstreamRepository: 'chirimen-oh/chirimen-drivers',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
+    upstreamPath: 'node-examples/adt7410',
+    upstreamPathUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
+    status: 'legacy',
+    circuitUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png',
+    verified: false,
+  },
+  {
+    hardware: 'Raspberry Pi',
+    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
+    deviceId: 'adt7410',
+    platform: 'raspi-node',
+    localPath: 'examples/devices/adt7410/platforms/raspi-node',
+    upstreamRepository: 'chirimen-oh/chirimen-drivers',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
+    upstreamPath: 'raspi-examples/adt7410',
+    upstreamPathUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
+    status: 'legacy',
+    circuitUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png',
+    verified: false,
+  },
+  {
+    hardware: 'micro:bit',
+    code: 'https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410',
+    deviceId: 'adt7410',
+    platform: 'microbit-driver',
+    localPath: 'examples/devices/adt7410/platforms/microbit-driver',
+    upstreamRepository: 'chirimen-oh/chirimen-drivers',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
+    upstreamPath: 'microbit-examples/adt7410',
+    upstreamPathUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/adt7410',
+    status: 'legacy',
+    circuitUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/adt7410/imgs/pinbit_adt7410.png',
+    verified: false,
+  },
+  {
+    hardware: 'chirimen',
+    code: 'https://r.chirimen.org/examples/#I2C-ADT7410',
+    deviceId: 'adt7410',
+    platform: 'legacy-gc-i2c',
+    localPath: 'examples/devices/adt7410/platforms/legacy-gc-i2c',
+    upstreamRepository: 'chirimen-oh/chirimen',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen',
+    upstreamPath: 'gc/i2c/i2c-ADT7410',
+    upstreamPathUrl:
+      'https://github.com/chirimen-oh/chirimen/tree/master/gc/i2c/i2c-ADT7410',
+    status: 'archive',
+    circuitUrl:
+      'https://github.com/chirimen-oh/chirimen/blob/master/gc/i2c/i2c-ADT7410/schematic.png',
+    verified: false,
+  },
+];
+
+export const legacyOnlyExamples: ExampleInfo[] = [
+  {
+    hardware: 'chirimen',
+    code: 'https://r.chirimen.org/examples/#I2C-ADS1015',
+  },
+  {
+    hardware: 'piZero',
+    code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1015',
+  },
+];

--- a/libs/devices/platform-specific-examples/src/lib/example-status.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/example-status.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getExampleStatusClasses,
+  getExampleStatusLabel,
+} from './example-status';
+
+describe('example-status', () => {
+  it('should return status labels', () => {
+    expect(getExampleStatusLabel('primary')).toBe('primary');
+    expect(getExampleStatusLabel('legacy')).toBe('legacy');
+    expect(getExampleStatusLabel('archive')).toBe('archive');
+  });
+
+  it('should return badge classes for each status', () => {
+    for (const status of [
+      'primary',
+      'legacy',
+      'archive',
+      'special',
+      'incubator',
+    ] as const) {
+      const classes = getExampleStatusClasses(status);
+      expect(classes).toContain('rounded-md');
+      expect(classes).toContain('font-medium');
+    }
+  });
+});

--- a/libs/devices/platform-specific-examples/src/lib/example-status.ts
+++ b/libs/devices/platform-specific-examples/src/lib/example-status.ts
@@ -1,0 +1,33 @@
+import type { ExampleStatus } from '@chirimen-device-dashboard/shared-types';
+
+const STATUS_LABELS: Record<ExampleStatus, string> = {
+  primary: 'primary',
+  legacy: 'legacy',
+  archive: 'archive',
+  special: 'special',
+  incubator: 'incubator',
+};
+
+const STATUS_CLASSES: Record<ExampleStatus, string> = {
+  primary:
+    'bg-[rgba(25,118,210,0.12)] text-[#1565c0] dark:bg-[rgba(66,165,245,0.16)] dark:text-[#90caf9]',
+  legacy:
+    'bg-[rgba(245,124,0,0.12)] text-[#e65100] dark:bg-[rgba(255,183,77,0.16)] dark:text-[#ffcc80]',
+  archive:
+    'bg-black/6 text-black/60 dark:bg-white/10 dark:text-white/60',
+  special:
+    'bg-[rgba(123,31,162,0.12)] text-[#6a1b9a] dark:bg-[rgba(186,104,200,0.16)] dark:text-[#ce93d8]',
+  incubator:
+    'bg-[rgba(46,125,50,0.12)] text-[#2e7d32] dark:bg-[rgba(102,187,106,0.16)] dark:text-[#a5d6a7]',
+};
+
+const BADGE_BASE =
+  'inline-flex text-[0.75rem] font-medium py-1 px-2.5 rounded-md whitespace-nowrap';
+
+export function getExampleStatusLabel(status: ExampleStatus): string {
+  return STATUS_LABELS[status];
+}
+
+export function getExampleStatusClasses(status: ExampleStatus): string {
+  return `${BADGE_BASE} ${STATUS_CLASSES[status]}`;
+}

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.html
@@ -1,8 +1,13 @@
 <div
   class="flex flex-col gap-3 py-4 px-4 bg-black/[0.02] rounded-lg border border-black/6 dark:bg-white/[0.04] dark:border-white/[0.08]"
 >
-  <div class="text-sm font-semibold text-black/87 dark:text-white/87">
-    {{ example().platform }}
+  <div class="flex flex-wrap items-center justify-between gap-2">
+    <div class="text-sm font-semibold text-black/87 dark:text-white/87">
+      {{ example().platform }}
+    </div>
+    <span [class]="getExampleStatusClasses(example().status)">{{
+      getExampleStatusLabel(example().status)
+    }}</span>
   </div>
 
   <div class="flex flex-col gap-1">
@@ -45,15 +50,6 @@
         example().upstreamPath
       }}</span>
     }
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <span class="text-xs font-medium text-black/55 dark:text-white/55"
-      >状態</span
-    >
-    <span class="text-[0.9375rem] text-black/75 dark:text-white/75">{{
-      example().status
-    }}</span>
   </div>
 
   <div class="flex flex-col gap-1">

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.spec.ts
@@ -28,10 +28,19 @@ describe('PlatformSpecificExampleCardComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display platform and status', () => {
+  it('should display platform and status badge in header', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('pizero-esm');
     expect(compiled.textContent).toContain('primary');
+    expect(compiled.querySelector('span.rounded-md')).toBeTruthy();
+  });
+
+  it('should not show separate status label row', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const labels = Array.from(compiled.querySelectorAll('span.text-xs')).map(
+      (el) => el.textContent?.trim(),
+    );
+    expect(labels).not.toContain('状態');
   });
 
   it('should render repository, path, and circuit links', () => {

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.ts
@@ -10,6 +10,10 @@ import type {
   ExampleInfo,
   ExampleStatus,
 } from '@chirimen-device-dashboard/shared-types';
+import {
+  getExampleStatusClasses,
+  getExampleStatusLabel,
+} from '../example-status';
 
 export type PlatformSpecificExample = ExampleInfo & {
   platform: string;
@@ -39,4 +43,7 @@ export class PlatformSpecificExampleCardComponent {
   getSanitizedUrl(url: string): string | null {
     return this.sanitizer.sanitize(SecurityContext.URL, url);
   }
+
+  getExampleStatusLabel = getExampleStatusLabel;
+  getExampleStatusClasses = getExampleStatusClasses;
 }

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
@@ -5,32 +5,32 @@
     Platform 別 Example はありません
   </p>
 } @else {
-  <div class="hidden md:block overflow-x-auto">
-    <table class="w-full border-collapse text-[0.875rem]">
+  <div class="hidden md:block">
+    <table class="w-full border-collapse text-[0.875rem] table-fixed">
       <thead>
         <tr class="border-b border-black/10 dark:border-white/10">
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[12%]"
           >
             Platform
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[18%]"
           >
             Upstream Repository
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[32%]"
           >
             Upstream Path
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[12%]"
           >
             状態
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[10%]"
           >
             回路図
           </th>
@@ -41,17 +41,19 @@
           <tr
             class="border-b border-black/6 last:border-b-0 dark:border-white/[0.06]"
           >
-            <td class="py-3 px-3 align-top text-black/87 dark:text-white/87">
+            <td
+              class="py-3 px-3 align-top text-black/87 dark:text-white/87 whitespace-nowrap"
+            >
               {{ example.platform }}
             </td>
-            <td class="py-3 px-3 align-top">
+            <td class="py-3 px-3 align-top break-all">
               @let repoUrl = getSanitizedUrl(example.upstreamRepositoryUrl ?? '');
               @if (repoUrl) {
                 <a
                   [href]="repoUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 text-[#1976d2] no-underline break-all hover:underline dark:text-[#42a5f5]"
+                  class="inline-flex items-center gap-1 text-[0.875rem] text-[#1976d2] no-underline break-all py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
                 >
                   {{ getRepositoryDisplayName(example) }}
                 </a>
@@ -61,14 +63,14 @@
                 }}</span>
               }
             </td>
-            <td class="py-3 px-3 align-top">
+            <td class="py-3 px-3 align-top break-all">
               @let pathUrl = getSanitizedUrl(example.upstreamPathUrl);
               @if (pathUrl) {
                 <a
                   [href]="pathUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 text-[#1976d2] no-underline break-all hover:underline dark:text-[#42a5f5]"
+                  class="inline-flex items-center gap-1 text-[0.875rem] text-[#1976d2] no-underline break-all py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
                 >
                   {{ example.upstreamPath }}
                 </a>
@@ -78,10 +80,12 @@
                 }}</span>
               }
             </td>
-            <td class="py-3 px-3 align-top text-black/75 dark:text-white/75">
-              {{ example.status }}
+            <td class="py-3 px-3 align-top whitespace-nowrap">
+              <span [class]="getExampleStatusClasses(example.status)">{{
+                getExampleStatusLabel(example.status)
+              }}</span>
             </td>
-            <td class="py-3 px-3 align-top">
+            <td class="py-3 px-3 align-top whitespace-nowrap">
               @if (example.circuitUrl) {
                 @let circuitUrl = getSanitizedUrl(example.circuitUrl);
                 @if (circuitUrl) {
@@ -89,7 +93,7 @@
                     [href]="circuitUrl"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="inline-flex items-center gap-1 text-[#1976d2] no-underline hover:underline dark:text-[#42a5f5]"
+                    class="inline-flex items-center gap-1 text-[0.875rem] text-[#1976d2] no-underline py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
                   >
                     回路図
                   </a>

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
@@ -1,9 +1,13 @@
 @if (platformSpecificExamples().length === 0) {
-  <p
-    class="m-0 text-[0.9375rem] leading-relaxed text-black/55 dark:text-white/55"
+  <div
+    class="py-4 px-4 rounded-lg border border-black/6 bg-black/[0.02] dark:bg-white/[0.04] dark:border-white/[0.08]"
   >
-    Platform 別 Example はありません
-  </p>
+    <p
+      class="m-0 text-[0.9375rem] leading-relaxed text-black/55 dark:text-white/55"
+    >
+      Platform 別 Example はありません
+    </p>
+  </div>
 } @else {
   <div class="hidden md:block">
     <table class="w-full border-collapse text-[0.875rem] table-fixed">

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
@@ -44,6 +44,7 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(compiled.textContent).toContain('Platform 別 Example はありません');
     expect(compiled.querySelector('table')).toBeFalsy();
     expect(compiled.querySelector('choh-platform-specific-example-card')).toBeFalsy();
+    expect(compiled.querySelector('.rounded-lg.border')).toBeTruthy();
   });
 
   it('should filter out legacy examples from mixed input', () => {
@@ -52,6 +53,36 @@ describe('PlatformSpecificExamplesComponent', () => {
 
     expect(component.platformSpecificExamples()).toHaveLength(1);
     expect(component.platformSpecificExamples()[0].platform).toBe('pizero-esm');
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).not.toContain('I2C-ADS1015');
+    expect(compiled.textContent).not.toContain('I2C_ads1015');
+  });
+
+  it('should use responsive layout classes for table and cards', () => {
+    fixture.componentRef.setInput('examples', adt7410PlatformExamples);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const tableWrapper = compiled.querySelector('.hidden.md\\:block');
+    const cardContainer = compiled.querySelector('.md\\:hidden');
+
+    expect(tableWrapper).toBeTruthy();
+    expect(cardContainer).toBeTruthy();
+    expect(compiled.querySelector('.overflow-x-auto')).toBeFalsy();
+  });
+
+  it('should render status badges in table rows', () => {
+    fixture.componentRef.setInput('examples', adt7410PlatformExamples);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const table = compiled.querySelector('table');
+    expect(table).toBeTruthy();
+    expect(table?.textContent).toContain('primary');
+    expect(table?.textContent).toContain('legacy');
+    expect(table?.textContent).toContain('archive');
+    expect(table?.querySelectorAll('tbody span.rounded-md').length).toBe(5);
   });
 
   it('should render table links for repository, path, and circuit', () => {
@@ -75,6 +106,11 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(repoLink).toBeTruthy();
     expect(pathLink).toBeTruthy();
     expect(circuitLink).toBeTruthy();
+
+    for (const link of [repoLink, pathLink, circuitLink]) {
+      expect(link?.getAttribute('target')).toBe('_blank');
+      expect(link?.getAttribute('rel')).toBe('noopener noreferrer');
+    }
   });
 
   it('should render mobile cards for platform-specific examples', () => {

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.ts
@@ -12,6 +12,10 @@ import {
   type ExampleInfo,
 } from '@chirimen-device-dashboard/shared-types';
 import {
+  getExampleStatusClasses,
+  getExampleStatusLabel,
+} from '../example-status';
+import {
   PlatformSpecificExampleCardComponent,
   type PlatformSpecificExample,
 } from '../platform-specific-example-card/platform-specific-example-card.component';
@@ -42,4 +46,7 @@ export class PlatformSpecificExamplesComponent {
   getSanitizedUrl(url: string): string | null {
     return this.sanitizer.sanitize(SecurityContext.URL, url);
   }
+
+  getExampleStatusLabel = getExampleStatusLabel;
+  getExampleStatusClasses = getExampleStatusClasses;
 }


### PR DESCRIPTION
## Summary

Platform 別 Example UI のレスポンシブ表示を調整し、status badge・外部リンク・empty state を改善した。あわせて component / device-detail / E2E のテストを拡充した。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #186
- 親: #177

## What changed?

- PC / タブレット向け table のレイアウト調整（横スクロール依存の解消、リンク・status badge）
- スマホ向け card / empty state の見た目調整
- `libs-platform-specific-examples` / `libs-device-detail` の unit test 拡充
- `i2c-adt7410` デバイス詳細の Platform 別 Example 表示 E2E 追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm exec nx run web:serve` で `/devices/i2c-adt7410` を開く
2. ブラウザ幅 768px 以上で table 表示、status badge・外部リンクを確認
3. 幅 375px 程度で card 表示に切り替わることを確認
4. `pnpm exec nx run libs-platform-specific-examples:test` / `libs-device-detail:test` / `web-e2e:e2e` が通ることを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)