### PR TITLE
fix(libs-platform-specific-examples): sort platform examples by status

### DIFF
--- a/libs/devices/platform-specific-examples/src/lib/example-status.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/example-status.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  compareExampleStatus,
   getExampleStatusClasses,
   getExampleStatusLabel,
 } from './example-status';
@@ -9,6 +10,15 @@ describe('example-status', () => {
     expect(getExampleStatusLabel('primary')).toBe('primary');
     expect(getExampleStatusLabel('legacy')).toBe('legacy');
     expect(getExampleStatusLabel('archive')).toBe('archive');
+  });
+
+  it('should compare statuses by priority order', () => {
+    expect(compareExampleStatus('primary', 'legacy')).toBeLessThan(0);
+    expect(compareExampleStatus('legacy', 'archive')).toBeLessThan(0);
+    expect(compareExampleStatus('archive', 'incubator')).toBeLessThan(0);
+    expect(compareExampleStatus('incubator', 'special')).toBeLessThan(0);
+    expect(compareExampleStatus('primary', 'primary')).toBe(0);
+    expect(compareExampleStatus('archive', 'primary')).toBeGreaterThan(0);
   });
 
   it('should return badge classes for each status', () => {

--- a/libs/devices/platform-specific-examples/src/lib/example-status.ts
+++ b/libs/devices/platform-specific-examples/src/lib/example-status.ts
@@ -24,6 +24,21 @@ const STATUS_CLASSES: Record<ExampleStatus, string> = {
 const BADGE_BASE =
   'inline-flex text-[0.75rem] font-medium py-1 px-2.5 rounded-md whitespace-nowrap';
 
+const STATUS_SORT_ORDER: Record<ExampleStatus, number> = {
+  primary: 0,
+  legacy: 1,
+  archive: 2,
+  incubator: 3,
+  special: 4,
+};
+
+export function compareExampleStatus(
+  a: ExampleStatus,
+  b: ExampleStatus,
+): number {
+  return STATUS_SORT_ORDER[a] - STATUS_SORT_ORDER[b];
+}
+
 export function getExampleStatusLabel(status: ExampleStatus): string {
   return STATUS_LABELS[status];
 }

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.spec.ts
@@ -8,7 +8,7 @@ describe('PlatformSpecificExampleCardComponent', () => {
   let component: PlatformSpecificExampleCardComponent;
   let fixture: ComponentFixture<PlatformSpecificExampleCardComponent>;
 
-  const example = adt7410PlatformExamples[0];
+  const example = adt7410PlatformExamples[3];
   if (!isPlatformSpecificExample(example)) {
     throw new Error('fixture example must be platform-specific');
   }

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
@@ -36,6 +36,32 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(compiled.textContent).toContain('legacy-gc-i2c');
   });
 
+  it('should sort platform-specific examples by status priority', () => {
+    fixture.componentRef.setInput('examples', adt7410PlatformExamples);
+    fixture.detectChanges();
+
+    const platforms = component
+      .platformSpecificExamples()
+      .map((example) => example.platform);
+    expect(platforms).toEqual([
+      'pizero-esm',
+      'microbit-driver',
+      'node',
+      'raspi-node',
+      'legacy-gc-i2c',
+    ]);
+  });
+
+  it('should render primary example as the first table row', () => {
+    fixture.componentRef.setInput('examples', adt7410PlatformExamples);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const firstRow = compiled.querySelector('table tbody tr');
+    expect(firstRow?.textContent).toContain('pizero-esm');
+    expect(firstRow?.textContent).toContain('primary');
+  });
+
   it('should show empty state when only legacy examples are provided', () => {
     fixture.componentRef.setInput('examples', legacyOnlyExamples);
     fixture.detectChanges();
@@ -99,7 +125,7 @@ describe('PlatformSpecificExamplesComponent', () => {
   });
 
   it('should truncate only upstream path cells', () => {
-    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[0]]);
+    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[3]]);
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
@@ -131,7 +157,7 @@ describe('PlatformSpecificExamplesComponent', () => {
   });
 
   it('should render table links for repository, path, and circuit', () => {
-    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[0]]);
+    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[3]]);
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.ts
@@ -12,6 +12,7 @@ import {
   type ExampleInfo,
 } from '@chirimen-device-dashboard/shared-types';
 import {
+  compareExampleStatus,
   getExampleStatusClasses,
   getExampleStatusLabel,
 } from '../example-status';
@@ -30,9 +31,12 @@ import {
 export class PlatformSpecificExamplesComponent {
   readonly examples = input.required<ExampleInfo[]>();
 
-  readonly platformSpecificExamples = computed(() =>
-    this.examples().filter(isPlatformSpecificExample),
-  );
+  readonly platformSpecificExamples = computed(() => {
+    const filtered = this.examples().filter(isPlatformSpecificExample);
+    return [...filtered].sort((a, b) =>
+      compareExampleStatus(a.status, b.status),
+    );
+  });
 
   private readonly sanitizer = inject(DomSanitizer);
 

--- a/libs/devices/platform-specific-examples/src/lib/testing/platform-examples.fixture.ts
+++ b/libs/devices/platform-specific-examples/src/lib/testing/platform-examples.fixture.ts
@@ -2,51 +2,19 @@ import type { ExampleInfo } from '@chirimen-device-dashboard/shared-types';
 
 export const adt7410PlatformExamples: ExampleInfo[] = [
   {
-    hardware: 'Pi Zero',
-    code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410',
+    hardware: 'chirimen',
+    code: 'https://r.chirimen.org/examples/#I2C-ADT7410',
     deviceId: 'adt7410',
-    platform: 'pizero-esm',
-    localPath: 'examples/devices/adt7410/platforms/pizero-esm',
-    upstreamRepository: 'chirimen-oh/chirimen.org',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen.org',
-    upstreamPath: 'pizero/src/esm-examples/adt7410',
+    platform: 'legacy-gc-i2c',
+    localPath: 'examples/devices/adt7410/platforms/legacy-gc-i2c',
+    upstreamRepository: 'chirimen-oh/chirimen',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen',
+    upstreamPath: 'gc/i2c/i2c-ADT7410',
     upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410',
-    status: 'primary',
+      'https://github.com/chirimen-oh/chirimen/tree/master/gc/i2c/i2c-ADT7410',
+    status: 'archive',
     circuitUrl:
-      'https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png',
-    verified: false,
-  },
-  {
-    hardware: 'Raspberry Pi',
-    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-    deviceId: 'adt7410',
-    platform: 'node',
-    localPath: 'examples/devices/adt7410/platforms/node',
-    upstreamRepository: 'chirimen-oh/chirimen-drivers',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-    upstreamPath: 'node-examples/adt7410',
-    upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-    status: 'legacy',
-    circuitUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png',
-    verified: false,
-  },
-  {
-    hardware: 'Raspberry Pi',
-    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-    deviceId: 'adt7410',
-    platform: 'raspi-node',
-    localPath: 'examples/devices/adt7410/platforms/raspi-node',
-    upstreamRepository: 'chirimen-oh/chirimen-drivers',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-    upstreamPath: 'raspi-examples/adt7410',
-    upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-    status: 'legacy',
-    circuitUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png',
+      'https://github.com/chirimen-oh/chirimen/blob/master/gc/i2c/i2c-ADT7410/schematic.png',
     verified: false,
   },
   {
@@ -66,19 +34,51 @@ export const adt7410PlatformExamples: ExampleInfo[] = [
     verified: false,
   },
   {
-    hardware: 'chirimen',
-    code: 'https://r.chirimen.org/examples/#I2C-ADT7410',
+    hardware: 'Raspberry Pi',
+    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
     deviceId: 'adt7410',
-    platform: 'legacy-gc-i2c',
-    localPath: 'examples/devices/adt7410/platforms/legacy-gc-i2c',
-    upstreamRepository: 'chirimen-oh/chirimen',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen',
-    upstreamPath: 'gc/i2c/i2c-ADT7410',
+    platform: 'node',
+    localPath: 'examples/devices/adt7410/platforms/node',
+    upstreamRepository: 'chirimen-oh/chirimen-drivers',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
+    upstreamPath: 'node-examples/adt7410',
     upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen/tree/master/gc/i2c/i2c-ADT7410',
-    status: 'archive',
+      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
+    status: 'legacy',
     circuitUrl:
-      'https://github.com/chirimen-oh/chirimen/blob/master/gc/i2c/i2c-ADT7410/schematic.png',
+      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png',
+    verified: false,
+  },
+  {
+    hardware: 'Pi Zero',
+    code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410',
+    deviceId: 'adt7410',
+    platform: 'pizero-esm',
+    localPath: 'examples/devices/adt7410/platforms/pizero-esm',
+    upstreamRepository: 'chirimen-oh/chirimen.org',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen.org',
+    upstreamPath: 'pizero/src/esm-examples/adt7410',
+    upstreamPathUrl:
+      'https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410',
+    status: 'primary',
+    circuitUrl:
+      'https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png',
+    verified: false,
+  },
+  {
+    hardware: 'Raspberry Pi',
+    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
+    deviceId: 'adt7410',
+    platform: 'raspi-node',
+    localPath: 'examples/devices/adt7410/platforms/raspi-node',
+    upstreamRepository: 'chirimen-oh/chirimen-drivers',
+    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
+    upstreamPath: 'raspi-examples/adt7410',
+    upstreamPathUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
+    status: 'legacy',
+    circuitUrl:
+      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png',
     verified: false,
   },
 ];
@@ -96,5 +96,5 @@ export const legacyOnlyExamples: ExampleInfo[] = [
 
 export const mixedExamples: ExampleInfo[] = [
   ...legacyOnlyExamples,
-  adt7410PlatformExamples[0],
+  adt7410PlatformExamples[3],
 ];


### PR DESCRIPTION
## Summary

Platform 別 Example を状態の優先順位（primary > legacy > archive > incubator > special）でソート表示するよう修正しました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #205

## What changed?

- `example-status.ts` に状態比較用の `compareExampleStatus` を追加
- `PlatformSpecificExamplesComponent` の `platformSpecificExamples` computed でフィルタ後にソートを適用
- ADT7410 フィクスチャを production データ順に合わせ、ソートの回帰テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx serve web` でアプリを起動
2. http://localhost:4200/ を開き、ADT7410 のデバイス詳細へ遷移
3. Platform 別 Example の先頭行が `pizero-esm`（primary）であることを確認
4. 続いて legacy 行、最後に `legacy-gc-i2c`（archive）が表示されることを確認
5. `pnpm nx test libs-platform-specific-examples` が成功することを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)