### PR TITLE
feat(sync-example-upstreams): remove deprecated driver sources

### DIFF
--- a/apps/web/public/devices.json
+++ b/apps/web/public/devices.json
@@ -24,20 +24,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ads1015",
-          "deviceId": "ads1015",
-          "platform": "node",
-          "localPath": "examples/devices/ads1015/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/ads1015",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ads1015",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ads1015/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ads1015",
           "deviceId": "ads1015",
@@ -49,20 +35,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ads1015",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ads1015/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ads1015",
-          "deviceId": "ads1015",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/ads1015/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/ads1015",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ads1015",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ads1015/schematic.png",
           "verified": false
         }
       ],
@@ -108,20 +80,6 @@
       "url": "http://www.aitendo.com/product/10938",
       "example": [
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pcf8591",
-          "deviceId": "pcf8591",
-          "platform": "node",
-          "localPath": "examples/devices/pcf8591/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/pcf8591",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pcf8591",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/pcf8591/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pcf8591",
           "deviceId": "pcf8591",
@@ -133,20 +91,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pcf8591",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/pcf8591/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pcf8591",
-          "deviceId": "pcf8591",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/pcf8591/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/pcf8591",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pcf8591",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/pcf8591/schematic.png",
           "verified": false
         }
       ]
@@ -191,20 +135,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
-          "deviceId": "adt7410",
-          "platform": "node",
-          "localPath": "examples/devices/adt7410/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/adt7410",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410",
           "deviceId": "adt7410",
@@ -216,20 +146,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
-          "deviceId": "adt7410",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/adt7410/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/adt7410",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png",
           "verified": false
         }
       ],
@@ -262,20 +178,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/amg8833",
-          "deviceId": "amg8833",
-          "platform": "node",
-          "localPath": "examples/devices/amg8833/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/amg8833",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/amg8833",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/amg8833/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/amg8833",
           "deviceId": "amg8833",
@@ -287,20 +189,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/amg8833",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/amg8833/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/amg8833",
-          "deviceId": "amg8833",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/amg8833/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/amg8833",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/amg8833",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/amg8833/schematic.png",
           "verified": false
         }
       ],
@@ -333,20 +221,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bme280",
-          "deviceId": "bme280",
-          "platform": "node",
-          "localPath": "examples/devices/bme280/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/bme280",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bme280",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bme280/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme280",
           "deviceId": "bme280",
@@ -358,20 +232,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme280",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bme280/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme280",
-          "deviceId": "bme280",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/bme280/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/bme280",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme280",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bme280/schematic.png",
           "verified": false
         }
       ],
@@ -403,20 +263,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp180",
-          "deviceId": "bmp180",
-          "platform": "node",
-          "localPath": "examples/devices/bmp180/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/bmp180",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp180",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bmp180/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp180",
           "deviceId": "bmp180",
@@ -428,20 +274,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp180",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bmp180/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp180",
-          "deviceId": "bmp180",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/bmp180/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/bmp180",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp180",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bmp180/schematic.png",
           "verified": false
         }
       ],
@@ -473,20 +305,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp280",
-          "deviceId": "bmp280",
-          "platform": "node",
-          "localPath": "examples/devices/bmp280/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/bmp280",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp280",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bmp280/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp280",
           "deviceId": "bmp280",
@@ -498,20 +316,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp280",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bmp280/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp280",
-          "deviceId": "bmp280",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/bmp280/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/bmp280",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp280",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bmp280/schematic.png",
           "verified": false
         }
       ],
@@ -543,20 +347,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/gp2y0e03",
-          "deviceId": "gp2y0e03",
-          "platform": "node",
-          "localPath": "examples/devices/gp2y0e03/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/gp2y0e03",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/gp2y0e03",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/gp2y0e03/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/gp2y0e03",
           "deviceId": "gp2y0e03",
@@ -568,20 +358,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/gp2y0e03",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/gp2y0e03/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/gp2y0e03",
-          "deviceId": "gp2y0e03",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/gp2y0e03/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/gp2y0e03",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/gp2y0e03",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/gp2y0e03/schematic.png",
           "verified": false
         }
       ],
@@ -628,20 +404,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l0x",
-          "deviceId": "vl53l0x",
-          "platform": "node",
-          "localPath": "examples/devices/vl53l0x/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/vl53l0x",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l0x",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/vl53l0x/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l0x",
           "deviceId": "vl53l0x",
@@ -653,20 +415,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l0x",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl53l0x/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l0x",
-          "deviceId": "vl53l0x",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/vl53l0x/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/vl53l0x",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l0x",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/vl53l0x/schematic.png",
           "verified": false
         }
       ],
@@ -699,20 +447,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l1x",
-          "deviceId": "vl53l1x",
-          "platform": "node",
-          "localPath": "examples/devices/vl53l1x/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/vl53l1x",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l1x",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/vl53l1x/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l1x",
           "deviceId": "vl53l1x",
@@ -724,20 +458,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l1x",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl53l1x/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l1x",
-          "deviceId": "vl53l1x",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/vl53l1x/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/vl53l1x",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l1x",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/vl53l1x/schematic.png",
           "verified": false
         }
       ]
@@ -826,20 +546,6 @@
       "url": "https://www.switch-science.com/catalog/1174/",
       "example": [
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tsl2561",
-          "deviceId": "tsl2561",
-          "platform": "node",
-          "localPath": "examples/devices/tsl2561/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/tsl2561",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tsl2561",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/tsl2561/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tsl2561",
           "deviceId": "tsl2561",
@@ -851,20 +557,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tsl2561",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/tsl2561/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tsl2561",
-          "deviceId": "tsl2561",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/tsl2561/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/tsl2561",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tsl2561",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/tsl2561/schematic.png",
           "verified": false
         }
       ],
@@ -927,20 +619,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1308",
-          "deviceId": "ssd1308",
-          "platform": "node",
-          "localPath": "examples/devices/ssd1308/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/ssd1308",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1308",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ssd1308/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1308",
           "deviceId": "ssd1308",
@@ -952,20 +630,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1308",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ssd1308/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1308",
-          "deviceId": "ssd1308",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/ssd1308/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/ssd1308",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1308",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ssd1308/schematic.png",
           "verified": false
         }
       ],
@@ -983,20 +647,6 @@
       "url": "https://akizukidenshi.com/catalog/g/g112031/",
       "example": [
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1306",
-          "deviceId": "ssd1306",
-          "platform": "node",
-          "localPath": "examples/devices/ssd1306/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/ssd1306",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1306",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ssd1306/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1306",
           "deviceId": "ssd1306",
@@ -1008,20 +658,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1306",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ssd1306/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1306",
-          "deviceId": "ssd1306",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/ssd1306/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/ssd1306",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1306",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ssd1306/schematic.png",
           "verified": false
         }
       ],
@@ -1068,20 +704,6 @@
       "url": "https://www.switch-science.com/catalog/825/",
       "example": [
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpr121",
-          "deviceId": "mpr121",
-          "platform": "node",
-          "localPath": "examples/devices/mpr121/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/mpr121",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpr121",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpr121/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpr121",
           "deviceId": "mpr121",
@@ -1093,20 +715,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpr121",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpr121/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpr121",
-          "deviceId": "mpr121",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/mpr121/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/mpr121",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpr121",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpr121/schematic.png",
           "verified": false
         }
       ],
@@ -1209,20 +817,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/s11059",
-          "deviceId": "s11059",
-          "platform": "node",
-          "localPath": "examples/devices/s11059/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/s11059",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/s11059",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/s11059/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/s11059",
           "deviceId": "s11059",
@@ -1234,20 +828,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/s11059",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/s11059/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/s11059",
-          "deviceId": "s11059",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/s11059/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/s11059",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/s11059",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/s11059/schematic.png",
           "verified": false
         }
       ],
@@ -1293,20 +873,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/veml6070",
-          "deviceId": "veml6070",
-          "platform": "node",
-          "localPath": "examples/devices/veml6070/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/veml6070",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/veml6070",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/veml6070/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/veml6070",
           "deviceId": "veml6070",
