### PR TITLE
feat(sync-devices): migrate legacy examples via url classification for catalog archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ Platform 別 Example の正本データは [`data/platform-examples/platform-exa
 
 編集方法・JSON スキーマ・ID 対応の詳細は [data/platform-examples/README.md](data/platform-examples/README.md) を参照してください。
 
+### chirimen-example-catalog archive 方針
+
+`chirimen-example-catalog` は **runtime dependency として参照しません**。Platform 別 Example の正本は本リポジトリ内の `data/platform-examples/platform-examples.json` です。
+
+| 項目 | 方針 |
+| --- | --- |
+| 正本データ | `data/platform-examples/platform-examples.json` |
+| 生成 | `pnpm generate:devices`（`sync-devices:sync`） |
+| 検証 | `pnpm validate:platform-examples` |
+| upstream 差分確認 | `pnpm sync:example-upstreams` → `generated/reports/` |
+| catalog 参照 | archive 後も不要（移行確認: [#188](https://github.com/gurezo/chirimen-device-dashboard/issues/188)） |
+
+legacy 形式（`hardware` + `code` のみ）だった 39 デバイスは、`code` URL パターンから platform / status を判定して Platform 別 Example に移行済みです。判定ルールは [data/platform-examples/README.md#legacy-code-url-から-platform--status-を判定](data/platform-examples/README.md) を参照してください。
+
 ## Running Tests
 
 ```bash

--- a/apps/web-e2e/src/platform-examples.spec.ts
+++ b/apps/web-e2e/src/platform-examples.spec.ts
@@ -65,6 +65,24 @@ test.describe('Platform 別 Example', () => {
     await expect(table.getByRole('cell', { name: 'pizero-esm' })).toBeVisible();
   });
 
+  test('desktop shows legacy-migrated platform examples for i2c-grove-gesture-paj7620u2', async ({
+    page,
+  }) => {
+    await page.goto('/devices/i2c-grove-gesture-paj7620u2');
+
+    await expect(
+      page.getByRole('heading', { name: 'Platform 別 Example' }),
+    ).toBeVisible();
+
+    const table = page.locator('table');
+    await expect(table).toBeVisible();
+    await expect(
+      table.getByRole('cell', { name: 'chirimen', exact: true }),
+    ).toBeVisible();
+    await expect(table.getByRole('cell', { name: 'pizero-esm' })).toBeVisible();
+    await expect(table.getByRole('link', { name: '回路図 ↗' }).first()).toBeVisible();
+  });
+
   test('mobile shows platform example cards', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto('/devices/i2c-adt7410');

--- a/apps/web/public/devices.json
+++ b/apps/web/public/devices.json
@@ -783,11 +783,31 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#I2C-Grove-Gesture"
+          "code": "https://r.chirimen.org/examples/#I2C-Grove-Gesture",
+          "deviceId": "paj7620",
+          "platform": "chirimen",
+          "localPath": "examples/devices/paj7620/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-Grove-Gesture",
+          "status": "legacy",
+          "circuitUrl": "https://github.com/SeeedDocument/Grove_Gesture_V_1.0/raw/master/res/Grove_-_Gesture_v1.0_sch_pcb.zip",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620",
+          "deviceId": "paj7620",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/paj7620/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620",
+          "status": "primary",
+          "circuitUrl": "https://github.com/SeeedDocument/Grove_Gesture_V_1.0/raw/master/res/Grove_-_Gesture_v1.0_sch_pcb.zip",
+          "verified": false
         }
       ],
       "circuit": "https://github.com/SeeedDocument/Grove_Gesture_V_1.0/raw/master/res/Grove_-_Gesture_v1.0_sch_pcb.zip",
@@ -1106,7 +1126,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner",
+          "deviceId": "qrcodescanner",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/qrcodescanner/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner",
+          "verified": false
         }
       ],
       "reference": "https://shop.m5stack.com/products/qr-code-scanner-unit-stm32f030"
@@ -2597,7 +2627,17 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-seesaw"
+          "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-seesaw",
+          "deviceId": "seesaw",
+          "platform": "chirimen",
+          "localPath": "examples/devices/seesaw/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-seesaw",
+          "status": "legacy",
+          "circuitUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-seesaw",
+          "verified": false
         }
       ]
     }
@@ -2852,7 +2892,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471",
+          "deviceId": "waveshare20471",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/waveshare20471/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471",
+          "verified": false
         }
       ],
       "reference": "https://www.waveshare.com/environment-sensor-hat.htm",
@@ -2871,11 +2921,31 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino"
+          "code": "https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino",
+          "deviceId": "grove-water-level-sensor",
+          "platform": "chirimen",
+          "localPath": "examples/devices/grove-water-level-sensor/platforms/chirimen",
+          "upstreamRepository": "SeeedDocument/Grove-Water-Level-Sensor",
+          "upstreamRepositoryUrl": "https://github.com/SeeedDocument/Grove-Water-Level-Sensor",
+          "upstreamPath": "examples",
+          "upstreamPathUrl": "https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino",
+          "status": "legacy",
+          "circuitUrl": "https://raw.githubusercontent.com/SeeedDocument/Grove-Water-LEVER-Sensor/master/res/Grove%20-%20Water%20Level%20Sensor%20(10CM)_SCH%26PCB.zip",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_grove-water-level-sensor"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_grove-water-level-sensor",
+          "deviceId": "grove-water-level-sensor",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/grove-water-level-sensor/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_grove-water-level-sensor",
+          "status": "primary",
+          "circuitUrl": "https://raw.githubusercontent.com/SeeedDocument/Grove-Water-LEVER-Sensor/master/res/Grove%20-%20Water%20Level%20Sensor%20(10CM)_SCH%26PCB.zip",
+          "verified": false
         }
       ],
       "circuit": "https://raw.githubusercontent.com/SeeedDocument/Grove-Water-LEVER-Sensor/master/res/Grove%20-%20Water%20Level%20Sensor%20(10CM)_SCH%26PCB.zip",
@@ -2895,7 +2965,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_max30102"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_max30102",
+          "deviceId": "max30102",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/max30102/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples/max30102",
+          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/max30102",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_max30102",
+          "verified": false
         }
       ],
       "datasheet": "https://www.analog.com/media/en/technical-documentation/data-sheets/MAX30102.pdf"
@@ -2913,15 +2993,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "led",
+          "platform": "chirimen",
+          "localPath": "examples/devices/led/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "led",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/led/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "led",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/led/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -2938,15 +3048,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "led-1",
+          "platform": "chirimen",
+          "localPath": "examples/devices/led-1/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "led-1",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/led-1/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "led-1",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/led-1/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -2963,15 +3103,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "led-2",
+          "platform": "chirimen",
+          "localPath": "examples/devices/led-2/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "led-2",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/led-2/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "led-2",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/led-2/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -2988,15 +3158,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "150",
+          "platform": "chirimen",
+          "localPath": "examples/devices/150/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "150",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/150/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "150",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/150/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -3013,15 +3213,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "10k",
+          "platform": "chirimen",
+          "localPath": "examples/devices/10k/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "10k",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/10k/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "10k",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/10k/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -3038,15 +3268,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "1k",
+          "platform": "chirimen",
+          "localPath": "examples/devices/1k/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "1k",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/1k/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "1k",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/1k/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -3063,15 +3323,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Button"
+          "code": "https://r.chirimen.org/examples/#GPIO-Button",
+          "deviceId": "2pin",
+          "platform": "chirimen",
+          "localPath": "examples/devices/2pin/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "deviceId": "2pin",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/2pin/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "2pin",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/2pin/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "verified": false
         }
       ]
     }
@@ -3088,15 +3378,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Button"
+          "code": "https://r.chirimen.org/examples/#GPIO-Button",
+          "deviceId": "4pin",
+          "platform": "chirimen",
+          "localPath": "examples/devices/4pin/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "deviceId": "4pin",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/4pin/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "4pin",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/4pin/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "verified": false
         }
       ]
     }
@@ -3113,15 +3433,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Button"
+          "code": "https://r.chirimen.org/examples/#GPIO-Button",
+          "deviceId": "ss-10gl13",
+          "platform": "chirimen",
+          "localPath": "examples/devices/ss-10gl13/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "deviceId": "ss-10gl13",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/ss-10gl13/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "ss-10gl13",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/ss-10gl13/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "verified": false
         }
       ]
     }
