### PR TITLE
fix(libs-platform-specific-examples): fix platform example table layout

### DIFF
--- a/libs/devices/device-detail/src/lib/device-detail/device-detail.component.html
+++ b/libs/devices/device-detail/src/lib/device-detail/device-detail.component.html
@@ -1,4 +1,4 @@
-<div class="max-w-[960px] mx-auto py-6 px-4">
+<div class="max-w-[1120px] mx-auto py-6 px-4">
   @let result = result$ | async;
   @if (result) {
     @if (result.error) {
@@ -20,7 +20,7 @@
           </a>
         </div>
         <div
-          class="grid grid-cols-1 gap-8 items-start md:grid-cols-[320px_1fr]"
+          class="grid grid-cols-1 gap-8 items-start md:grid-cols-[260px_1fr]"
         >
           <div
             class="bg-white md:sticky md:top-4 rounded-xl p-6 shadow-[0_1px_3px_rgba(0,0,0,0.08)] border border-black/6 dark:bg-white/5 dark:border-white/[0.08] dark:shadow-[0_1px_3px_rgba(0,0,0,0.2)]"

--- a/libs/devices/device-detail/src/lib/product-info/product-info.component.html
+++ b/libs/devices/device-detail/src/lib/product-info/product-info.component.html
@@ -21,7 +21,7 @@
 
   @if (product().example.length) {
     <div
-      class="bg-white rounded-lg p-4 px-5 border border-black/6 shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.04] dark:border-white/[0.08] dark:shadow-[0_1px_2px_rgba(0,0,0,0.15)]"
+      class="w-full bg-white rounded-lg p-4 px-4 md:px-6 border border-black/6 shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:bg-white/[0.04] dark:border-white/[0.08] dark:shadow-[0_1px_2px_rgba(0,0,0,0.15)]"
     >
       <h3
         class="text-sm font-semibold mb-3 pb-2 border-b border-black/8 text-black/87 dark:border-white/10 dark:text-white/87"

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
@@ -12,28 +12,32 @@
   <div class="hidden md:block min-w-0">
     <table class="w-full table-fixed border-collapse text-[0.875rem]">
       <colgroup>
-        <col class="w-[18%]" />
-        <col class="w-[16%]" />
-        <col class="w-[32%]" />
-        <col class="w-[14%]" />
-        <col class="w-[20%]" />
+        <col class="w-[17%]" />
+        <col class="w-[24%]" />
+        <col class="w-[30%]" />
+        <col class="w-[12%]" />
+        <col class="w-[17%]" />
       </colgroup>
       <thead>
         <tr class="border-b border-black/10 dark:border-white/10">
           <th
-            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 max-w-0"
           >
-            Platform
+            <span class="block truncate" title="Platform">Platform</span>
           </th>
           <th
-            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 max-w-0"
           >
-            Upstream Repository
+            <span class="block truncate" title="Upstream Repository"
+              >Upstream Repository</span
+            >
           </th>
           <th
-            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 max-w-0"
           >
-            Upstream Path
+            <span class="block truncate" title="Upstream Path"
+              >Upstream Path</span
+            >
           </th>
           <th
             class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
@@ -10,31 +10,31 @@
   </div>
 } @else {
   <div class="hidden md:block">
-    <table class="w-full border-collapse text-[0.875rem] table-fixed">
+    <table class="w-full min-w-full border-collapse text-[0.875rem]">
       <thead>
         <tr class="border-b border-black/10 dark:border-white/10">
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[12%]"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             Platform
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[18%]"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             Upstream Repository
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[32%]"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             Upstream Path
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[12%]"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             状態
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 w-[10%]"
+            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             回路図
           </th>
@@ -50,38 +50,44 @@
             >
               {{ example.platform }}
             </td>
-            <td class="py-3 px-3 align-top break-all">
+            <td class="py-3 px-3 align-top max-w-0">
               @let repoUrl = getSanitizedUrl(example.upstreamRepositoryUrl ?? '');
               @if (repoUrl) {
                 <a
                   [href]="repoUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 text-[0.875rem] text-[#1976d2] no-underline break-all py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
+                  class="block truncate text-[0.875rem] text-[#1976d2] no-underline py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
+                  [attr.title]="getRepositoryDisplayName(example)"
                 >
                   {{ getRepositoryDisplayName(example) }}
                 </a>
               } @else {
-                <span class="text-black/75 dark:text-white/75">{{
-                  getRepositoryDisplayName(example)
-                }}</span>
+                <span
+                  class="block truncate text-black/75 dark:text-white/75"
+                  [attr.title]="getRepositoryDisplayName(example)"
+                  >{{ getRepositoryDisplayName(example) }}</span
+                >
               }
             </td>
-            <td class="py-3 px-3 align-top break-all">
+            <td class="py-3 px-3 align-top max-w-0">
               @let pathUrl = getSanitizedUrl(example.upstreamPathUrl);
               @if (pathUrl) {
                 <a
                   [href]="pathUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 text-[0.875rem] text-[#1976d2] no-underline break-all py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
+                  class="block truncate text-[0.875rem] text-[#1976d2] no-underline py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
+                  [attr.title]="example.upstreamPath"
                 >
                   {{ example.upstreamPath }}
                 </a>
               } @else {
-                <span class="text-black/75 dark:text-white/75">{{
-                  example.upstreamPath
-                }}</span>
+                <span
+                  class="block truncate text-black/75 dark:text-white/75"
+                  [attr.title]="example.upstreamPath"
+                  >{{ example.upstreamPath }}</span
+                >
               }
             </td>
             <td class="py-3 px-3 align-top whitespace-nowrap">

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
@@ -9,32 +9,39 @@
     </p>
   </div>
 } @else {
-  <div class="hidden md:block">
-    <table class="w-full min-w-full border-collapse text-[0.875rem]">
+  <div class="hidden md:block min-w-0">
+    <table class="w-full table-fixed border-collapse text-[0.875rem]">
+      <colgroup>
+        <col class="w-[18%]" />
+        <col class="w-[16%]" />
+        <col class="w-[32%]" />
+        <col class="w-[14%]" />
+        <col class="w-[20%]" />
+      </colgroup>
       <thead>
         <tr class="border-b border-black/10 dark:border-white/10">
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             Platform
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             Upstream Repository
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             Upstream Path
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             状態
           </th>
           <th
-            class="py-2 px-3 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             回路図
           </th>
@@ -45,12 +52,14 @@
           <tr
             class="border-b border-black/6 last:border-b-0 dark:border-white/[0.06]"
           >
-            <td
-              class="py-3 px-3 align-top text-black/87 dark:text-white/87 whitespace-nowrap"
-            >
-              {{ example.platform }}
+            <td class="py-3 px-2 align-top max-w-0">
+              <span
+                class="block truncate text-black/87 dark:text-white/87"
+                [attr.title]="example.platform"
+                >{{ example.platform }}</span
+              >
             </td>
-            <td class="py-3 px-3 align-top max-w-0">
+            <td class="py-3 px-2 align-top max-w-0">
               @let repoUrl = getSanitizedUrl(example.upstreamRepositoryUrl ?? '');
               @if (repoUrl) {
                 <a
@@ -70,7 +79,7 @@
                 >
               }
             </td>
-            <td class="py-3 px-3 align-top max-w-0">
+            <td class="py-3 px-2 align-top max-w-0">
               @let pathUrl = getSanitizedUrl(example.upstreamPathUrl);
               @if (pathUrl) {
                 <a
@@ -90,12 +99,12 @@
                 >
               }
             </td>
-            <td class="py-3 px-3 align-top whitespace-nowrap">
+            <td class="py-3 px-2 align-top whitespace-nowrap">
               <span [class]="getExampleStatusClasses(example.status)">{{
                 getExampleStatusLabel(example.status)
               }}</span>
             </td>
-            <td class="py-3 px-3 align-top whitespace-nowrap">
+            <td class="py-3 px-2 align-top whitespace-nowrap">
               @if (example.circuitUrl) {
                 @let circuitUrl = getSanitizedUrl(example.circuitUrl);
                 @if (circuitUrl) {

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
@@ -12,11 +12,11 @@
   <div class="hidden md:block min-w-0">
     <table class="w-full table-fixed border-collapse text-[0.875rem]">
       <colgroup>
-        <col class="w-[22%]" />
-        <col class="w-[30%]" />
-        <col class="w-[26%]" />
-        <col class="w-[11%]" />
-        <col class="w-[11%]" />
+        <col class="w-[21%]" />
+        <col class="w-[28%]" />
+        <col class="w-[24%]" />
+        <col class="w-[13%]" />
+        <col class="w-[14%]" />
       </colgroup>
       <thead>
         <tr class="border-b border-black/10 dark:border-white/10">
@@ -38,12 +38,12 @@
             >
           </th>
           <th
-            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 pl-2 pr-4 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             状態
           </th>
           <th
-            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
+            class="py-2 pl-3 pr-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
             回路図
           </th>
@@ -96,12 +96,12 @@
                 >
               }
             </td>
-            <td class="py-3 px-2 align-top whitespace-nowrap">
+            <td class="py-3 pl-2 pr-4 align-top whitespace-nowrap">
               <span [class]="getExampleStatusClasses(example.status)">{{
                 getExampleStatusLabel(example.status)
               }}</span>
             </td>
-            <td class="py-3 px-2 align-top whitespace-nowrap">
+            <td class="py-3 pl-3 pr-2 align-top whitespace-nowrap">
               @if (example.circuitUrl) {
                 @let circuitUrl = getSanitizedUrl(example.circuitUrl);
                 @if (circuitUrl) {

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.html
@@ -12,25 +12,23 @@
   <div class="hidden md:block min-w-0">
     <table class="w-full table-fixed border-collapse text-[0.875rem]">
       <colgroup>
-        <col class="w-[17%]" />
-        <col class="w-[24%]" />
+        <col class="w-[22%]" />
         <col class="w-[30%]" />
-        <col class="w-[12%]" />
-        <col class="w-[17%]" />
+        <col class="w-[26%]" />
+        <col class="w-[11%]" />
+        <col class="w-[11%]" />
       </colgroup>
       <thead>
         <tr class="border-b border-black/10 dark:border-white/10">
           <th
-            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 max-w-0"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
-            <span class="block truncate" title="Platform">Platform</span>
+            Platform
           </th>
           <th
-            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 max-w-0"
+            class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 whitespace-nowrap"
           >
-            <span class="block truncate" title="Upstream Repository"
-              >Upstream Repository</span
-            >
+            Upstream Repository
           </th>
           <th
             class="py-2 px-2 text-left font-semibold text-black/70 dark:text-white/80 max-w-0"
@@ -56,31 +54,26 @@
           <tr
             class="border-b border-black/6 last:border-b-0 dark:border-white/[0.06]"
           >
-            <td class="py-3 px-2 align-top max-w-0">
-              <span
-                class="block truncate text-black/87 dark:text-white/87"
-                [attr.title]="example.platform"
-                >{{ example.platform }}</span
-              >
+            <td
+              class="py-3 px-2 align-top text-black/87 dark:text-white/87 whitespace-nowrap"
+            >
+              {{ example.platform }}
             </td>
-            <td class="py-3 px-2 align-top max-w-0">
+            <td class="py-3 px-2 align-top whitespace-nowrap">
               @let repoUrl = getSanitizedUrl(example.upstreamRepositoryUrl ?? '');
               @if (repoUrl) {
                 <a
                   [href]="repoUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="block truncate text-[0.875rem] text-[#1976d2] no-underline py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
-                  [attr.title]="getRepositoryDisplayName(example)"
+                  class="inline-flex items-center gap-1 text-[0.875rem] text-[#1976d2] no-underline py-1 rounded transition-all duration-150 hover:underline hover:bg-[rgba(25,118,210,0.08)] dark:text-[#42a5f5] after:content-['↗'] after:text-[0.75em] after:opacity-70"
                 >
                   {{ getRepositoryDisplayName(example) }}
                 </a>
               } @else {
-                <span
-                  class="block truncate text-black/75 dark:text-white/75"
-                  [attr.title]="getRepositoryDisplayName(example)"
-                  >{{ getRepositoryDisplayName(example) }}</span
-                >
+                <span class="text-black/75 dark:text-white/75">{{
+                  getRepositoryDisplayName(example)
+                }}</span>
               }
             </td>
             <td class="py-3 px-2 align-top max-w-0">

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
@@ -83,9 +83,11 @@ describe('PlatformSpecificExamplesComponent', () => {
 
     const headers = table?.querySelectorAll('thead th');
     expect(headers?.length).toBe(5);
-    for (const header of Array.from(headers ?? [])) {
-      expect(header.classList.contains('whitespace-nowrap')).toBe(true);
-    }
+
+    const repoHeader = table?.querySelector('thead th span[title="Upstream Repository"]');
+    const pathHeader = table?.querySelector('thead th span[title="Upstream Path"]');
+    expect(repoHeader?.classList.contains('truncate')).toBe(true);
+    expect(pathHeader?.classList.contains('truncate')).toBe(true);
 
     const repoLink = compiled.querySelector(
       'table a[href="https://github.com/chirimen-oh/chirimen.org"]',

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
@@ -72,6 +72,36 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(compiled.querySelector('.overflow-x-auto')).toBeFalsy();
   });
 
+  it('should apply nowrap headers and truncate long table cells', () => {
+    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[0]]);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const table = compiled.querySelector('table');
+    expect(table).toBeTruthy();
+    expect(table?.classList.contains('table-fixed')).toBe(false);
+
+    const headers = table?.querySelectorAll('thead th');
+    expect(headers?.length).toBe(5);
+    for (const header of Array.from(headers ?? [])) {
+      expect(header.classList.contains('whitespace-nowrap')).toBe(true);
+    }
+
+    const repoLink = compiled.querySelector(
+      'table a[href="https://github.com/chirimen-oh/chirimen.org"]',
+    );
+    const pathLink = compiled.querySelector(
+      'table a[href="https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410"]',
+    );
+
+    expect(repoLink?.classList.contains('truncate')).toBe(true);
+    expect(pathLink?.classList.contains('truncate')).toBe(true);
+    expect(repoLink?.getAttribute('title')).toBe('chirimen.org');
+    expect(pathLink?.getAttribute('title')).toBe(
+      'pizero/src/esm-examples/adt7410',
+    );
+  });
+
   it('should render status badges in table rows', () => {
     fixture.componentRef.setInput('examples', adt7410PlatformExamples);
     fixture.detectChanges();

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
@@ -79,7 +79,7 @@ describe('PlatformSpecificExamplesComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     const table = compiled.querySelector('table');
     expect(table).toBeTruthy();
-    expect(table?.classList.contains('table-fixed')).toBe(false);
+    expect(table?.classList.contains('table-fixed')).toBe(true);
 
     const headers = table?.querySelectorAll('thead th');
     expect(headers?.length).toBe(5);

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
@@ -72,8 +72,8 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(compiled.querySelector('.overflow-x-auto')).toBeFalsy();
   });
 
-  it('should apply nowrap headers and truncate long table cells', () => {
-    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[0]]);
+  it('should show platform and repository columns without truncation', () => {
+    fixture.componentRef.setInput('examples', adt7410PlatformExamples);
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
@@ -81,24 +81,37 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(table).toBeTruthy();
     expect(table?.classList.contains('table-fixed')).toBe(true);
 
-    const headers = table?.querySelectorAll('thead th');
-    expect(headers?.length).toBe(5);
+    const platformHeader = table?.querySelector('thead th');
+    const repoHeader = table?.querySelectorAll('thead th')[1];
+    expect(platformHeader?.classList.contains('whitespace-nowrap')).toBe(true);
+    expect(repoHeader?.classList.contains('whitespace-nowrap')).toBe(true);
+    expect(repoHeader?.textContent?.trim()).toBe('Upstream Repository');
 
-    const repoHeader = table?.querySelector('thead th span[title="Upstream Repository"]');
-    const pathHeader = table?.querySelector('thead th span[title="Upstream Path"]');
-    expect(repoHeader?.classList.contains('truncate')).toBe(true);
-    expect(pathHeader?.classList.contains('truncate')).toBe(true);
+    const platformCell = table?.querySelector('tbody td');
+    expect(platformCell?.classList.contains('whitespace-nowrap')).toBe(true);
+    expect(platformCell?.classList.contains('truncate')).toBe(false);
 
     const repoLink = compiled.querySelector(
-      'table a[href="https://github.com/chirimen-oh/chirimen.org"]',
+      'table a[href="https://github.com/chirimen-oh/chirimen-drivers"]',
+    );
+    expect(repoLink?.classList.contains('truncate')).toBe(false);
+    expect(repoLink?.textContent?.trim()).toContain('chirimen-drivers');
+  });
+
+  it('should truncate only upstream path cells', () => {
+    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[0]]);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const pathHeader = compiled.querySelector(
+      'thead th span[title="Upstream Path"]',
     );
     const pathLink = compiled.querySelector(
       'table a[href="https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410"]',
     );
 
-    expect(repoLink?.classList.contains('truncate')).toBe(true);
+    expect(pathHeader?.classList.contains('truncate')).toBe(true);
     expect(pathLink?.classList.contains('truncate')).toBe(true);
-    expect(repoLink?.getAttribute('title')).toBe('chirimen.org');
     expect(pathLink?.getAttribute('title')).toBe(
       'pizero/src/esm-examples/adt7410',
     );


### PR DESCRIPTION
## Summary

Platform 別 Example テーブルのレイアウト崩れ（セル折り返し、右端見切れ、ヘッダー重なり、列間余白不足）を修正しました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #203

## What changed?

- `table-fixed` と `colgroup` による列幅配分でテーブルをコンテナ内に収めた
- テーブルヘッダーに `truncate` / `whitespace-nowrap` を適用し、重なりを防止した
- Platform / Upstream Repository 列は全文表示、Upstream Path のみ `truncate` で省略表示
- 状態・回路図列の幅とパディングを調整し、列間の余白を確保した
- デバイス詳細ページの最大幅を 1120px に拡大し、画像列を 260px に縮小してテーブル表示領域を広げた
- Platform 別 Example カードに `w-full` を追加し、横幅を有効活用

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx serve web` でアプリを起動する
2. `http://localhost:4200/devices/i2c-adt7410` にアクセスする
3. Platform 別 Example テーブルで以下を確認する
   - ヘッダーが重ならないこと
   - Platform / Upstream Repository が全文表示されること
   - 回路図列が右端で見切れないこと
   - 状態と回路図の間に適切な余白があること
4. ウィンドウ幅を 375px に縮小し、カードレイアウトに切り替わることを確認する
5. `pnpm nx test libs-platform-specific-examples libs-device-detail` が通ること

## Environment (if relevant)

- Browser: Chrome / Safari
- OS: macOS

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)