@@ -1318,20 +884,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/veml6070",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/veml6070/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/veml6070",
-          "deviceId": "veml6070",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/veml6070/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/veml6070",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/veml6070",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/veml6070/schematic.png",
           "verified": false
         }
       ],
@@ -1408,20 +960,6 @@
       "url": "https://www.switch-science.com/catalog/972/",
       "example": [
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adxl345",
-          "deviceId": "adxl345",
-          "platform": "node",
-          "localPath": "examples/devices/adxl345/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/adxl345",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adxl345",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adxl345/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adxl345",
           "deviceId": "adxl345",
@@ -1433,20 +971,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adxl345",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adxl345/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
-          "deviceId": "adxl345",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/adxl345/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/adxl345",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adxl345/schematic.png",
           "verified": false
         }
       ],
@@ -1478,20 +1002,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu6050",
-          "deviceId": "mpu6050",
-          "platform": "node",
-          "localPath": "examples/devices/mpu6050/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/mpu6050",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu6050",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpu6050/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu6050",
           "deviceId": "mpu6050",
@@ -1503,20 +1013,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu6050",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpu6050/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu6050",
-          "deviceId": "mpu6050",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/mpu6050/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/mpu6050",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu6050",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpu6050/schematic.png",
           "verified": false
         }
       ],
@@ -1549,20 +1045,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu9250",
-          "deviceId": "mpu9250",
-          "platform": "node",
-          "localPath": "examples/devices/mpu9250/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/mpu9250",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu9250",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpu9250/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu9250",
           "deviceId": "mpu9250",
@@ -1574,20 +1056,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu9250",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpu9250/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu9250",
-          "deviceId": "mpu9250",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/mpu9250/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/mpu9250",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu9250",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpu9250/schematic.png",
           "verified": false
         }
       ],
@@ -1693,20 +1161,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "deviceId": "neopixel-i2c",
@@ -1718,20 +1172,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
           "verified": false
         }
       ]
@@ -1762,20 +1202,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "deviceId": "neopixel-i2c",
@@ -1787,20 +1213,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
           "verified": false
         }
       ],
@@ -1832,20 +1244,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "deviceId": "neopixel-i2c",
@@ -1857,20 +1255,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
           "verified": false
         }
       ]
@@ -1901,20 +1285,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "deviceId": "neopixel-i2c",
@@ -1926,20 +1296,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "deviceId": "neopixel-i2c",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/neopixel-i2c",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
           "verified": false
         }
       ]
@@ -2127,20 +1483,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pca9685",
-          "deviceId": "pca9685",
-          "platform": "node",
-          "localPath": "examples/devices/pca9685/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/pca9685",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pca9685",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/pca9685/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pca9685",
           "deviceId": "pca9685",
@@ -2152,20 +1494,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pca9685",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/pca9685/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pca9685",
-          "deviceId": "pca9685",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/pca9685/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/pca9685",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pca9685",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/pca9685/schematic.png",
           "verified": false
         }
       ],
@@ -2239,20 +1567,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/sht30",
-          "deviceId": "sht30",
-          "platform": "node",
-          "localPath": "examples/devices/sht30/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/sht30",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/sht30",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/sht30/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/sht30",
           "deviceId": "sht30",
@@ -2264,20 +1578,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/sht30",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/sht30/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/sht30",
-          "deviceId": "sht30",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/sht30/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/sht30",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/sht30",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/sht30/schematic.png",
           "verified": false
         }
       ],
@@ -2406,20 +1706,6 @@
       "url": "https://akizukidenshi.com/catalog/g/g108220/",
       "example": [
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tcs34725",
-          "deviceId": "tcs34725",
-          "platform": "node",
-          "localPath": "examples/devices/tcs34725/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/tcs34725",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tcs34725",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/tcs34725/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tcs34725",
           "deviceId": "tcs34725",
@@ -2431,20 +1717,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tcs34725",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/tcs34725/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tcs34725",
-          "deviceId": "tcs34725",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/tcs34725/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/tcs34725",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tcs34725",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/tcs34725/schematic.png",
           "verified": false
         }
       ]
@@ -2475,20 +1747,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ina219",
-          "deviceId": "ina219",
-          "platform": "node",
-          "localPath": "examples/devices/ina219/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/ina219",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ina219",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ina219/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ina219",
           "deviceId": "ina219",
@@ -2500,20 +1758,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ina219",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ina219/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ina219",
-          "deviceId": "ina219",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/ina219/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/ina219",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ina219",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ina219/schematic.png",
           "verified": false
         }
       ]
@@ -2544,20 +1788,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mlx90614",
-          "deviceId": "mlx90614",
-          "platform": "node",
-          "localPath": "examples/devices/mlx90614/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/mlx90614",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mlx90614",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mlx90614/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mlx90614",
           "deviceId": "mlx90614",
@@ -2569,20 +1799,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mlx90614",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mlx90614/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mlx90614",
-          "deviceId": "mlx90614",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/mlx90614/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/mlx90614",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mlx90614",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mlx90614/schematic.png",
           "verified": false
         }
       ]
@@ -2599,18 +1815,8 @@
       "url": "https://www.switch-science.com/catalog/3531/",
       "example": [
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/apds9960",
-          "deviceId": "apds9960",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/apds9960/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/apds9960",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/apds9960",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/apds9960/schematic.png",
-          "verified": false
+          "hardware": "chirimen",
+          "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-APDS9960"
         }
       ]
     }
@@ -2667,20 +1873,6 @@
           "verified": false
         },
         {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bh1750",
-          "deviceId": "bh1750",
-          "platform": "node",
-          "localPath": "examples/devices/bh1750/platforms/node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "node-examples/bh1750",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bh1750",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bh1750/schematic.png",
-          "verified": false
-        },
-        {
           "hardware": "Pi Zero",
           "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bh1750",
           "deviceId": "bh1750",
@@ -2692,20 +1884,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bh1750",
           "status": "primary",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bh1750/schematic.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bh1750",
-          "deviceId": "bh1750",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/bh1750/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/bh1750",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bh1750",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bh1750/schematic.png",
           "verified": false
         }
       ]
@@ -2762,20 +1940,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/ccs811",
           "status": "legacy",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/ccs811/imgs/pinbit_ccs811.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ccs811",
-          "deviceId": "ccs811",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/ccs811/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/ccs811",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ccs811",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ccs811/CCS811schematic.png",
           "verified": false
         }
       ]
@@ -2861,20 +2025,6 @@
           "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/bme680",
           "status": "legacy",
           "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/bme680/imgs/pinbit_bme680.png",
-          "verified": false
-        },
-        {
-          "hardware": "Raspberry Pi",
-          "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme680",
-          "deviceId": "bme680",
-          "platform": "raspi-node",
-          "localPath": "examples/devices/bme680/platforms/raspi-node",
-          "upstreamRepository": "chirimen-oh/chirimen-drivers",
-          "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-          "upstreamPath": "raspi-examples/bme680",
-          "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme680",
-          "status": "legacy",
-          "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bme680/BME680schematic.png",
           "verified": false
         }
       ]

--- a/data/example-upstreams/sources.yaml
+++ b/data/example-upstreams/sources.yaml
@@ -7,22 +7,6 @@ sources:
     priority: primary
     description: CHIRIMEN Pi Zero 向けの現行 ESM examples
 
-  - id: chirimen-drivers-raspi
-    repo: chirimen-oh/chirimen-drivers
-    branch: master
-    path: raspi-examples
-    platform: raspi-node
-    priority: legacy
-    description: Raspberry Pi / Node.js 向け examples
-
-  - id: chirimen-drivers-node
-    repo: chirimen-oh/chirimen-drivers
-    branch: master
-    path: node-examples
-    platform: node
-    priority: legacy
-    description: Node.js 向け examples
-
   - id: chirimen-drivers-microbit
     repo: chirimen-oh/chirimen-drivers
     branch: master