@@ -3138,7 +3488,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "tp223",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/tp223/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/gpio-onchange/index.html#gpio",
+          "verified": false
         }
       ],
       "circuit": "https://tutorial.chirimen.org/pizero/esm-examples/gpio-onchange/index.html#gpio",
@@ -3157,15 +3517,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://tutorial.chirimen.org/raspi/section1#section-9"
+          "code": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "deviceId": "2sk4017",
+          "platform": "chirimen",
+          "localPath": "examples/devices/2sk4017/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+          "deviceId": "2sk4017",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/2sk4017/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "2sk4017",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/2sk4017/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         }
       ],
       "circuit": "https://tutorial.chirimen.org/raspi/section1#section-9",
@@ -3184,15 +3574,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://tutorial.chirimen.org/raspi/section1#section-9"
+          "code": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "deviceId": "irf520",
+          "platform": "chirimen",
+          "localPath": "examples/devices/irf520/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+          "deviceId": "irf520",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/irf520/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "irf520",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/irf520/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         }
       ],
       "circuit": "https://tutorial.chirimen.org/raspi/section1#section-9",
@@ -3212,15 +3632,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://tutorial.chirimen.org/raspi/section1#section-9"
+          "code": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "deviceId": "d4184",
+          "platform": "chirimen",
+          "localPath": "examples/devices/d4184/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+          "deviceId": "d4184",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/d4184/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "d4184",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/d4184/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+          "verified": false
         }
       ],
       "circuit": "https://tutorial.chirimen.org/raspi/section1#section-9",
@@ -3336,15 +3786,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-pirSensor"
+          "code": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+          "deviceId": "kp-ir412",
+          "platform": "chirimen",
+          "localPath": "examples/devices/kp-ir412/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+          "deviceId": "kp-ir412",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/kp-ir412/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "kp-ir412",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/kp-ir412/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "verified": false
         }
       ],
       "reference": "http://www.kyohritsu.sakura.ne.jp/prowiki/index.php?%BF%CD%C2%CE%C0%D6%B3%B0%C0%FE%B4%B6%C3%CE%C1%C7%BB%D2%2FKP-IR412"
@@ -3362,15 +3842,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-pirSensor"
+          "code": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+          "deviceId": "hc-sr501",
+          "platform": "chirimen",
+          "localPath": "examples/devices/hc-sr501/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+          "deviceId": "hc-sr501",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/hc-sr501/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "hc-sr501",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/hc-sr501/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "verified": false
         }
       ],
       "reference": "https://www.mpja.com/download/31227sc.pdf"
@@ -3417,7 +3927,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "rd-4p",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/rd-4p/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "verified": false
         }
       ]
     }
@@ -3434,7 +3954,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "deviceId": "m-wl-j3y",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/m-wl-j3y/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+          "verified": false
         }
       ]
     }
@@ -3451,7 +3981,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+          "deviceId": "fsr-400",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/fsr-400/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+          "verified": false
         }
       ]
     }
@@ -3468,7 +4008,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+          "deviceId": "tsr-3386",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/tsr-3386/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+          "verified": false
         }
       ],
       "datasheet": "http://akizukidenshi.com/download/ds/suntan/tsr-3386.pdf"
@@ -3486,15 +4036,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-ADS1115-LoadCell"
+          "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-ADS1115-LoadCell",
+          "deviceId": "device",
+          "platform": "chirimen",
+          "localPath": "examples/devices/device/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-ADS1115-LoadCell",
+          "status": "legacy",
+          "circuitUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-ADS1115-LoadCell",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#I2C_ADS1115_LoadCell"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#I2C_ADS1115_LoadCell",
+          "deviceId": "device",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/device/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#I2C_ADS1115_LoadCell",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#I2C_ADS1115_LoadCell",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1115-loadcell"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1115-loadcell",
+          "deviceId": "device",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/device/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1115-loadcell",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1115-loadcell",
+          "verified": false
         }
       ],
       "datasheet": "https://akizukidenshi.com/catalog/c/cloadcell/"
@@ -3512,11 +4092,31 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#I2C-PCA9685"
+          "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "deviceId": "sg90",
+          "platform": "chirimen",
+          "localPath": "examples/devices/sg90/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "deviceId": "sg90",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/sg90/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "verified": false
         }
       ],
       "datasheet": "http://akizukidenshi.com/download/ds/towerpro/SG90_a.pdf"
@@ -3534,11 +4134,31 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#I2C-PCA9685"
+          "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "deviceId": "mg90s",
+          "platform": "chirimen",
+          "localPath": "examples/devices/mg90s/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "deviceId": "mg90s",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/mg90s/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "verified": false
         }
       ],
       "datasheet": "https://www.towerpro.com.tw/product/mg90s-3/"
@@ -3556,11 +4176,31 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#I2C-PCA9685"
+          "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "deviceId": "es08maii",
+          "platform": "chirimen",
+          "localPath": "examples/devices/es08maii/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "deviceId": "es08maii",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/es08maii/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "verified": false
         }
       ],
       "datasheet": "https://emax-usa.com/products/emx-sv-0275-es08ma-ii-metal-analog-servo"
@@ -3578,11 +4218,31 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#I2C-PCA9685"
+          "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "deviceId": "mg995",
+          "platform": "chirimen",
+          "localPath": "examples/devices/mg995/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "deviceId": "mg995",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/mg995/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+          "verified": false
         }
       ],
       "datasheet": "https://www.towerpro.com.tw/product/mg995/"
@@ -3627,15 +4287,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-A4988"
+          "code": "https://r.chirimen.org/examples/#GPIO-A4988",
+          "deviceId": "ts3692n65",
+          "platform": "chirimen",
+          "localPath": "examples/devices/ts3692n65/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_HBridge"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_HBridge",
+          "deviceId": "ts3692n65",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/ts3692n65/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_HBridge",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_a4988"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_a4988",
+          "deviceId": "ts3692n65",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/ts3692n65/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_a4988",
+          "status": "primary",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+          "verified": false
         }
       ],
       "circuit": "https://r.chirimen.org/examples/#GPIO-A4988"
@@ -3653,11 +4343,31 @@
       "example": [
         {
           "hardware": "microbit",
-          "code": "https://tutorial.chirimen.org/microbit/iot_actuate"
+          "code": "https://tutorial.chirimen.org/microbit/iot_actuate",
+          "deviceId": "device-1",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/device-1/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/#gpio-2"
+          "code": "https://tutorial.chirimen.org/pizero/#gpio-2",
+          "deviceId": "device-1",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/device-1/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+          "verified": false
         }
       ],
       "datasheet": "https://tiisai.dip.jp/?p=2676",
@@ -3676,11 +4386,31 @@
       "example": [
         {
           "hardware": "microbit",
-          "code": "https://tutorial.chirimen.org/microbit/iot_actuate"
+          "code": "https://tutorial.chirimen.org/microbit/iot_actuate",
+          "deviceId": "n20",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/n20/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+          "status": "legacy",
+          "circuitUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/#gpio-2"
+          "code": "https://tutorial.chirimen.org/pizero/#gpio-2",
+          "deviceId": "n20",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/n20/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+          "verified": false
         }
       ],
       "datasheet": "https://akizukidenshi.com/download/ds/mercurymotor/MG1012-0669-150L.pdf",
@@ -3723,11 +4453,31 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#OTHERS-CAMERA"
+          "code": "https://r.chirimen.org/examples/#OTHERS-CAMERA",
+          "deviceId": "device-2",
+          "platform": "chirimen",
+          "localPath": "examples/devices/device-2/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#OTHERS-CAMERA",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#OTHERS-CAMERA",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-camera"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-camera",
+          "deviceId": "device-2",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/device-2/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-camera",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-camera",
+          "verified": false
         }
       ]
     }
