### PR TITLE
fix(ci): avoid duplicate refresh device workflow runs

### DIFF
--- a/.github/workflows/refresh-devices.yml
+++ b/.github/workflows/refresh-devices.yml
@@ -168,7 +168,8 @@ jobs:
         run: |
           gh issue comment "${{ steps.request.outputs.issue_number }}" --body "最新の \`partslist.csv\` と upstream example を同期しましたが、\`main\` との差分はありませんでした。
 
-          ダッシュボードへ反映する追加変更はありません。"
+          ダッシュボードへ反映する追加変更はないため、この Issue を完了として close します。"
+          gh issue close "${{ steps.request.outputs.issue_number }}" --reason completed
 
       - name: Comment on failure
         if: failure() && github.event_name == 'issues'

--- a/.github/workflows/refresh-devices.yml
+++ b/.github/workflows/refresh-devices.yml
@@ -3,7 +3,7 @@ name: Refresh devices data
 on:
   workflow_dispatch:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 permissions:
   contents: write
@@ -51,7 +51,7 @@ jobs:
 
       - name: Save upstream mirrors cache
         uses: actions/cache/save@v4
-        if: success()
+        if: success() && github.event_name != 'issues'
         with:
           path: generated/upstreams
           key: example-upstreams-${{ steps.sources.outputs.hash }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary

Issue #222 に対応し、`refresh-devices` ラベル付き Issue で `Refresh devices data` workflow が重複実行されないようにしました。差分なしの場合はデプロイを行わず、Issue に完了コメントを残して自動 close します。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #222

## What changed?

- `refresh-devices.yml` の Issue trigger を `opened + labeled` から `labeled` のみに変更
- Issue 起動時は upstream mirrors cache の save を skip し、cache write 権限 warning を抑制
- `main` との差分がない場合、PR を作らず Issue に「差分なし・反映不要」をコメントして close
- 差分ありの場合は従来通り同期 PR を作成し、deploy 成功後に Issue を close

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details: なし
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: なし

## How to test

1. `pnpm exec prettier --check .github/workflows/refresh-devices.yml .github/workflows/deploy.yml`
2. `pnpm nx run sync-devices:test`
3. `pnpm nx run generate-platform-examples:test`
4. `pnpm nx run validate-platform-examples:test`

## Environment (if relevant)

- Browser: N/A
- OS: macOS / Linux
- Node version: 24
- pnpm version: 11.8.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)