--- a/data/platform-examples/README.md
+++ b/data/platform-examples/README.md
@@ -51,7 +51,7 @@
 | フィールド | 説明 |
 | --- | --- |
 | `deviceId` | Example catalog 側の device id |
-| `platform` | Platform 識別子（例: `pizero-esm`, `node`） |
+| `platform` | Platform 識別子（例: `pizero-esm`, `microbit-driver`） |
 | `localPath` | catalog 互換のローカルパス |
 | `upstreamRepository` | GitHub リポジトリ（例: `chirimen-oh/chirimen.org`） |
 | `upstreamRepositoryUrl` | リポジトリ URL |
@@ -75,13 +75,11 @@
 
 ## ADT7410 移行記録（#180）
 
-`chirimen-example-catalog` の `catalog/examples.json` / `metadata.md` と突合し、以下 5 platform を移行済みです。
+`chirimen-example-catalog` の `catalog/examples.json` / `metadata.md` と突合し、以下 3 platform を移行済みです。`chirimen-drivers` の旧 Node.js / Raspberry Pi examples は upstream 側で削除予定のため、生成元から除外しています。
 
 | Platform | Status | Upstream Repository | Upstream Path |
 | --- | --- | --- | --- |
 | `pizero-esm` | primary | `chirimen-oh/chirimen.org` | `pizero/src/esm-examples/adt7410` |
-| `node` | legacy | `chirimen-oh/chirimen-drivers` | `node-examples/adt7410` |
-| `raspi-node` | legacy | `chirimen-oh/chirimen-drivers` | `raspi-examples/adt7410` |
 | `microbit-driver` | legacy | `chirimen-oh/chirimen-drivers` | `microbit-examples/adt7410` |
 | `legacy-gc-i2c` | archive | `chirimen-oh/chirimen` | `gc/i2c/i2c-ADT7410` |
 
@@ -94,8 +92,6 @@
 | `pizero-esm` | `Pi Zero` | `https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410` |
 | `microbit-driver` | `micro:bit` | `https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410` |
 | `legacy-gc-i2c` | `chirimen` | `https://r.chirimen.org/examples/#I2C-ADT7410` |
-
-`node` / `raspi-node` は legacy `devices.json` に対応エントリがないため、`code` = `upstreamPathUrl` です。
 
 ## 編集フロー
 

--- a/data/platform-examples/platform-examples.generated.json
+++ b/data/platform-examples/platform-examples.generated.json
@@ -158,20 +158,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ads1015",
-        "deviceId": "ads1015",
-        "platform": "node",
-        "localPath": "examples/devices/ads1015/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ads1015",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ads1015",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ads1015/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ads1015",
         "deviceId": "ads1015",
@@ -183,20 +169,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ads1015",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ads1015/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ads1015",
-        "deviceId": "ads1015",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ads1015/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ads1015",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ads1015",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ads1015/schematic.png",
         "verified": false
       }
     ]
@@ -254,20 +226,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
-        "deviceId": "adt7410",
-        "platform": "node",
-        "localPath": "examples/devices/adt7410/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/adt7410",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410",
         "deviceId": "adt7410",
@@ -279,20 +237,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
-        "deviceId": "adt7410",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/adt7410/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/adt7410",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png",
         "verified": false
       }
     ]
@@ -356,20 +300,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/amg8833",
-        "deviceId": "amg8833",
-        "platform": "node",
-        "localPath": "examples/devices/amg8833/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/amg8833",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/amg8833",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/amg8833/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/amg8833",
         "deviceId": "amg8833",
@@ -381,40 +311,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/amg8833",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/amg8833/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/amg8833",
-        "deviceId": "amg8833",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/amg8833/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/amg8833",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/amg8833",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/amg8833/schematic.png",
-        "verified": false
-      }
-    ]
-  },
-  {
-    "dashboardDeviceId": "i2c-apds9960",
-    "exampleDeviceId": "apds9960",
-    "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/apds9960",
-        "deviceId": "apds9960",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/apds9960/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/apds9960",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/apds9960",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/apds9960/schematic.png",
         "verified": false
       }
     ]
@@ -492,20 +388,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bh1750",
-        "deviceId": "bh1750",
-        "platform": "node",
-        "localPath": "examples/devices/bh1750/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bh1750",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bh1750",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bh1750/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bh1750",
         "deviceId": "bh1750",
@@ -517,20 +399,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bh1750",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bh1750/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bh1750",
-        "deviceId": "bh1750",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bh1750/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bh1750",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bh1750",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bh1750/schematic.png",
         "verified": false
       }
     ]
@@ -554,20 +422,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bme280",
-        "deviceId": "bme280",
-        "platform": "node",
-        "localPath": "examples/devices/bme280/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bme280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bme280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bme280/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme280",
         "deviceId": "bme280",
@@ -579,20 +433,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme280",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bme280/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme280",
-        "deviceId": "bme280",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bme280/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bme280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bme280/schematic.png",
         "verified": false
       }
     ]
@@ -613,20 +453,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/bme680",
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/bme680/imgs/pinbit_bme680.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme680",
-        "deviceId": "bme680",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bme680/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bme680",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme680",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bme680/BME680schematic.png",
         "verified": false
       }
     ]
@@ -650,20 +476,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp180",
-        "deviceId": "bmp180",
-        "platform": "node",
-        "localPath": "examples/devices/bmp180/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bmp180",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp180",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bmp180/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp180",
         "deviceId": "bmp180",
@@ -675,20 +487,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp180",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bmp180/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp180",
-        "deviceId": "bmp180",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bmp180/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bmp180",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp180",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bmp180/schematic.png",
         "verified": false
       }
     ]
@@ -712,20 +510,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp280",
-        "deviceId": "bmp280",
-        "platform": "node",
-        "localPath": "examples/devices/bmp280/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bmp280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bmp280/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp280",
         "deviceId": "bmp280",
@@ -737,20 +521,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp280",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bmp280/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp280",
-        "deviceId": "bmp280",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bmp280/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bmp280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bmp280/schematic.png",
         "verified": false
       }
     ]
@@ -771,20 +541,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/ccs811",
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/ccs811/imgs/pinbit_ccs811.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ccs811",
-        "deviceId": "ccs811",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ccs811/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ccs811",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ccs811",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ccs811/CCS811schematic.png",
         "verified": false
       }
     ]
@@ -828,20 +584,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/gp2y0e03",
-        "deviceId": "gp2y0e03",
-        "platform": "node",
-        "localPath": "examples/devices/gp2y0e03/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/gp2y0e03",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/gp2y0e03",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/gp2y0e03/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/gp2y0e03",
         "deviceId": "gp2y0e03",
@@ -853,20 +595,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/gp2y0e03",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/gp2y0e03/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/gp2y0e03",
-        "deviceId": "gp2y0e03",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/gp2y0e03/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/gp2y0e03",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/gp2y0e03",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/gp2y0e03/schematic.png",
         "verified": false
       }
     ]
@@ -896,20 +624,6 @@
     "exampleDeviceId": "adxl345",
     "examples": [
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adxl345",
-        "deviceId": "adxl345",
-        "platform": "node",
-        "localPath": "examples/devices/adxl345/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/adxl345",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adxl345",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adxl345/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adxl345",
         "deviceId": "adxl345",
@@ -922,20 +636,6 @@
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adxl345/schematic.png",
         "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
-        "deviceId": "adxl345",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/adxl345/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/adxl345",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adxl345/schematic.png",
-        "verified": false
       }
     ]
   },
@@ -943,20 +643,6 @@
     "dashboardDeviceId": "i2c-grove-gesture-paj7620u2",
     "exampleDeviceId": "paj7620",
     "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/paj7620",