@@ -3793,15 +4543,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "device",
+          "platform": "chirimen",
+          "localPath": "examples/devices/device/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "device",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/device/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "device",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/device/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -3818,15 +4598,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "device-1",
+          "platform": "chirimen",
+          "localPath": "examples/devices/device-1/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "device-1",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/device-1/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "device-1",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/device-1/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -3843,15 +4653,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "device-2",
+          "platform": "chirimen",
+          "localPath": "examples/devices/device-2/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "device-2",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/device-2/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "device-2",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/device-2/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -3868,15 +4708,45 @@
       "example": [
         {
           "hardware": "chirimen",
-          "code": "https://r.chirimen.org/examples/#GPIO-Blink"
+          "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "deviceId": "device-3",
+          "platform": "chirimen",
+          "localPath": "examples/devices/device-3/platforms/chirimen",
+          "upstreamRepository": "chirimen-oh/chirimen",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+          "upstreamPath": "gc/examples",
+          "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "status": "legacy",
+          "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+          "verified": false
         },
         {
           "hardware": "microbit",
-          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1"
+          "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "deviceId": "device-3",
+          "platform": "microbit-driver",
+          "localPath": "examples/devices/device-3/platforms/microbit-driver",
+          "upstreamRepository": "chirimen-oh/chirimen-drivers",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+          "upstreamPath": "microbit-examples",
+          "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "status": "legacy",
+          "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+          "verified": false
         },
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "deviceId": "device-3",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/device-3/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+          "verified": false
         }
       ]
     }
@@ -3949,7 +4819,17 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_serial_gps"
+          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_serial_gps",
+          "deviceId": "gy-gps6mv2",
+          "platform": "pizero-esm",
+          "localPath": "examples/devices/gy-gps6mv2/platforms/pizero-esm",
+          "upstreamRepository": "chirimen-oh/chirimen.org",
+          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+          "upstreamPath": "pizero/src/esm-examples",
+          "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_serial_gps",
+          "status": "primary",
+          "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_serial_gps",
+          "verified": false
         }
       ],
       "datasheet": "https://content.u-blox.com/sites/default/files/products/documents/NEO-6_DataSheet_%28GPS.G6-HW-09005%29.pdf"

--- a/data/example-upstreams/device-id-overrides.yaml
+++ b/data/example-upstreams/device-id-overrides.yaml
@@ -12,3 +12,9 @@ overrides:
     - gpio-l9110s
     - gpio-mx1508
     - actuator-device
+  paj7620: i2c-grove-gesture-paj7620u2
+  max30102: i2c-max30102
+  qrcodescanner: i2c-m5-qr-stm32f030
+  waveshare20471: i2c-waveshare-20471
+  grove-water-level-sensor: i2c-grove
+  seesaw: i2c-seesaw

--- a/data/platform-examples/README.md
+++ b/data/platform-examples/README.md
@@ -124,6 +124,41 @@ pnpm generate:platform-examples
 
 `sync-devices` は `platform-examples.json` を読み込み、`dashboardDeviceId` が一致する device の `product.example` を洗い替えます。
 