-        "deviceId": "paj7620",
-        "platform": "node",
-        "localPath": "examples/devices/paj7620/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/paj7620",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/paj7620",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/paj7620/schematic.png",
-        "verified": false
-      },
       {
         "hardware": "piZero",
         "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_paj7620",
@@ -970,20 +656,6 @@
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/paj7620/schematic.png",
         "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/paj7620",
-        "deviceId": "paj7620",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/paj7620/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/paj7620",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/paj7620",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/paj7620/schematic.png",
-        "verified": false
       }
     ]
   },
@@ -991,20 +663,6 @@
     "dashboardDeviceId": "i2c-grove-light-tsl2561",
     "exampleDeviceId": "tsl2561",
     "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tsl2561",
-        "deviceId": "tsl2561",
-        "platform": "node",
-        "localPath": "examples/devices/tsl2561/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/tsl2561",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tsl2561",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/tsl2561/schematic.png",
-        "verified": false
-      },
       {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tsl2561",
@@ -1017,20 +675,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tsl2561",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/tsl2561/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tsl2561",
-        "deviceId": "tsl2561",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/tsl2561/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/tsl2561",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tsl2561",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/tsl2561/schematic.png",
         "verified": false
       }
     ]
@@ -1054,20 +698,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1308",
-        "deviceId": "ssd1308",
-        "platform": "node",
-        "localPath": "examples/devices/ssd1308/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ssd1308",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1308",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ssd1308/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1308",
         "deviceId": "ssd1308",
@@ -1080,20 +710,6 @@
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ssd1308/schematic.png",
         "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1308",
-        "deviceId": "ssd1308",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ssd1308/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ssd1308",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1308",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ssd1308/schematic.png",
-        "verified": false
       }
     ]
   },
@@ -1101,20 +717,6 @@
     "dashboardDeviceId": "i2c-grove-touch-mpr121",
     "exampleDeviceId": "mpr121",
     "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpr121",
-        "deviceId": "mpr121",
-        "platform": "node",
-        "localPath": "examples/devices/mpr121/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mpr121",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpr121",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpr121/schematic.png",
-        "verified": false
-      },
       {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpr121",
@@ -1127,20 +729,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpr121",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpr121/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpr121",
-        "deviceId": "mpr121",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mpr121/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mpr121",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpr121",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpr121/schematic.png",
         "verified": false
       }
     ]
@@ -1324,20 +912,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ina219",
-        "deviceId": "ina219",
-        "platform": "node",
-        "localPath": "examples/devices/ina219/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ina219",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ina219",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ina219/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ina219",
         "deviceId": "ina219",
@@ -1349,20 +923,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ina219",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ina219/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ina219",
-        "deviceId": "ina219",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ina219/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ina219",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ina219",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ina219/schematic.png",
         "verified": false
       }
     ]
@@ -1466,20 +1026,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mlx90614",
-        "deviceId": "mlx90614",
-        "platform": "node",
-        "localPath": "examples/devices/mlx90614/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mlx90614",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mlx90614",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mlx90614/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mlx90614",
         "deviceId": "mlx90614",
@@ -1491,20 +1037,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mlx90614",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mlx90614/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mlx90614",
-        "deviceId": "mlx90614",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mlx90614/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mlx90614",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mlx90614",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mlx90614/schematic.png",
         "verified": false
       }
     ]
@@ -1528,20 +1060,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu6050",
-        "deviceId": "mpu6050",
-        "platform": "node",
-        "localPath": "examples/devices/mpu6050/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mpu6050",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu6050",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpu6050/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu6050",
         "deviceId": "mpu6050",
@@ -1553,20 +1071,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu6050",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpu6050/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu6050",
-        "deviceId": "mpu6050",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mpu6050/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mpu6050",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu6050",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpu6050/schematic.png",
         "verified": false
       }
     ]
@@ -1590,20 +1094,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu9250",
-        "deviceId": "mpu9250",
-        "platform": "node",
-        "localPath": "examples/devices/mpu9250/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mpu9250",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu9250",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpu9250/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu9250",
         "deviceId": "mpu9250",
@@ -1615,20 +1105,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu9250",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpu9250/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu9250",
-        "deviceId": "mpu9250",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mpu9250/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mpu9250",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu9250",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpu9250/schematic.png",
         "verified": false
       }
     ]
@@ -1652,20 +1128,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -1677,20 +1139,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -1714,20 +1162,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -1739,20 +1173,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -1776,20 +1196,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -1801,20 +1207,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -1838,20 +1230,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -1863,20 +1241,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -1914,20 +1278,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pca9685",
-        "deviceId": "pca9685",
-        "platform": "node",
-        "localPath": "examples/devices/pca9685/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/pca9685",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pca9685",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/pca9685/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pca9685",
         "deviceId": "pca9685",
@@ -1939,20 +1289,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pca9685",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/pca9685/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pca9685",
-        "deviceId": "pca9685",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/pca9685/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/pca9685",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pca9685",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/pca9685/schematic.png",
         "verified": false
       }
     ]
@@ -1982,20 +1318,6 @@
     "exampleDeviceId": "pcf8591",
     "examples": [
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pcf8591",
-        "deviceId": "pcf8591",
-        "platform": "node",
-        "localPath": "examples/devices/pcf8591/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/pcf8591",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pcf8591",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/pcf8591/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pcf8591",
         "deviceId": "pcf8591",
@@ -2007,20 +1329,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pcf8591",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/pcf8591/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pcf8591",
-        "deviceId": "pcf8591",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/pcf8591/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/pcf8591",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pcf8591",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/pcf8591/schematic.png",
         "verified": false
       }
     ]
@@ -2058,20 +1366,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/s11059",
-        "deviceId": "s11059",
-        "platform": "node",
-        "localPath": "examples/devices/s11059/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/s11059",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/s11059",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/s11059/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/s11059",
         "deviceId": "s11059",
@@ -2083,20 +1377,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/s11059",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/s11059/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/s11059",
-        "deviceId": "s11059",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/s11059/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/s11059",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/s11059",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/s11059/schematic.png",
         "verified": false
       }
     ]
@@ -2174,20 +1454,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/sht30",
-        "deviceId": "sht30",
-        "platform": "node",
-        "localPath": "examples/devices/sht30/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/sht30",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/sht30",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/sht30/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/sht30",
         "deviceId": "sht30",
@@ -2199,20 +1465,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/sht30",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/sht30/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/sht30",
-        "deviceId": "sht30",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/sht30/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/sht30",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/sht30",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/sht30/schematic.png",
         "verified": false
       }
     ]
@@ -2242,20 +1494,6 @@
     "exampleDeviceId": "ssd1306",
     "examples": [
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1306",
-        "deviceId": "ssd1306",
-        "platform": "node",
-        "localPath": "examples/devices/ssd1306/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ssd1306",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1306",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ssd1306/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1306",
         "deviceId": "ssd1306",
@@ -2268,20 +1506,6 @@
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ssd1306/schematic.png",
         "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1306",
-        "deviceId": "ssd1306",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ssd1306/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ssd1306",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1306",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ssd1306/schematic.png",
-        "verified": false
       }
     ]
   },
@@ -2289,20 +1513,6 @@
     "dashboardDeviceId": "i2c-tcs34725",
     "exampleDeviceId": "tcs34725",
     "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tcs34725",
-        "deviceId": "tcs34725",
-        "platform": "node",
-        "localPath": "examples/devices/tcs34725/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/tcs34725",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tcs34725",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/tcs34725/schematic.png",
-        "verified": false
-      },
       {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tcs34725",
@@ -2315,20 +1525,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tcs34725",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/tcs34725/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tcs34725",
-        "deviceId": "tcs34725",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/tcs34725/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/tcs34725",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tcs34725",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/tcs34725/schematic.png",
         "verified": false
       }
     ]
@@ -2386,20 +1582,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/veml6070",
-        "deviceId": "veml6070",
-        "platform": "node",
-        "localPath": "examples/devices/veml6070/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/veml6070",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/veml6070",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/veml6070/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/veml6070",
         "deviceId": "veml6070",
@@ -2411,20 +1593,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/veml6070",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/veml6070/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/veml6070",
-        "deviceId": "veml6070",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/veml6070/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/veml6070",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/veml6070",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/veml6070/schematic.png",
         "verified": false
       }
     ]
@@ -2462,20 +1630,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l0x",
-        "deviceId": "vl53l0x",
-        "platform": "node",
-        "localPath": "examples/devices/vl53l0x/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/vl53l0x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l0x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/vl53l0x/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l0x",
         "deviceId": "vl53l0x",
@@ -2487,20 +1641,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l0x",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl53l0x/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l0x",
-        "deviceId": "vl53l0x",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/vl53l0x/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/vl53l0x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l0x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/vl53l0x/schematic.png",
         "verified": false
       }
     ]
@@ -2524,20 +1664,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l1x",
-        "deviceId": "vl53l1x",
-        "platform": "node",
-        "localPath": "examples/devices/vl53l1x/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/vl53l1x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l1x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/vl53l1x/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l1x",
         "deviceId": "vl53l1x",
@@ -2549,20 +1675,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l1x",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl53l1x/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l1x",
-        "deviceId": "vl53l1x",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/vl53l1x/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/vl53l1x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l1x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/vl53l1x/schematic.png",
         "verified": false
       }
     ]

--- a/data/platform-examples/platform-examples.json
+++ b/data/platform-examples/platform-examples.json
@@ -1422,20 +1422,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ads1015",
-        "deviceId": "ads1015",
-        "platform": "node",
-        "localPath": "examples/devices/ads1015/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ads1015",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ads1015",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ads1015/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ads1015",
         "deviceId": "ads1015",
@@ -1447,20 +1433,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ads1015",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ads1015/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ads1015",
-        "deviceId": "ads1015",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ads1015/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ads1015",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ads1015",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ads1015/schematic.png",
         "verified": false
       }
     ]
@@ -1518,20 +1490,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
-        "deviceId": "adt7410",
-        "platform": "node",
-        "localPath": "examples/devices/adt7410/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/adt7410",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410",
         "deviceId": "adt7410",
@@ -1543,20 +1501,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adt7410",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
-        "deviceId": "adt7410",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/adt7410/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/adt7410",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png",
         "verified": false
       }
     ]
@@ -1620,20 +1564,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/amg8833",
-        "deviceId": "amg8833",
-        "platform": "node",
-        "localPath": "examples/devices/amg8833/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/amg8833",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/amg8833",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/amg8833/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/amg8833",
         "deviceId": "amg8833",
@@ -1645,40 +1575,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/amg8833",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/amg8833/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/amg8833",
-        "deviceId": "amg8833",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/amg8833/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/amg8833",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/amg8833",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/amg8833/schematic.png",
-        "verified": false
-      }
-    ]
-  },
-  {
-    "dashboardDeviceId": "i2c-apds9960",
-    "exampleDeviceId": "apds9960",
-    "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/apds9960",
-        "deviceId": "apds9960",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/apds9960/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/apds9960",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/apds9960",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/apds9960/schematic.png",
         "verified": false
       }
     ]
@@ -1756,20 +1652,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bh1750",
-        "deviceId": "bh1750",
-        "platform": "node",
-        "localPath": "examples/devices/bh1750/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bh1750",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bh1750",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bh1750/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bh1750",
         "deviceId": "bh1750",
@@ -1781,20 +1663,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bh1750",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bh1750/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bh1750",
-        "deviceId": "bh1750",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bh1750/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bh1750",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bh1750",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bh1750/schematic.png",
         "verified": false
       }
     ]
@@ -1818,20 +1686,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bme280",
-        "deviceId": "bme280",
-        "platform": "node",
-        "localPath": "examples/devices/bme280/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bme280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bme280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bme280/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme280",
         "deviceId": "bme280",
@@ -1843,20 +1697,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme280",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bme280/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme280",
-        "deviceId": "bme280",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bme280/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bme280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bme280/schematic.png",
         "verified": false
       }
     ]
@@ -1877,20 +1717,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/bme680",
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/bme680/imgs/pinbit_bme680.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme680",
-        "deviceId": "bme680",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bme680/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bme680",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bme680",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bme680/BME680schematic.png",
         "verified": false
       }
     ]
@@ -1914,20 +1740,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp180",
-        "deviceId": "bmp180",
-        "platform": "node",
-        "localPath": "examples/devices/bmp180/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bmp180",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp180",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bmp180/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp180",
         "deviceId": "bmp180",
@@ -1939,20 +1751,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp180",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bmp180/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp180",
-        "deviceId": "bmp180",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bmp180/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bmp180",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp180",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bmp180/schematic.png",
         "verified": false
       }
     ]
@@ -1976,20 +1774,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp280",
-        "deviceId": "bmp280",
-        "platform": "node",
-        "localPath": "examples/devices/bmp280/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/bmp280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/bmp280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/bmp280/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp280",
         "deviceId": "bmp280",
@@ -2001,20 +1785,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bmp280",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/bmp280/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp280",
-        "deviceId": "bmp280",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/bmp280/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/bmp280",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/bmp280",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/bmp280/schematic.png",
         "verified": false
       }
     ]
@@ -2035,20 +1805,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/ccs811",
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/ccs811/imgs/pinbit_ccs811.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ccs811",
-        "deviceId": "ccs811",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ccs811/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ccs811",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ccs811",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ccs811/CCS811schematic.png",
         "verified": false
       }
     ]
@@ -2092,20 +1848,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/gp2y0e03",
-        "deviceId": "gp2y0e03",
-        "platform": "node",
-        "localPath": "examples/devices/gp2y0e03/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/gp2y0e03",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/gp2y0e03",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/gp2y0e03/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/gp2y0e03",
         "deviceId": "gp2y0e03",
@@ -2117,20 +1859,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/gp2y0e03",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/gp2y0e03/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/gp2y0e03",
-        "deviceId": "gp2y0e03",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/gp2y0e03/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/gp2y0e03",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/gp2y0e03",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/gp2y0e03/schematic.png",
         "verified": false
       }
     ]
@@ -2174,20 +1902,6 @@
     "exampleDeviceId": "adxl345",
     "examples": [
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adxl345",
-        "deviceId": "adxl345",
-        "platform": "node",
-        "localPath": "examples/devices/adxl345/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/adxl345",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adxl345",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adxl345/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adxl345",
         "deviceId": "adxl345",
@@ -2199,20 +1913,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/adxl345",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adxl345/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
-        "deviceId": "adxl345",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/adxl345/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/adxl345",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adxl345",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adxl345/schematic.png",
         "verified": false
       }
     ]
@@ -2256,20 +1956,6 @@
     "exampleDeviceId": "tsl2561",
     "examples": [
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tsl2561",
-        "deviceId": "tsl2561",
-        "platform": "node",
-        "localPath": "examples/devices/tsl2561/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/tsl2561",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tsl2561",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/tsl2561/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tsl2561",
         "deviceId": "tsl2561",
@@ -2281,20 +1967,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tsl2561",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/tsl2561/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tsl2561",
-        "deviceId": "tsl2561",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/tsl2561/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/tsl2561",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tsl2561",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/tsl2561/schematic.png",
         "verified": false
       }
     ]
@@ -2318,20 +1990,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1308",
-        "deviceId": "ssd1308",
-        "platform": "node",
-        "localPath": "examples/devices/ssd1308/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ssd1308",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1308",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ssd1308/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1308",
         "deviceId": "ssd1308",
@@ -2344,20 +2002,6 @@
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ssd1308/schematic.png",
         "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1308",
-        "deviceId": "ssd1308",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ssd1308/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ssd1308",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1308",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ssd1308/schematic.png",
-        "verified": false
       }
     ]
   },
@@ -2365,20 +2009,6 @@
     "dashboardDeviceId": "i2c-grove-touch-mpr121",
     "exampleDeviceId": "mpr121",
     "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpr121",