+## legacy `code` URL から platform / status を判定
+
+partslist.csv 由来の legacy Example（`hardware` + `code` のみ）を Platform 別 Example に移行する際、`code` URL パターンから platform / status を判定します（[#188](https://github.com/gurezo/chirimen-device-dashboard/issues/188)）。
+
+判定順序は具体パス優先です（`pizero/esm-examples` を `pizero/` より先に評価）。
+
+| `code` URL パターン | platform | status |
+| --- | --- | --- |
+| `tutorial.chirimen.org/pizero/esm-examples` | `pizero-esm` | `primary` |
+| `tutorial.chirimen.org/pizero/`（esm-examples 以外） | `pizero-esm` | `primary` |
+| `r.chirimen.org/examples` | `chirimen` | `legacy` |
+| `chirimen.org/chirimen/gc/top/examples` | `chirimen` | `legacy` |
+| `tutorial.chirimen.org/raspi` | `chirimen` | `legacy` |
+| `chirimen.org/examples`（上記以外） | `chirimen` | `legacy` |
+| `chirimen.org/chirimen-micro-bit/examples` | `microbit-driver` | `legacy` |
+| `tutorial.chirimen.org/microbit` | `microbit-driver` | `legacy` |
+| 外部 GitHub 等 | `chirimen` | `legacy` |
+
+### 適用例: `i2c-grove-gesture-paj7620u2`
+
+| legacy `code` | 判定結果 |
+| --- | --- |
+| `https://r.chirimen.org/examples/#I2C-Grove-Gesture` | platform: `chirimen`, status: `legacy` |
+| `https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620` | platform: `pizero-esm`, status: `primary` |
+
+legacy 39 件の bootstrap は以下で実行できます。
+
+```bash
+pnpm exec tsx tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples-main.ts --write
+pnpm generate:devices
+pnpm validate:platform-examples
+```
+
+実装: [`tools/scripts/sync-devices/src/classify-legacy-example-url.ts`](../../tools/scripts/sync-devices/src/classify-legacy-example-url.ts)
+
 ## Validation
 
 Platform 別 Example 元データと `devices.json` の `product.example` を検証する場合:
@@ -181,3 +216,4 @@ pnpm generate:devices
 - [#183](https://github.com/gurezo/chirimen-device-dashboard/issues/183) — `devices.json` 生成時の洗い替え
 - [#189](https://github.com/gurezo/chirimen-device-dashboard/issues/189) — validation / reports ツール
 - [#187](https://github.com/gurezo/chirimen-device-dashboard/issues/187) — Example 同期・生成・検証用 GitHub Actions
+- [#188](https://github.com/gurezo/chirimen-device-dashboard/issues/188) — catalog archive 前の移行確認（legacy URL 判定による 39 件移行）

--- a/data/platform-examples/platform-examples.generated.json
+++ b/data/platform-examples/platform-examples.generated.json
@@ -872,6 +872,26 @@
     ]
   },
   {
+    "dashboardDeviceId": "i2c-grove",
+    "exampleDeviceId": "grove-water-level-sensor",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_grove-water-level-sensor",
+        "deviceId": "grove-water-level-sensor",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/grove-water-level-sensor/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/grove-water-level-sensor",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/grove-water-level-sensor",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/grove-water-level-sensor/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-grove-accelerometer-adxl345",
     "exampleDeviceId": "adxl345",
     "examples": [
@@ -915,6 +935,54 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adxl345/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-grove-gesture-paj7620u2",
+    "exampleDeviceId": "paj7620",
+    "examples": [
+      {
+        "hardware": "Raspberry Pi",
+        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/paj7620",
+        "deviceId": "paj7620",
+        "platform": "node",
+        "localPath": "examples/devices/paj7620/platforms/node",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "node-examples/paj7620",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/paj7620",
+        "status": "legacy",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/paj7620/schematic.png",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620",
+        "deviceId": "paj7620",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/paj7620/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/paj7620",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/paj7620",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/paj7620/schematic.png",
+        "verified": false
+      },
+      {
+        "hardware": "Raspberry Pi",
+        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/paj7620",
+        "deviceId": "paj7620",
+        "platform": "raspi-node",
+        "localPath": "examples/devices/paj7620/platforms/raspi-node",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "raspi-examples/paj7620",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/paj7620",
+        "status": "legacy",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/paj7620/schematic.png",
         "verified": false
       }
     ]
@@ -1320,6 +1388,26 @@
     ]
   },
   {
+    "dashboardDeviceId": "i2c-m5-qr-stm32f030",
+    "exampleDeviceId": "qrcodescanner",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner",
+        "deviceId": "qrcodescanner",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/qrcodescanner/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/qrcodescanner",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/qrcodescanner",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/qrcodescanner/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-m5-rfid-2-ws1850s",
     "exampleDeviceId": "ws1850s",
     "examples": [
@@ -1344,8 +1432,8 @@
     "exampleDeviceId": "max30102",
     "examples": [
       {
-        "hardware": "Pi Zero",
-        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/max30102",
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_max30102",
         "deviceId": "max30102",
         "platform": "pizero-esm",
         "localPath": "examples/devices/max30102/platforms/pizero-esm",
@@ -1354,7 +1442,8 @@
         "upstreamPath": "pizero/src/esm-examples/max30102",
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/max30102",
         "status": "primary",
-        "verified": false
+        "verified": false,
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_max30102"
       }
     ]
   },
@@ -2495,6 +2584,26 @@
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl6180x/schematic.png",
         "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-waveshare-20471",
+    "exampleDeviceId": "waveshare20471",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471",
+        "deviceId": "waveshare20471",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/waveshare20471/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/waveshare20471",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/waveshare20471",
+        "status": "primary",
+        "verified": false,
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471"
       }
     ]
   }

--- a/data/platform-examples/platform-examples.json
+++ b/data/platform-examples/platform-examples.json
@@ -20,6 +20,674 @@
     ]
   },
   {
+    "dashboardDeviceId": "actuator-device-1",
+    "exampleDeviceId": "device-1",
+    "examples": [
+      {
+        "hardware": "microbit",
+        "code": "https://tutorial.chirimen.org/microbit/iot_actuate",
+        "deviceId": "device-1",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/device-1/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/#gpio-2",
+        "deviceId": "device-1",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/device-1/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "actuator-es08maii",
+    "exampleDeviceId": "es08maii",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "deviceId": "es08maii",
+        "platform": "chirimen",
+        "localPath": "examples/devices/es08maii/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "deviceId": "es08maii",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/es08maii/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "actuator-mg90s",
+    "exampleDeviceId": "mg90s",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "deviceId": "mg90s",
+        "platform": "chirimen",
+        "localPath": "examples/devices/mg90s/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "deviceId": "mg90s",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/mg90s/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "actuator-mg995",
+    "exampleDeviceId": "mg995",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "deviceId": "mg995",
+        "platform": "chirimen",
+        "localPath": "examples/devices/mg995/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "deviceId": "mg995",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/mg995/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "actuator-n20",
+    "exampleDeviceId": "n20",
+    "examples": [
+      {
+        "hardware": "microbit",
+        "code": "https://tutorial.chirimen.org/microbit/iot_actuate",
+        "deviceId": "n20",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/n20/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/microbit/iot_actuate",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/#gpio-2",
+        "deviceId": "n20",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/n20/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/#gpio-2",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "actuator-sg90",
+    "exampleDeviceId": "sg90",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "deviceId": "sg90",
+        "platform": "chirimen",
+        "localPath": "examples/devices/sg90/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#I2C-PCA9685",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "deviceId": "sg90",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/sg90/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_pca9685",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "actuator-ts3692n65",
+    "exampleDeviceId": "ts3692n65",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-A4988",
+        "deviceId": "ts3692n65",
+        "platform": "chirimen",
+        "localPath": "examples/devices/ts3692n65/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_HBridge",
+        "deviceId": "ts3692n65",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/ts3692n65/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_HBridge",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_a4988",
+        "deviceId": "ts3692n65",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/ts3692n65/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_a4988",
+        "status": "primary",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-A4988",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "analog-device",
+    "exampleDeviceId": "device",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-ADS1115-LoadCell",
+        "deviceId": "device",
+        "platform": "chirimen",
+        "localPath": "examples/devices/device/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-ADS1115-LoadCell",
+        "status": "legacy",
+        "circuitUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-ADS1115-LoadCell",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#I2C_ADS1115_LoadCell",
+        "deviceId": "device",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/device/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#I2C_ADS1115_LoadCell",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#I2C_ADS1115_LoadCell",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1115-loadcell",
+        "deviceId": "device",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/device/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1115-loadcell",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1115-loadcell",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "analog-fsr-400",
+    "exampleDeviceId": "fsr-400",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+        "deviceId": "fsr-400",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/fsr-400/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "analog-m-wl-j3y",
+    "exampleDeviceId": "m-wl-j3y",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "m-wl-j3y",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/m-wl-j3y/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "analog-rd-4p",
+    "exampleDeviceId": "rd-4p",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "rd-4p",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/rd-4p/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "analog-tsr-3386",
+    "exampleDeviceId": "tsr-3386",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+        "deviceId": "tsr-3386",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/tsr-3386/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_ads1x15",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-10k",
+    "exampleDeviceId": "10k",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "10k",
+        "platform": "chirimen",
+        "localPath": "examples/devices/10k/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "10k",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/10k/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "10k",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/10k/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-150",
+    "exampleDeviceId": "150",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "150",
+        "platform": "chirimen",
+        "localPath": "examples/devices/150/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "150",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/150/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "150",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/150/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-1k",
+    "exampleDeviceId": "1k",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "1k",
+        "platform": "chirimen",
+        "localPath": "examples/devices/1k/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "1k",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/1k/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "1k",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/1k/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-2pin",
+    "exampleDeviceId": "2pin",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Button",
+        "deviceId": "2pin",
+        "platform": "chirimen",
+        "localPath": "examples/devices/2pin/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "deviceId": "2pin",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/2pin/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "2pin",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/2pin/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-2sk4017",
+    "exampleDeviceId": "2sk4017",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "deviceId": "2sk4017",
+        "platform": "chirimen",
+        "localPath": "examples/devices/2sk4017/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+        "deviceId": "2sk4017",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/2sk4017/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "2sk4017",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/2sk4017/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-4pin",
+    "exampleDeviceId": "4pin",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Button",
+        "deviceId": "4pin",
+        "platform": "chirimen",
+        "localPath": "examples/devices/4pin/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "deviceId": "4pin",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/4pin/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "4pin",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/4pin/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "gpio-a4988",
     "exampleDeviceId": "a4988",
     "examples": [
@@ -35,6 +703,246 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/a4988",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/a4988/Schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-d4184",
+    "exampleDeviceId": "d4184",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "deviceId": "d4184",
+        "platform": "chirimen",
+        "localPath": "examples/devices/d4184/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+        "deviceId": "d4184",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/d4184/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "d4184",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/d4184/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-device",
+    "exampleDeviceId": "device",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "device",
+        "platform": "chirimen",
+        "localPath": "examples/devices/device/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "device",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/device/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "device",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/device/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-device-1",
+    "exampleDeviceId": "device-1",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "device-1",
+        "platform": "chirimen",
+        "localPath": "examples/devices/device-1/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "device-1",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/device-1/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "device-1",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/device-1/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-device-2",
+    "exampleDeviceId": "device-2",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "device-2",
+        "platform": "chirimen",
+        "localPath": "examples/devices/device-2/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "device-2",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/device-2/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "device-2",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/device-2/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-device-3",
+    "exampleDeviceId": "device-3",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "device-3",
+        "platform": "chirimen",
+        "localPath": "examples/devices/device-3/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "device-3",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/device-3/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "device-3",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/device-3/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
         "verified": false
       }
     ]
@@ -60,6 +968,102 @@
     ]
   },
   {
+    "dashboardDeviceId": "gpio-hc-sr501",
+    "exampleDeviceId": "hc-sr501",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+        "deviceId": "hc-sr501",
+        "platform": "chirimen",
+        "localPath": "examples/devices/hc-sr501/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+        "deviceId": "hc-sr501",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/hc-sr501/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "hc-sr501",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/hc-sr501/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-irf520",
+    "exampleDeviceId": "irf520",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "deviceId": "irf520",
+        "platform": "chirimen",
+        "localPath": "examples/devices/irf520/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+        "deviceId": "irf520",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/irf520/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO3",
+        "status": "legacy",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "irf520",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/irf520/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/raspi/section1#section-9",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "gpio-isd1820",
     "exampleDeviceId": "isd1820",
     "examples": [
@@ -75,6 +1079,54 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/isd1820",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/isd1820/ISD1820.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-kp-ir412",
+    "exampleDeviceId": "kp-ir412",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+        "deviceId": "kp-ir412",
+        "platform": "chirimen",
+        "localPath": "examples/devices/kp-ir412/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-pirSensor",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+        "deviceId": "kp-ir412",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/kp-ir412/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO_PYR",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "kp-ir412",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/kp-ir412/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
         "verified": false
       }
     ]
@@ -120,6 +1172,150 @@
     ]
   },
   {
+    "dashboardDeviceId": "gpio-led",
+    "exampleDeviceId": "led",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "led",
+        "platform": "chirimen",
+        "localPath": "examples/devices/led/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "led",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/led/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "led",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/led/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-led-1",
+    "exampleDeviceId": "led-1",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "led-1",
+        "platform": "chirimen",
+        "localPath": "examples/devices/led-1/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "led-1",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/led-1/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "led-1",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/led-1/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-led-2",
+    "exampleDeviceId": "led-2",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "deviceId": "led-2",
+        "platform": "chirimen",
+        "localPath": "examples/devices/led-2/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Blink",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "deviceId": "led-2",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/led-2/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO1",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "deviceId": "led-2",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/led-2/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-real-world",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "gpio-mx1508",
     "exampleDeviceId": "hbridge1",
     "examples": [
@@ -135,6 +1331,74 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/hbridge1",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/hbridge1/l298n_wiring.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-ss-10gl13",
+    "exampleDeviceId": "ss-10gl13",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#GPIO-Button",
+        "deviceId": "ss-10gl13",
+        "platform": "chirimen",
+        "localPath": "examples/devices/ss-10gl13/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#GPIO-Button",
+        "verified": false
+      },
+      {
+        "hardware": "microbit",
+        "code": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "deviceId": "ss-10gl13",
+        "platform": "microbit-driver",
+        "localPath": "examples/devices/ss-10gl13/platforms/microbit-driver",
+        "upstreamRepository": "chirimen-oh/chirimen-drivers",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
+        "upstreamPath": "microbit-examples",
+        "upstreamPathUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "status": "legacy",
+        "circuitUrl": "https://chirimen.org/chirimen-micro-bit/examples/#GPIO0",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "ss-10gl13",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/ss-10gl13/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "gpio-tp223",
+    "exampleDeviceId": "tp223",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "deviceId": "tp223",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/tp223/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-onchange",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/gpio-onchange/index.html#gpio",
         "verified": false
       }
     ]