-        "deviceId": "mpr121",
-        "platform": "node",
-        "localPath": "examples/devices/mpr121/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mpr121",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpr121",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpr121/schematic.png",
-        "verified": false
-      },
       {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpr121",
@@ -2391,20 +2021,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpr121",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpr121/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpr121",
-        "deviceId": "mpr121",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mpr121/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mpr121",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpr121",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpr121/schematic.png",
         "verified": false
       }
     ]
@@ -2588,20 +2204,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ina219",
-        "deviceId": "ina219",
-        "platform": "node",
-        "localPath": "examples/devices/ina219/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ina219",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ina219",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ina219/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ina219",
         "deviceId": "ina219",
@@ -2613,20 +2215,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ina219",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ina219/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ina219",
-        "deviceId": "ina219",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ina219/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ina219",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ina219",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ina219/schematic.png",
         "verified": false
       }
     ]
@@ -2730,20 +2318,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mlx90614",
-        "deviceId": "mlx90614",
-        "platform": "node",
-        "localPath": "examples/devices/mlx90614/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mlx90614",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mlx90614",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mlx90614/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mlx90614",
         "deviceId": "mlx90614",
@@ -2755,20 +2329,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mlx90614",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mlx90614/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mlx90614",
-        "deviceId": "mlx90614",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mlx90614/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mlx90614",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mlx90614",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mlx90614/schematic.png",
         "verified": false
       }
     ]
@@ -2792,20 +2352,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu6050",
-        "deviceId": "mpu6050",
-        "platform": "node",
-        "localPath": "examples/devices/mpu6050/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mpu6050",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu6050",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpu6050/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu6050",
         "deviceId": "mpu6050",
@@ -2817,20 +2363,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu6050",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpu6050/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu6050",
-        "deviceId": "mpu6050",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mpu6050/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mpu6050",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu6050",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpu6050/schematic.png",
         "verified": false
       }
     ]
@@ -2854,20 +2386,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu9250",
-        "deviceId": "mpu9250",
-        "platform": "node",
-        "localPath": "examples/devices/mpu9250/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/mpu9250",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/mpu9250",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/mpu9250/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu9250",
         "deviceId": "mpu9250",
@@ -2879,20 +2397,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mpu9250",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mpu9250/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu9250",
-        "deviceId": "mpu9250",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/mpu9250/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/mpu9250",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/mpu9250",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/mpu9250/schematic.png",
         "verified": false
       }
     ]
@@ -2916,20 +2420,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -2941,20 +2431,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -2978,20 +2454,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -3003,20 +2465,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -3040,20 +2488,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -3065,20 +2499,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -3102,20 +2522,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "deviceId": "neopixel-i2c",
@@ -3127,20 +2533,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/neopixel-i2c",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/neopixel-i2c/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "deviceId": "neopixel-i2c",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/neopixel-i2c/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/neopixel-i2c",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/neopixel-i2c",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/neopixel-i2c/schematic.png",
         "verified": false
       }
     ]
@@ -3178,20 +2570,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pca9685",
-        "deviceId": "pca9685",
-        "platform": "node",
-        "localPath": "examples/devices/pca9685/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/pca9685",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pca9685",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/pca9685/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pca9685",
         "deviceId": "pca9685",
@@ -3203,20 +2581,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pca9685",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/pca9685/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pca9685",
-        "deviceId": "pca9685",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/pca9685/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/pca9685",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pca9685",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/pca9685/schematic.png",
         "verified": false
       }
     ]
@@ -3246,20 +2610,6 @@
     "exampleDeviceId": "pcf8591",
     "examples": [
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pcf8591",
-        "deviceId": "pcf8591",
-        "platform": "node",
-        "localPath": "examples/devices/pcf8591/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/pcf8591",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/pcf8591",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/pcf8591/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pcf8591",
         "deviceId": "pcf8591",
@@ -3271,20 +2621,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/pcf8591",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/pcf8591/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pcf8591",
-        "deviceId": "pcf8591",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/pcf8591/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/pcf8591",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/pcf8591",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/pcf8591/schematic.png",
         "verified": false
       }
     ]
@@ -3322,20 +2658,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/s11059",
-        "deviceId": "s11059",
-        "platform": "node",
-        "localPath": "examples/devices/s11059/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/s11059",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/s11059",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/s11059/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/s11059",
         "deviceId": "s11059",
@@ -3347,20 +2669,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/s11059",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/s11059/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/s11059",
-        "deviceId": "s11059",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/s11059/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/s11059",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/s11059",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/s11059/schematic.png",
         "verified": false
       }
     ]
@@ -3458,20 +2766,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/sht30",
-        "deviceId": "sht30",
-        "platform": "node",
-        "localPath": "examples/devices/sht30/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/sht30",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/sht30",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/sht30/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/sht30",
         "deviceId": "sht30",
@@ -3483,20 +2777,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/sht30",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/sht30/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/sht30",
-        "deviceId": "sht30",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/sht30/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/sht30",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/sht30",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/sht30/schematic.png",
         "verified": false
       }
     ]
@@ -3526,20 +2806,6 @@
     "exampleDeviceId": "ssd1306",
     "examples": [
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1306",
-        "deviceId": "ssd1306",
-        "platform": "node",
-        "localPath": "examples/devices/ssd1306/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/ssd1306",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/ssd1306",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/ssd1306/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ssd1306",
         "deviceId": "ssd1306",
@@ -3552,20 +2818,6 @@
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/ssd1306/schematic.png",
         "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1306",
-        "deviceId": "ssd1306",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/ssd1306/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/ssd1306",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/ssd1306",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/ssd1306/schematic.png",
-        "verified": false
       }
     ]
   },
@@ -3573,20 +2825,6 @@
     "dashboardDeviceId": "i2c-tcs34725",
     "exampleDeviceId": "tcs34725",
     "examples": [
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tcs34725",
-        "deviceId": "tcs34725",
-        "platform": "node",
-        "localPath": "examples/devices/tcs34725/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/tcs34725",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/tcs34725",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/tcs34725/schematic.png",
-        "verified": false
-      },
       {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tcs34725",
@@ -3599,20 +2837,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tcs34725",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/tcs34725/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tcs34725",
-        "deviceId": "tcs34725",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/tcs34725/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/tcs34725",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/tcs34725",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/tcs34725/schematic.png",
         "verified": false
       }
     ]
@@ -3670,20 +2894,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/veml6070",
-        "deviceId": "veml6070",
-        "platform": "node",
-        "localPath": "examples/devices/veml6070/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/veml6070",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/veml6070",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/veml6070/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/veml6070",
         "deviceId": "veml6070",
@@ -3695,20 +2905,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/veml6070",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/veml6070/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/veml6070",
-        "deviceId": "veml6070",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/veml6070/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/veml6070",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/veml6070",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/veml6070/schematic.png",
         "verified": false
       }
     ]
@@ -3746,20 +2942,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l0x",
-        "deviceId": "vl53l0x",
-        "platform": "node",
-        "localPath": "examples/devices/vl53l0x/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/vl53l0x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l0x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/vl53l0x/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l0x",
         "deviceId": "vl53l0x",
@@ -3771,20 +2953,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l0x",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl53l0x/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l0x",
-        "deviceId": "vl53l0x",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/vl53l0x/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/vl53l0x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l0x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/vl53l0x/schematic.png",
         "verified": false
       }
     ]
@@ -3808,20 +2976,6 @@
         "verified": false
       },
       {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l1x",
-        "deviceId": "vl53l1x",
-        "platform": "node",
-        "localPath": "examples/devices/vl53l1x/platforms/node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "node-examples/vl53l1x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/vl53l1x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/vl53l1x/schematic.png",
-        "verified": false
-      },
-      {
         "hardware": "Pi Zero",
         "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l1x",
         "deviceId": "vl53l1x",
@@ -3833,20 +2987,6 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/vl53l1x",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/vl53l1x/schematic.png",
-        "verified": false
-      },
-      {
-        "hardware": "Raspberry Pi",
-        "code": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l1x",
-        "deviceId": "vl53l1x",
-        "platform": "raspi-node",
-        "localPath": "examples/devices/vl53l1x/platforms/raspi-node",
-        "upstreamRepository": "chirimen-oh/chirimen-drivers",
-        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen-drivers",
-        "upstreamPath": "raspi-examples/vl53l1x",
-        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/vl53l1x",
-        "status": "legacy",
-        "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/vl53l1x/schematic.png",
         "verified": false
       }
     ]