@@ -872,6 +2136,40 @@
     ]
   },
   {
+    "dashboardDeviceId": "i2c-grove",
+    "exampleDeviceId": "grove-water-level-sensor",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino",
+        "deviceId": "grove-water-level-sensor",
+        "platform": "chirimen",
+        "localPath": "examples/devices/grove-water-level-sensor/platforms/chirimen",
+        "upstreamRepository": "SeeedDocument/Grove-Water-Level-Sensor",
+        "upstreamRepositoryUrl": "https://github.com/SeeedDocument/Grove-Water-Level-Sensor",
+        "upstreamPath": "examples",
+        "upstreamPathUrl": "https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino",
+        "status": "legacy",
+        "circuitUrl": "https://raw.githubusercontent.com/SeeedDocument/Grove-Water-LEVER-Sensor/master/res/Grove%20-%20Water%20Level%20Sensor%20(10CM)_SCH%26PCB.zip",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_grove-water-level-sensor",
+        "deviceId": "grove-water-level-sensor",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/grove-water-level-sensor/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_grove-water-level-sensor",
+        "status": "primary",
+        "circuitUrl": "https://raw.githubusercontent.com/SeeedDocument/Grove-Water-LEVER-Sensor/master/res/Grove%20-%20Water%20Level%20Sensor%20(10CM)_SCH%26PCB.zip",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-grove-accelerometer-adxl345",
     "exampleDeviceId": "adxl345",
     "examples": [
@@ -915,6 +2213,40 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adxl345/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-grove-gesture-paj7620u2",
+    "exampleDeviceId": "paj7620",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#I2C-Grove-Gesture",
+        "deviceId": "paj7620",
+        "platform": "chirimen",
+        "localPath": "examples/devices/paj7620/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#I2C-Grove-Gesture",
+        "status": "legacy",
+        "circuitUrl": "https://github.com/SeeedDocument/Grove_Gesture_V_1.0/raw/master/res/Grove_-_Gesture_v1.0_sch_pcb.zip",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620",
+        "deviceId": "paj7620",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/paj7620/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620",
+        "status": "primary",
+        "circuitUrl": "https://github.com/SeeedDocument/Grove_Gesture_V_1.0/raw/master/res/Grove_-_Gesture_v1.0_sch_pcb.zip",
         "verified": false
       }
     ]
@@ -1320,6 +2652,26 @@
     ]
   },
   {
+    "dashboardDeviceId": "i2c-m5-qr-stm32f030",
+    "exampleDeviceId": "qrcodescanner",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner",
+        "deviceId": "qrcodescanner",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/qrcodescanner/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_qrcodescanner",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-m5-rfid-2-ws1850s",
     "exampleDeviceId": "ws1850s",
     "examples": [
@@ -1335,6 +2687,26 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ws1850s",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ws1850s/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-max30102",
+    "exampleDeviceId": "max30102",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_max30102",
+        "deviceId": "max30102",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/max30102/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/max30102",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/max30102",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_max30102",
         "verified": false
       }
     ]
@@ -2014,6 +3386,26 @@
     ]
   },
   {
+    "dashboardDeviceId": "i2c-seesaw",
+    "exampleDeviceId": "seesaw",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-seesaw",
+        "deviceId": "seesaw",
+        "platform": "chirimen",
+        "localPath": "examples/devices/seesaw/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-seesaw",
+        "status": "legacy",
+        "circuitUrl": "http://chirimen.org/chirimen/gc/top/examples/#I2C-seesaw",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-sgp40",
     "exampleDeviceId": "sgp40",
     "examples": [
@@ -2475,6 +3867,80 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl6180x",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl6180x/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-waveshare-20471",
+    "exampleDeviceId": "waveshare20471",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471",
+        "deviceId": "waveshare20471",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/waveshare20471/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_waveshare20471",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "other-device-2",
+    "exampleDeviceId": "device-2",
+    "examples": [
+      {
+        "hardware": "chirimen",
+        "code": "https://r.chirimen.org/examples/#OTHERS-CAMERA",
+        "deviceId": "device-2",
+        "platform": "chirimen",
+        "localPath": "examples/devices/device-2/platforms/chirimen",
+        "upstreamRepository": "chirimen-oh/chirimen",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen",
+        "upstreamPath": "gc/examples",
+        "upstreamPathUrl": "https://r.chirimen.org/examples/#OTHERS-CAMERA",
+        "status": "legacy",
+        "circuitUrl": "https://r.chirimen.org/examples/#OTHERS-CAMERA",
+        "verified": false
+      },
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-camera",
+        "deviceId": "device-2",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/device-2/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-camera",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_gpio-camera",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "other-gy-gps6mv2",
+    "exampleDeviceId": "gy-gps6mv2",
+    "examples": [
+      {
+        "hardware": "piZero",
+        "code": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_serial_gps",
+        "deviceId": "gy-gps6mv2",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/gy-gps6mv2/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples",
+        "upstreamPathUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_serial_gps",
+        "status": "primary",
+        "circuitUrl": "https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_serial_gps",
         "verified": false
       }
     ]

--- a/tools/scripts/sync-devices/README.md
+++ b/tools/scripts/sync-devices/README.md
@@ -32,3 +32,14 @@ pnpm nx run sync-devices:sync
 ```bash
 pnpm nx run sync-devices:test
 ```
+
+## legacy Platform 別 Example の bootstrap
+
+partslist.csv 由来の legacy Example を Platform 別形式に変換して `platform-examples.json` へ追記する場合:
+
+```bash
+pnpm exec tsx tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples-main.ts --write
+pnpm nx run sync-devices:sync
+```
+
+判定ルールは [data/platform-examples/README.md](../../../data/platform-examples/README.md) を参照してください。

--- a/tools/scripts/sync-devices/project.json
+++ b/tools/scripts/sync-devices/project.json
@@ -47,6 +47,14 @@
         "cwd": "{workspaceRoot}"
       },
       "configurations": {}
+    },
+    "bootstrap-legacy-platform-examples": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec tsx tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples-main.ts",
+        "cwd": "{workspaceRoot}"
+      },
+      "configurations": {}
     }
   }
 }

--- a/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
+++ b/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
@@ -18,6 +18,22 @@ function loadPlatformExamplesFixture(): PlatformExampleDeviceEntry[] {
   return JSON.parse(readFileSync(platformExamplesPath, 'utf8'));
 }
 