--- a/libs/devices/device-detail/src/lib/device-detail/device-detail.component.spec.ts
+++ b/libs/devices/device-detail/src/lib/device-detail/device-detail.component.spec.ts
@@ -86,8 +86,6 @@ describe('DeviceDetailComponent', () => {
 
     expect(headings).toContain('Platform 別 Example');
     expect(compiled.textContent).toContain('pizero-esm');
-    expect(compiled.textContent).toContain('node');
-    expect(compiled.textContent).toContain('raspi-node');
     expect(compiled.textContent).toContain('microbit-driver');
     expect(compiled.textContent).toContain('legacy-gc-i2c');
     expect(compiled.querySelector('table')).toBeTruthy();

--- a/libs/devices/device-detail/src/lib/testing/platform-examples.fixture.ts
+++ b/libs/devices/device-detail/src/lib/testing/platform-examples.fixture.ts
@@ -18,38 +18,6 @@ export const adt7410PlatformExamples: ExampleInfo[] = [
     verified: false,
   },
   {
-    hardware: 'Raspberry Pi',
-    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-    deviceId: 'adt7410',
-    platform: 'node',
-    localPath: 'examples/devices/adt7410/platforms/node',
-    upstreamRepository: 'chirimen-oh/chirimen-drivers',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-    upstreamPath: 'node-examples/adt7410',
-    upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-    status: 'legacy',
-    circuitUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png',
-    verified: false,
-  },
-  {
-    hardware: 'Raspberry Pi',
-    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-    deviceId: 'adt7410',
-    platform: 'raspi-node',
-    localPath: 'examples/devices/adt7410/platforms/raspi-node',
-    upstreamRepository: 'chirimen-oh/chirimen-drivers',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-    upstreamPath: 'raspi-examples/adt7410',
-    upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-    status: 'legacy',
-    circuitUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png',
-    verified: false,
-  },
-  {
     hardware: 'micro:bit',
     code: 'https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410',
     deviceId: 'adt7410',

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-example-card/platform-specific-example-card.component.spec.ts
@@ -8,7 +8,7 @@ describe('PlatformSpecificExampleCardComponent', () => {
   let component: PlatformSpecificExampleCardComponent;
   let fixture: ComponentFixture<PlatformSpecificExampleCardComponent>;
 
-  const example = adt7410PlatformExamples[3];
+  const example = adt7410PlatformExamples[2];
   if (!isPlatformSpecificExample(example)) {
     throw new Error('fixture example must be platform-specific');
   }

--- a/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
+++ b/libs/devices/platform-specific-examples/src/lib/platform-specific-examples/platform-specific-examples.component.spec.ts
@@ -30,7 +30,7 @@ describe('PlatformSpecificExamplesComponent', () => {
     fixture.componentRef.setInput('examples', adt7410PlatformExamples);
     fixture.detectChanges();
 
-    expect(component.platformSpecificExamples()).toHaveLength(5);
+    expect(component.platformSpecificExamples()).toHaveLength(3);
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.textContent).toContain('pizero-esm');
     expect(compiled.textContent).toContain('legacy-gc-i2c');
@@ -46,8 +46,6 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(platforms).toEqual([
       'pizero-esm',
       'microbit-driver',
-      'node',
-      'raspi-node',
       'legacy-gc-i2c',
     ]);
   });
@@ -125,7 +123,7 @@ describe('PlatformSpecificExamplesComponent', () => {
   });
 
   it('should truncate only upstream path cells', () => {
-    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[3]]);
+    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[2]]);
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
@@ -153,11 +151,11 @@ describe('PlatformSpecificExamplesComponent', () => {
     expect(table?.textContent).toContain('primary');
     expect(table?.textContent).toContain('legacy');
     expect(table?.textContent).toContain('archive');
-    expect(table?.querySelectorAll('tbody span.rounded-md').length).toBe(5);
+    expect(table?.querySelectorAll('tbody span.rounded-md').length).toBe(3);
   });
 
   it('should render table links for repository, path, and circuit', () => {
-    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[3]]);
+    fixture.componentRef.setInput('examples', [adt7410PlatformExamples[2]]);
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
@@ -190,6 +188,6 @@ describe('PlatformSpecificExamplesComponent', () => {
 
     const compiled = fixture.nativeElement as HTMLElement;
     const cards = compiled.querySelectorAll('choh-platform-specific-example-card');
-    expect(cards.length).toBe(5);
+    expect(cards.length).toBe(3);
   });
 });

--- a/libs/devices/platform-specific-examples/src/lib/testing/platform-examples.fixture.ts
+++ b/libs/devices/platform-specific-examples/src/lib/testing/platform-examples.fixture.ts
@@ -34,22 +34,6 @@ export const adt7410PlatformExamples: ExampleInfo[] = [
     verified: false,
   },
   {
-    hardware: 'Raspberry Pi',
-    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-    deviceId: 'adt7410',
-    platform: 'node',
-    localPath: 'examples/devices/adt7410/platforms/node',
-    upstreamRepository: 'chirimen-oh/chirimen-drivers',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-    upstreamPath: 'node-examples/adt7410',
-    upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-    status: 'legacy',
-    circuitUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png',
-    verified: false,
-  },
-  {
     hardware: 'Pi Zero',
     code: 'https://tutorial.chirimen.org/pizero/esm-examples/#I2C_adt7410',
     deviceId: 'adt7410',
@@ -63,22 +47,6 @@ export const adt7410PlatformExamples: ExampleInfo[] = [
     status: 'primary',
     circuitUrl:
       'https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/adt7410/PiZero_ADT7410.png',
-    verified: false,
-  },
-  {
-    hardware: 'Raspberry Pi',
-    code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-    deviceId: 'adt7410',
-    platform: 'raspi-node',
-    localPath: 'examples/devices/adt7410/platforms/raspi-node',
-    upstreamRepository: 'chirimen-oh/chirimen-drivers',
-    upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-    upstreamPath: 'raspi-examples/adt7410',
-    upstreamPathUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-    status: 'legacy',
-    circuitUrl:
-      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png',
     verified: false,
   },
 ];
@@ -96,5 +64,5 @@ export const legacyOnlyExamples: ExampleInfo[] = [
 
 export const mixedExamples: ExampleInfo[] = [
   ...legacyOnlyExamples,
-  adt7410PlatformExamples[3],
+  adt7410PlatformExamples[2],
 ];

--- a/tools/scripts/generate-platform-examples/src/generate-platform-examples.spec.ts
+++ b/tools/scripts/generate-platform-examples/src/generate-platform-examples.spec.ts
@@ -38,7 +38,10 @@ describe('buildPlatformExamplesJson', () => {
           exampleDeviceId: 'adt7410',
           examples: [
             makeExample('pizero-esm'),
-            makeExample('node', { hardware: 'Raspberry Pi', status: 'legacy' }),
+            makeExample('microbit-driver', {
+              hardware: 'micro:bit',
+              status: 'legacy',
+            }),
           ],
           warnings: [],
         },
@@ -49,7 +52,7 @@ describe('buildPlatformExamplesJson', () => {
     expect(result).toHaveLength(1);
     expect(result[0].dashboardDeviceId).toBe('i2c-adt7410');
     expect(result[0].examples.map((e) => e.platform)).toEqual([
-      'node',
+      'microbit-driver',
       'pizero-esm',
     ]);
   });

--- a/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
+++ b/tools/scripts/sync-devices/src/apply-platform-examples.spec.ts
@@ -53,7 +53,7 @@ function createDevice(
 }
 
 describe('applyPlatformExamples', () => {
-  it('replaces i2c-adt7410 product.example with 5 platform entries', () => {
+  it('replaces i2c-adt7410 product.example with 3 platform entries', () => {
     const platformEntries = loadPlatformEntry('i2c-adt7410');
     const devices = [
       createDevice('i2c-adt7410', [
@@ -69,7 +69,7 @@ describe('applyPlatformExamples', () => {
     );
 
     expect(warnings).toHaveLength(0);
-    expect(merged[0].product.example).toHaveLength(5);
+    expect(merged[0].product.example).toHaveLength(3);
   });
 
   it('includes all required ADT7410 platforms as platform-specific examples', () => {
@@ -86,8 +86,6 @@ describe('applyPlatformExamples', () => {
     expect(platforms.sort()).toEqual(
       [
         'pizero-esm',
-        'node',
-        'raspi-node',
         'microbit-driver',
         'legacy-gc-i2c',
       ].sort()
@@ -124,7 +122,7 @@ describe('applyPlatformExamples', () => {
     const { devices: merged } = applyPlatformExamples(devices, platformEntries);
 
     expect(merged[0].product.example).toEqual(originalExamples);
-    expect(merged[1].product.example).toHaveLength(5);
+    expect(merged[1].product.example).toHaveLength(3);
   });
 
   it('warns when platform-examples.json references an unknown dashboardDeviceId', () => {

--- a/tools/scripts/sync-example-upstreams/src/build-example-urls.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/build-example-urls.spec.ts
@@ -29,20 +29,20 @@ describe('buildExampleUrls', () => {
     expect(
       buildCircuitBlobUrl(
         'chirimen-oh/chirimen-drivers',
-        'node-examples/adt7410',
-        'schematic.png'
+        'microbit-examples/adt7410',
+        'imgs/pinbit_adt7410.png'
       )
     ).toBe(
-      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png'
+      'https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/adt7410/imgs/pinbit_adt7410.png'
     );
   });
 
   it('builds full example urls object', () => {
     const urls = buildExampleUrls(
       'chirimen-oh/chirimen-drivers',
-      'node-examples/adt7410',
+      'microbit-examples/adt7410',
       'master',
-      'schematic.png'
+      'imgs/pinbit_adt7410.png'
     );
     expect(urls.upstreamRepositoryUrl).toContain('chirimen-drivers');
     expect(urls.upstreamPathUrl).toContain('/tree/master/');
@@ -61,8 +61,8 @@ describe('buildExampleUrls', () => {
 
 describe('buildUpstreamPath', () => {
   it('joins source path and dir name', () => {
-    expect(buildUpstreamPath('node-examples', 'adt7410')).toBe(
-      'node-examples/adt7410'
+    expect(buildUpstreamPath('microbit-examples', 'adt7410')).toBe(
+      'microbit-examples/adt7410'
     );
   });
 

--- a/tools/scripts/sync-example-upstreams/src/build-example-urls.ts
+++ b/tools/scripts/sync-example-upstreams/src/build-example-urls.ts
@@ -8,8 +8,6 @@ export type ExampleUrls = {
 
 const PLATFORM_HARDWARE: Record<string, string> = {
   'pizero-esm': 'Pi Zero',
-  node: 'Raspberry Pi',
-  'raspi-node': 'Raspberry Pi',
   'microbit-driver': 'micro:bit',
   'microbit-web': 'micro:bit',
   'legacy-gc-gpio': 'chirimen',

--- a/tools/scripts/validate-platform-examples/src/validate-device-product-examples.spec.ts
+++ b/tools/scripts/validate-platform-examples/src/validate-device-product-examples.spec.ts
@@ -78,7 +78,7 @@ describe('comparePlatformExamplesWithSource', () => {
         examples: [
           {
             ...platformSpecificExample,
-            platform: 'node',
+            platform: 'microbit-driver',
           },
         ],
       },

--- a/tools/scripts/validate-platform-examples/src/validate-platform-examples.spec.ts
+++ b/tools/scripts/validate-platform-examples/src/validate-platform-examples.spec.ts
@@ -29,38 +29,6 @@ const validAdt7410Entry: PlatformExampleDeviceEntry = {
       verified: false,
     },
     {
-      hardware: 'Raspberry Pi',
-      code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-      deviceId: 'adt7410',
-      platform: 'node',
-      localPath: 'examples/devices/adt7410/platforms/node',
-      upstreamRepository: 'chirimen-oh/chirimen-drivers',
-      upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-      upstreamPath: 'node-examples/adt7410',
-      upstreamPathUrl:
-        'https://github.com/chirimen-oh/chirimen-drivers/tree/master/node-examples/adt7410',
-      status: 'legacy',
-      circuitUrl:
-        'https://github.com/chirimen-oh/chirimen-drivers/blob/master/node-examples/adt7410/schematic.png',
-      verified: false,
-    },
-    {
-      hardware: 'Raspberry Pi',
-      code: 'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-      deviceId: 'adt7410',
-      platform: 'raspi-node',
-      localPath: 'examples/devices/adt7410/platforms/raspi-node',
-      upstreamRepository: 'chirimen-oh/chirimen-drivers',
-      upstreamRepositoryUrl: 'https://github.com/chirimen-oh/chirimen-drivers',
-      upstreamPath: 'raspi-examples/adt7410',
-      upstreamPathUrl:
-        'https://github.com/chirimen-oh/chirimen-drivers/tree/master/raspi-examples/adt7410',
-      status: 'legacy',
-      circuitUrl:
-        'https://github.com/chirimen-oh/chirimen-drivers/blob/master/raspi-examples/adt7410/schematic.png',
-      verified: false,
-    },
-    {
       hardware: 'micro:bit',
       code: 'https://chirimen.org/chirimen-micro-bit/examples/#I2C1_ADT7410',
       deviceId: 'adt7410',
@@ -132,7 +100,7 @@ describe('validatePlatformExamples', () => {
 });
 
 describe('validateAdt7410Platforms', () => {
-  it('passes when all 5 platforms are present', () => {
+  it('passes when all 3 platforms are present', () => {
     expect(validateAdt7410Platforms([validAdt7410Entry])).toHaveLength(0);
   });
 

--- a/tools/scripts/validate-platform-examples/src/validate-platform-examples.ts
+++ b/tools/scripts/validate-platform-examples/src/validate-platform-examples.ts
@@ -22,8 +22,6 @@ const VALID_STATUSES: ExampleStatus[] = [
 
 const ADT7410_PLATFORMS = [
   'pizero-esm',
-  'node',
-  'raspi-node',
   'microbit-driver',
   'legacy-gc-i2c',
 ] as const;


### PR DESCRIPTION
## Summary

Issue #214 に対応し、`chirimen-drivers` 側で削除予定の legacy Node.js / Raspberry Pi examples を `devices.json` 生成フローから除外します。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #214

## What changed?

- `sync-example-upstreams` の upstream source から削除予定の driver example source を除外しました。
- `platform-examples.json` / `platform-examples.generated.json` / `devices.json` から該当 platform entry を削除しました。
- ADT7410 の期待 platform を `pizero-esm`, `microbit-driver`, `legacy-gc-i2c` の 3 種に更新し、関連テスト・fixture・README を更新しました。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `devices.json` の `product.example` から削除予定 source に由来する legacy platform entries が除外されます。TypeScript の公開 export / 関数シグネチャ変更はありません。
- [ ] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx run-many -t test -p sync-example-upstreams generate-platform-examples validate-platform-examples sync-devices libs-platform-specific-examples libs-device-detail --nxBail`
2. `pnpm generate:devices`
3. `pnpm nx serve web` でローカル起動し、デバイス一覧と `i2c-adt7410` 詳細の Platform 別 Example 表示を確認
4. `rg "node-examples|raspi-examples"` と `rg "(^|[^A-Za-z0-9_-])examples/[^/]+\\.md"` で削除対象参照が残っていないことを確認

## Environment (if relevant)

- Browser: Cursor browser tab / localhost
- OS: macOS
- Node version: 24.16.0
- pnpm version: 11.8.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)