+function loadPlatformEntry(
+  dashboardDeviceId: string
+): PlatformExampleDeviceEntry[] {
+  const entry = loadPlatformExamplesFixture().find(
+    (item) => item.dashboardDeviceId === dashboardDeviceId
+  );
+
+  if (!entry) {
+    throw new Error(
+      `platform-examples.json does not contain dashboardDeviceId: ${dashboardDeviceId}`
+    );
+  }
+
+  return [entry];
+}
+
 function createDevice(
   id: string,
   examples: DeviceInfo['product']['example']
@@ -38,7 +54,7 @@ function createDevice(
 
 describe('applyPlatformExamples', () => {
   it('replaces i2c-adt7410 product.example with 5 platform entries', () => {
-    const platformEntries = loadPlatformExamplesFixture();
+    const platformEntries = loadPlatformEntry('i2c-adt7410');
     const devices = [
       createDevice('i2c-adt7410', [
         { hardware: 'chirimen', code: 'https://r.chirimen.org/examples/#I2C-ADT7410' },
@@ -57,7 +73,7 @@ describe('applyPlatformExamples', () => {
   });
 
   it('includes all required ADT7410 platforms as platform-specific examples', () => {
-    const platformEntries = loadPlatformExamplesFixture();
+    const platformEntries = loadPlatformEntry('i2c-adt7410');
     const devices = [createDevice('i2c-adt7410', [])];
 
     const { devices: merged } = applyPlatformExamples(devices, platformEntries);
@@ -67,18 +83,20 @@ describe('applyPlatformExamples', () => {
       .map((example) => example.platform)
       .filter(Boolean);
 
-    expect(platforms).toEqual([
-      'pizero-esm',
-      'node',
-      'raspi-node',
-      'microbit-driver',
-      'legacy-gc-i2c',
-    ]);
+    expect(platforms.sort()).toEqual(
+      [
+        'pizero-esm',
+        'node',
+        'raspi-node',
+        'microbit-driver',
+        'legacy-gc-i2c',
+      ].sort()
+    );
     expect(examples.every(isPlatformSpecificExample)).toBe(true);
   });
 
   it('preserves legacy hardware and code fields for transition compatibility', () => {
-    const platformEntries = loadPlatformExamplesFixture();
+    const platformEntries = loadPlatformEntry('i2c-adt7410');
     const devices = [createDevice('i2c-adt7410', [])];
 
     const { devices: merged } = applyPlatformExamples(devices, platformEntries);
@@ -90,7 +108,7 @@ describe('applyPlatformExamples', () => {
   });
 
   it('keeps product.example unchanged for devices not listed in platform-examples.json', () => {
-    const platformEntries = loadPlatformExamplesFixture();
+    const platformEntries = loadPlatformEntry('i2c-adt7410');
     const originalExamples = [
       { hardware: 'chirimen', code: 'https://r.chirimen.org/examples/#I2C-ADS1015' },
       {
@@ -99,7 +117,7 @@ describe('applyPlatformExamples', () => {
       },
     ];
     const devices = [
-      createDevice('i2c-ads1015', originalExamples),
+      createDevice('i2c-unlisted-fixture-device', originalExamples),
       createDevice('i2c-adt7410', [{ hardware: 'chirimen', code: 'https://example.com' }]),
     ];
 

--- a/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples-main.ts
+++ b/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples-main.ts
@@ -1,0 +1,97 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
+import {
+  bootstrapLegacyPlatformExamples,
+  buildReverseOverrideMap,
+} from './bootstrap-legacy-platform-examples';
+import type { PlatformExampleDeviceEntry } from './types';
+
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as T;
+}
+
+function mergePlatformExamples(
+  canonical: PlatformExampleDeviceEntry[],
+  bootstrap: PlatformExampleDeviceEntry[]
+): PlatformExampleDeviceEntry[] {
+  const canonicalIds = new Set(canonical.map((entry) => entry.dashboardDeviceId));
+  const merged = [...canonical];
+
+  for (const entry of bootstrap) {
+    if (canonicalIds.has(entry.dashboardDeviceId)) {
+      console.warn(
+        `Skipping bootstrap entry for ${entry.dashboardDeviceId}: already in platform-examples.json`
+      );
+      continue;
+    }
+    merged.push(entry);
+  }
+
+  return merged.sort((a, b) =>
+    a.dashboardDeviceId.localeCompare(b.dashboardDeviceId)
+  );
+}
+
+export async function main(): Promise<void> {
+  const devicesPath = path.join(repoRoot, 'apps/web/public/devices.json');
+  const platformExamplesPath = path.join(
+    repoRoot,
+    'data/platform-examples/platform-examples.json'
+  );
+  const generatedPath = path.join(
+    repoRoot,
+    'data/platform-examples/platform-examples.generated.json'
+  );
+  const overridesPath = path.join(
+    repoRoot,
+    'data/example-upstreams/device-id-overrides.yaml'
+  );
+  const outputFlag = process.argv.includes('--write');
+  const outputPath =
+    process.argv.find((arg) => arg.startsWith('--output='))?.split('=')[1] ??
+    platformExamplesPath;
+
+  const devices = readJson<DeviceInfo[]>(devicesPath);
+  const canonical = readJson<PlatformExampleDeviceEntry[]>(platformExamplesPath);
+
+  let enrichedEntries: PlatformExampleDeviceEntry[] = [];
+  try {
+    enrichedEntries = readJson<PlatformExampleDeviceEntry[]>(generatedPath);
+  } catch {
+    console.warn(`No generated platform examples found at ${generatedPath}`);
+  }
+
+  const overridesFile = parseYaml(readFileSync(overridesPath, 'utf8')) as {
+    overrides: Record<string, string | string[]>;
+  };
+  const overrideExampleDeviceIds = buildReverseOverrideMap(
+    overridesFile.overrides ?? {}
+  );
+
+  const bootstrap = bootstrapLegacyPlatformExamples(devices, {
+    overrideExampleDeviceIds,
+    enrichedEntries,
+  });
+
+  console.log(`Bootstrap entries: ${bootstrap.length}`);
+
+  if (outputFlag) {
+    const merged = mergePlatformExamples(canonical, bootstrap);
+    writeFileSync(outputPath, `${JSON.stringify(merged, null, 2)}\n`, 'utf8');
+    console.log(`Wrote ${merged.length} entries to ${outputPath}`);
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(bootstrap, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples.spec.ts
+++ b/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
+import { isPlatformSpecificExample } from '@chirimen-device-dashboard/shared-types';
+import {
+  bootstrapLegacyExampleEntry,
+  bootstrapLegacyPlatformExamples,
+  deriveExampleDeviceId,
+  isLegacyOnlyDevice,
+} from './bootstrap-legacy-platform-examples';
+
+function createLegacyDevice(
+  id: string,
+  examples: DeviceInfo['product']['example'],
+  circuit?: string
+): DeviceInfo {
+  return {
+    id,
+    deviceName: id,
+    tag: 'I2C',
+    category: 'test',
+    description: 'test',
+    image: './no_image.png',
+    product: {
+      url: 'https://example.com/',
+      example: examples,
+      circuit,
+    },
+  };
+}
+
+describe('bootstrapLegacyPlatformExamples', () => {
+  it('derives example device id from dashboard device id', () => {
+    expect(deriveExampleDeviceId('i2c-grove-gesture-paj7620u2')).toBe(
+      'grove-gesture-paj7620u2'
+    );
+    expect(deriveExampleDeviceId('gpio-led')).toBe('led');
+  });
+
+  it('detects legacy-only devices', () => {
+    expect(
+      isLegacyOnlyDevice(
+        createLegacyDevice('i2c-grove-gesture-paj7620u2', [
+          { hardware: 'chirimen', code: 'https://r.chirimen.org/examples/#I2C-Grove-Gesture' },
+        ])
+      )
+    ).toBe(true);
+
+    expect(
+      isLegacyOnlyDevice(
+        createLegacyDevice('i2c-adt7410', [
+          {
+            hardware: 'Pi Zero',
+            code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410',
+            platform: 'pizero-esm',
+            upstreamRepository: 'chirimen-oh/chirimen.org',
+            upstreamPath: 'pizero/src/esm-examples/adt7410',
+            upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen.org',
+            upstreamPathUrl:
+              'https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410',
+            status: 'primary',
+          },
+        ])
+      )
+    ).toBe(false);
+  });
+
+  it('bootstraps paj7620u2 with chirimen legacy and pizero-esm primary', () => {
+    const entry = bootstrapLegacyExampleEntry(
+      {
+        hardware: 'chirimen',
+        code: 'https://r.chirimen.org/examples/#I2C-Grove-Gesture',
+      },
+      {
+        dashboardDeviceId: 'i2c-grove-gesture-paj7620u2',
+        exampleDeviceId: 'paj7620',
+        productCircuit: 'https://example.com/circuit.zip',
+      }
+    );
+
+    expect(entry?.platform).toBe('chirimen');
+    expect(entry?.status).toBe('legacy');
+    expect(entry?.circuitUrl).toBe('https://example.com/circuit.zip');
+    expect(isPlatformSpecificExample(entry!)).toBe(true);
+  });
+
+  it('bootstraps legacy devices into platform example entries', () => {
+    const devices = [
+      createLegacyDevice('i2c-grove-gesture-paj7620u2', [
+        {
+          hardware: 'chirimen',
+          code: 'https://r.chirimen.org/examples/#I2C-Grove-Gesture',
+        },
+        {
+          hardware: 'piZero',
+          code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620',
+        },
+      ]),
+    ];
+
+    const result = bootstrapLegacyPlatformExamples(devices, {
+      overrideExampleDeviceIds: new Map([
+        ['i2c-grove-gesture-paj7620u2', 'paj7620'],
+      ]),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].exampleDeviceId).toBe('paj7620');
+    expect(result[0].examples.map((example) => example.platform)).toEqual([
+      'chirimen',
+      'pizero-esm',
+    ]);
+    expect(result[0].examples.every(isPlatformSpecificExample)).toBe(true);
+  });
+});

--- a/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples.ts
+++ b/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples.ts
@@ -1,0 +1,237 @@
+import type { DeviceInfo, ExampleInfo } from '@chirimen-device-dashboard/shared-types';
+import { isPlatformSpecificExample } from '@chirimen-device-dashboard/shared-types';
+import { classifyLegacyExampleUrl } from './classify-legacy-example-url';
+import type { PlatformExampleDeviceEntry } from './types';
+
+const DEFAULT_UPSTREAM_BY_PLATFORM: Record<
+  string,
+  { upstreamRepository: string; upstreamPath: string }
+> = {
+  'pizero-esm': {
+    upstreamRepository: 'chirimen-oh/chirimen.org',
+    upstreamPath: 'pizero/src/esm-examples',
+  },
+  'microbit-driver': {
+    upstreamRepository: 'chirimen-oh/chirimen-drivers',
+    upstreamPath: 'microbit-examples',
+  },
+  chirimen: {
+    upstreamRepository: 'chirimen-oh/chirimen',
+    upstreamPath: 'gc/examples',
+  },
+};
+
+function buildUpstreamRepositoryUrl(upstreamRepository: string): string {
+  return `https://github.com/${upstreamRepository}`;
+}
+
+function buildUpstreamPathUrl(
+  upstreamRepository: string,
+  upstreamPath: string
+): string {
+  return `https://github.com/${upstreamRepository}/tree/master/${upstreamPath}`;
+}
+
+function buildLocalPath(exampleDeviceId: string, platform: string): string {
+  return `examples/devices/${exampleDeviceId}/platforms/${platform}`;
+}
+
+function parseGithubRepository(codeUrl: string): string | null {
+  const match = codeUrl.match(/github\.com\/([^/]+\/[^/]+)/i);
+  return match?.[1] ?? null;
+}
+
+function resolveUpstreamFields(
+  platform: string,
+  codeUrl: string,
+  enriched?: Partial<ExampleInfo>
+): Pick<
+  ExampleInfo,
+  | 'upstreamRepository'
+  | 'upstreamRepositoryUrl'
+  | 'upstreamPath'
+  | 'upstreamPathUrl'
+  | 'circuitUrl'
+> {
+  if (
+    enriched?.upstreamRepository &&
+    enriched.upstreamPath &&
+    enriched.upstreamRepositoryUrl &&
+    enriched.upstreamPathUrl
+  ) {
+    return {
+      upstreamRepository: enriched.upstreamRepository,
+      upstreamRepositoryUrl: enriched.upstreamRepositoryUrl,
+      upstreamPath: enriched.upstreamPath,
+      upstreamPathUrl: enriched.upstreamPathUrl,
+      circuitUrl: enriched.circuitUrl || codeUrl,
+    };
+  }
+
+  const externalRepo = parseGithubRepository(codeUrl);
+  if (externalRepo && !codeUrl.includes('chirimen-oh/')) {
+    const upstreamPath = 'examples';
+    return {
+      upstreamRepository: externalRepo,
+      upstreamRepositoryUrl: buildUpstreamRepositoryUrl(externalRepo),
+      upstreamPath,
+      upstreamPathUrl: codeUrl,
+      circuitUrl: codeUrl,
+    };
+  }
+
+  const defaults = DEFAULT_UPSTREAM_BY_PLATFORM[platform];
+  if (!defaults) {
+    return {
+      upstreamRepository: 'chirimen-oh/chirimen.org',
+      upstreamRepositoryUrl: buildUpstreamRepositoryUrl('chirimen-oh/chirimen.org'),
+      upstreamPath: 'examples',
+      upstreamPathUrl: codeUrl,
+      circuitUrl: codeUrl,
+    };
+  }
+
+  const useTutorialUrl =
+    codeUrl.includes('tutorial.chirimen.org') ||
+    codeUrl.includes('r.chirimen.org') ||
+    codeUrl.includes('chirimen.org/chirimen');
+
+  return {
+    upstreamRepository: defaults.upstreamRepository,
+    upstreamRepositoryUrl: buildUpstreamRepositoryUrl(defaults.upstreamRepository),
+    upstreamPath: defaults.upstreamPath,
+    upstreamPathUrl: useTutorialUrl
+      ? codeUrl
+      : buildUpstreamPathUrl(defaults.upstreamRepository, defaults.upstreamPath),
+    circuitUrl: enriched?.circuitUrl || codeUrl,
+  };
+}
+
+export function deriveExampleDeviceId(dashboardDeviceId: string): string {
+  return dashboardDeviceId
+    .replace(/^(i2c|gpio|analog|actuator|other)-/, '')
+    .replace(/-device(-\d+)?$/, '')
+    .replace(/-device$/, '');
+}
+
+export function buildReverseOverrideMap(
+  overrides: Record<string, string | string[]>
+): Map<string, string> {
+  const reverse = new Map<string, string>();
+
+  for (const [exampleDeviceId, dashboardValue] of Object.entries(overrides)) {
+    const dashboardIds = Array.isArray(dashboardValue)
+      ? dashboardValue
+      : [dashboardValue];
+    for (const dashboardDeviceId of dashboardIds) {
+      reverse.set(dashboardDeviceId, exampleDeviceId);
+    }
+  }
+
+  return reverse;
+}
+
+export function isLegacyOnlyDevice(device: DeviceInfo): boolean {
+  const examples = device.product?.example ?? [];
+  if (examples.length === 0) {
+    return false;
+  }
+
+  return !examples.some(isPlatformSpecificExample);
+}
+
+export function bootstrapLegacyExampleEntry(
+  legacyExample: ExampleInfo,
+  options: {
+    dashboardDeviceId: string;
+    exampleDeviceId: string;
+    productCircuit?: string;
+    enrichedByPlatform?: Map<string, Partial<ExampleInfo>>;
+  }
+): ExampleInfo | null {
+  const code = legacyExample.code?.trim() ?? '';
+  const classification = classifyLegacyExampleUrl(code);
+  if (!classification) {
+    return null;
+  }
+
+  const { platform, status } = classification;
+  const enriched = options.enrichedByPlatform?.get(platform);
+  const upstream = resolveUpstreamFields(platform, code, enriched);
+  const circuitUrl =
+    enriched?.circuitUrl?.trim() ||
+    options.productCircuit?.trim() ||
+    upstream.circuitUrl ||
+    code;
+
+  return {
+    hardware: legacyExample.hardware?.trim() || platform,
+    code,
+    deviceId: options.exampleDeviceId,
+    platform,
+    localPath: buildLocalPath(options.exampleDeviceId, platform),
+    upstreamRepository: upstream.upstreamRepository,
+    upstreamRepositoryUrl: upstream.upstreamRepositoryUrl,
+    upstreamPath: upstream.upstreamPath,
+    upstreamPathUrl: upstream.upstreamPathUrl,
+    status,
+    circuitUrl,
+    verified: enriched?.verified ?? false,
+  };
+}
+
+export function bootstrapLegacyPlatformExamples(
+  devices: DeviceInfo[],
+  options: {
+    overrideExampleDeviceIds?: Map<string, string>;
+    enrichedEntries?: PlatformExampleDeviceEntry[];
+  } = {}
+): PlatformExampleDeviceEntry[] {
+  const enrichedByDashboard = new Map(
+    (options.enrichedEntries ?? []).map((entry) => [entry.dashboardDeviceId, entry])
+  );
+
+  const entries: PlatformExampleDeviceEntry[] = [];
+
+  for (const device of devices) {
+    if (!isLegacyOnlyDevice(device)) {
+      continue;
+    }
+
+    const exampleDeviceId =
+      options.overrideExampleDeviceIds?.get(device.id) ??
+      deriveExampleDeviceId(device.id);
+
+    const enrichedEntry = enrichedByDashboard.get(device.id);
+    const enrichedByPlatform = new Map(
+      (enrichedEntry?.examples ?? [])
+        .filter((example) => example.platform)
+        .map((example) => [example.platform as string, example])
+    );
+
+    const examples = device.product.example
+      .map((legacyExample) =>
+        bootstrapLegacyExampleEntry(legacyExample, {
+          dashboardDeviceId: device.id,
+          exampleDeviceId,
+          productCircuit: device.product.circuit,
+          enrichedByPlatform,
+        })
+      )
+      .filter((example): example is ExampleInfo => example !== null);
+
+    if (examples.length === 0) {
+      continue;
+    }
+
+    entries.push({
+      dashboardDeviceId: device.id,
+      exampleDeviceId,
+      examples,
+    });
+  }
+
+  return entries.sort((a, b) =>
+    a.dashboardDeviceId.localeCompare(b.dashboardDeviceId)
+  );
+}

--- a/tools/scripts/sync-devices/src/classify-legacy-example-url.spec.ts
+++ b/tools/scripts/sync-devices/src/classify-legacy-example-url.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { classifyLegacyExampleUrl } from './classify-legacy-example-url';
+
+describe('classifyLegacyExampleUrl', () => {
+  it('classifies i2c-grove-gesture-paj7620u2 examples', () => {
+    expect(
+      classifyLegacyExampleUrl(
+        'https://r.chirimen.org/examples/#I2C-Grove-Gesture'
+      )
+    ).toEqual({ platform: 'chirimen', status: 'legacy' });
+
+    expect(
+      classifyLegacyExampleUrl(
+        'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620'
+      )
+    ).toEqual({ platform: 'pizero-esm', status: 'primary' });
+  });
+
+  it('classifies gpio-led examples across three platforms', () => {
+    expect(
+      classifyLegacyExampleUrl('https://r.chirimen.org/examples/#GPIO-Blink')
+    ).toEqual({ platform: 'chirimen', status: 'legacy' });
+
+    expect(
+      classifyLegacyExampleUrl(
+        'https://chirimen.org/chirimen-micro-bit/examples/#GPIO1'
+      )
+    ).toEqual({ platform: 'microbit-driver', status: 'legacy' });
+
+    expect(
+      classifyLegacyExampleUrl(
+        'https://tutorial.chirimen.org/pizero/esm-examples/#GPIO_hello-world'
+      )
+    ).toEqual({ platform: 'pizero-esm', status: 'primary' });
+  });
+
+  it('classifies actuator-device-1 microbit and non-esm pizero urls', () => {
+    expect(
+      classifyLegacyExampleUrl('https://tutorial.chirimen.org/microbit/iot_actuate')
+    ).toEqual({ platform: 'microbit-driver', status: 'legacy' });
+
+    expect(
+      classifyLegacyExampleUrl('https://tutorial.chirimen.org/pizero/#gpio-2')
+    ).toEqual({ platform: 'pizero-esm', status: 'primary' });
+  });
+
+  it('classifies external github urls as chirimen legacy', () => {
+    expect(
+      classifyLegacyExampleUrl(
+        'https://github.com/SeeedDocument/Grove-Water-Level-Sensor/blob/master/water-level-sensor-demo.ino'
+      )
+    ).toEqual({ platform: 'chirimen', status: 'legacy' });
+  });
+
+  it('returns null for empty or unknown urls', () => {
+    expect(classifyLegacyExampleUrl('')).toBeNull();
+    expect(classifyLegacyExampleUrl('https://example.com/unknown')).toBeNull();
+  });
+});

--- a/tools/scripts/sync-devices/src/classify-legacy-example-url.ts
+++ b/tools/scripts/sync-devices/src/classify-legacy-example-url.ts
@@ -1,0 +1,78 @@
+import type { ExampleStatus } from '@chirimen-device-dashboard/shared-types';
+
+export type LegacyExampleClassification = {
+  platform: string;
+  status: ExampleStatus;
+};
+
+type UrlRule = {
+  test: (url: string) => boolean;
+  platform: string;
+  status: ExampleStatus;
+};
+
+const URL_RULES: UrlRule[] = [
+  {
+    test: (url) => /tutorial\.chirimen\.org\/pizero\/esm-examples/i.test(url),
+    platform: 'pizero-esm',
+    status: 'primary',
+  },
+  {
+    test: (url) => /tutorial\.chirimen\.org\/pizero\//i.test(url),
+    platform: 'pizero-esm',
+    status: 'primary',
+  },
+  {
+    test: (url) => /r\.chirimen\.org\/examples/i.test(url),
+    platform: 'chirimen',
+    status: 'legacy',
+  },
+  {
+    test: (url) => /chirimen\.org\/chirimen\/gc\/top\/examples/i.test(url),
+    platform: 'chirimen',
+    status: 'legacy',
+  },
+  {
+    test: (url) => /tutorial\.chirimen\.org\/raspi/i.test(url),
+    platform: 'chirimen',
+    status: 'legacy',
+  },
+  {
+    test: (url) =>
+      /chirimen\.org\/chirimen-micro-bit\/examples/i.test(url),
+    platform: 'microbit-driver',
+    status: 'legacy',
+  },
+  {
+    test: (url) => /tutorial\.chirimen\.org\/microbit/i.test(url),
+    platform: 'microbit-driver',
+    status: 'legacy',
+  },
+  {
+    test: (url) => /chirimen\.org\/examples/i.test(url),
+    platform: 'chirimen',
+    status: 'legacy',
+  },
+  {
+    test: (url) => /github\.com/i.test(url),
+    platform: 'chirimen',
+    status: 'legacy',
+  },
+];
+
+export function classifyLegacyExampleUrl(
+  codeUrl: string
+): LegacyExampleClassification | null {
+  const normalized = codeUrl.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  for (const rule of URL_RULES) {
+    if (rule.test(normalized)) {
+      return { platform: rule.platform, status: rule.status };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- legacy 形式だった 39 デバイスを `code` URL パターンから platform / status を判定し、Platform 別 Example として `platform-examples.json` に移行しました
- `devices.json` を再生成し、Issue #188 の archive 前移行確認（表示・生成・検証）を完了しました
- README / migration note に `chirimen-example-catalog` archive 方針と URL 判定ルールを追記しました

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #188

## What changed?

- `classify-legacy-example-url.ts`: legacy `code` URL から platform / status を判定するユーティリティを追加
- `bootstrap-legacy-platform-examples.ts`: legacy 39 件を Platform 別エントリに変換する bootstrap スクリプトを追加
- `platform-examples.json`: 39 デバイス分の Platform 別 Example を追記（合計 100 件）
- `devices.json`: `product.example` を洗い替えて再生成
- `device-id-overrides.yaml`: paj7620 等の ID マッピングを追加
- E2E: `i2c-grove-gesture-paj7620u2` の Platform 別 Example 表示テストを追加
- README: catalog archive 方針と URL 判定ルールへのリンクを追記

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx test sync-devices` — URL 分類・bootstrap の単体テスト
2. `pnpm validate:platform-examples` — validation PASS（issues: 0, warnings: 0）
3. `pnpm nx e2e web-e2e --grep "Platform 別 Example"` — E2E 18 件 PASS
4. ブラウザで `/devices/i2c-grove-gesture-paj7620u2` を開き、`chirimen` (legacy) と `pizero-esm` (primary) が表示されることを確認

## Environment (if relevant)

- Browser: Chromium / Firefox / WebKit（E2E）
- OS: macOS / Windows / Linux
- Node version: 24.x
- pnpm version: 11.5.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)