### PR TITLE
feat(sync-example-upstreams): add refresh source hash report

### DIFF
--- a/.github/workflows/refresh-devices.yml
+++ b/.github/workflows/refresh-devices.yml
@@ -117,12 +117,14 @@ jobs:
             - `apps/web/public/devices.json` — 最新 `partslist.csv` と正本 `platform-examples.json` に基づく再生成結果
             - `data/platform-examples/**` — upstream example から生成した review 用候補 JSON
             - `generated/reports/**` — example 同期・validation レポート
+            - `generated/reports/refresh-sources.json` — `partslist.csv` と upstream example の取得元 commit hash
 
             ## Review points
 
             - `platform-examples.generated.json` と正本 `platform-examples.json` の差分を確認してください
             - 正本 `platform-examples.json` への手動マージが必要な場合は、レビュー後に別途反映してください
             - `devices.json` の追加・削除・`product.example` 洗い替え結果を確認してください
+            - `refresh-sources.json` で同期元 repository / branch / commit を確認してください
             - validation レポートに issue / warning がないか確認してください
 
             ## API / Compatibility

--- a/tools/scripts/sync-example-upstreams/src/main.ts
+++ b/tools/scripts/sync-example-upstreams/src/main.ts
@@ -12,6 +12,7 @@ import {
 import { resolveExampleDeviceId } from './resolve-example-device-id';
 import type { SourceSyncResult, SyncSummary, UpstreamSource } from './types';
 import { writeExampleCandidatesReport } from './write-example-candidates-report';
+import { writeRefreshSourcesReport } from './write-refresh-sources-report';
 import { writeSyncSummary } from './write-sync-summary';
 
 function getRepoRoot(): string {
@@ -22,7 +23,7 @@ async function syncSource(
   repoRoot: string,
   source: UpstreamSource,
   dashboardDeviceIds: string[],
-  overrides: Record<string, DeviceIdOverrideValue>
+  overrides: Record<string, DeviceIdOverrideValue>,
 ): Promise<SourceSyncResult> {
   const result: SourceSyncResult = {
     sourceId: source.id,
@@ -39,7 +40,7 @@ async function syncSource(
   try {
     const { mirrorPath: mirror, commitSha } = await cloneOrFetchSource(
       repoRoot,
-      source
+      source,
     );
     result.mirrorPath = mirror;
     result.commitSha = commitSha;
@@ -54,7 +55,7 @@ async function syncSource(
         ? resolveDashboardDeviceId(
             parsedExampleDeviceId,
             dashboardDeviceIds,
-            overrides
+            overrides,
           )
         : {
             dashboardDeviceIds: [],
@@ -96,7 +97,7 @@ async function main(): Promise<void> {
       repoRoot,
       source,
       dashboardDeviceIds,
-      overrides
+      overrides,
     );
     sourceResults.push(result);
     if (result.errors.length > 0) {
@@ -114,13 +115,23 @@ async function main(): Promise<void> {
   const summaryPath = await writeSyncSummary(repoRoot, summary);
   const candidatesReportPath = await writeExampleCandidatesReport(
     repoRoot,
-    summary
+    summary,
+  );
+  const refreshSourcesReport = await writeRefreshSourcesReport(
+    repoRoot,
+    summary,
   );
 
   console.log(`Sync complete.`);
   console.log(`  Summary: ${path.relative(repoRoot, summaryPath)}`);
   console.log(
-    `  Candidates report: ${path.relative(repoRoot, candidatesReportPath)}`
+    `  Candidates report: ${path.relative(repoRoot, candidatesReportPath)}`,
+  );
+  console.log(
+    `  Refresh sources: ${path.relative(
+      repoRoot,
+      refreshSourcesReport.filePath,
+    )} (${refreshSourcesReport.changed ? 'updated' : 'unchanged'})`,
   );
   console.log(`  Next: pnpm generate:platform-examples`);
 
@@ -128,7 +139,7 @@ async function main(): Promise<void> {
     const relMirror = path.relative(repoRoot, source.mirrorPath);
     const status = source.errors.length > 0 ? 'ERROR' : 'OK';
     console.log(
-      `  [${status}] ${source.sourceId}: ${source.exampleCount} example(s) → ${relMirror}`
+      `  [${status}] ${source.sourceId}: ${source.exampleCount} example(s) → ${relMirror}`,
     );
   }
 

--- a/tools/scripts/sync-example-upstreams/src/types.ts
+++ b/tools/scripts/sync-example-upstreams/src/types.ts
@@ -1,4 +1,7 @@
-import type { ExampleInfo, ExampleStatus } from '@chirimen-device-dashboard/shared-types';
+import type {
+  ExampleInfo,
+  ExampleStatus,
+} from '@chirimen-device-dashboard/shared-types';
 
 export interface UpstreamSource {
   id: string;
@@ -48,6 +51,24 @@ export interface SyncSummary {
   repoRoot: string;
   sources: SourceSyncResult[];
   fatalErrors: string[];
+}
+
+export interface RefreshSourceReport {
+  generatedAt: string;
+  partslist: {
+    repository: string;
+    branch: string;
+    path: string;
+    commit: string | null;
+  };
+  examples: {
+    sourceId: string;
+    repository: string;
+    branch: string;
+    path: string;
+    platform: string;
+    commit: string | null;
+  }[];
 }
 
 export interface PlatformExampleDeviceEntry {

--- a/tools/scripts/sync-example-upstreams/src/write-refresh-sources-report.spec.ts
+++ b/tools/scripts/sync-example-upstreams/src/write-refresh-sources-report.spec.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { SyncSummary } from './types';
+import {
+  buildRefreshSourceReport,
+  writeRefreshSourcesReport,
+} from './write-refresh-sources-report';
+
+function createSummary(overrides: Partial<SyncSummary> = {}): SyncSummary {
+  return {
+    generatedAt: '2026-07-04T00:00:00.000Z',
+    repoRoot: '/repo',
+    fatalErrors: [],
+    sources: [
+      {
+        sourceId: 'chirimen-org-pizero-esm',
+        repo: 'chirimen-oh/chirimen.org',
+        branch: 'master',
+        path: 'pizero/src/esm-examples',
+        platform: 'pizero-esm',
+        mirrorPath: '/repo/generated/upstreams/chirimen-org-pizero-esm',
+        commitSha: 'partslist-and-example-sha',
+        exampleCount: 1,
+        errors: [],
+        candidates: [],
+      },
+      {
+        sourceId: 'chirimen-drivers-microbit',
+        repo: 'chirimen-oh/chirimen-drivers',
+        branch: 'master',
+        path: 'microbit-examples',
+        platform: 'microbit-driver',
+        mirrorPath: '/repo/generated/upstreams/chirimen-drivers-microbit',
+        commitSha: 'driver-sha',
+        exampleCount: 1,
+        errors: [],
+        candidates: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('buildRefreshSourceReport', () => {
+  it('records partslist and upstream example source commits', () => {
+    const report = buildRefreshSourceReport(createSummary());
+
+    expect(report.partslist).toEqual({
+      repository: 'chirimen-oh/chirimen.org',
+      branch: 'master',
+      path: '_data/partslist.csv',
+      commit: 'partslist-and-example-sha',
+    });
+    expect(report.examples).toEqual([
+      {
+        sourceId: 'chirimen-org-pizero-esm',
+        repository: 'chirimen-oh/chirimen.org',
+        branch: 'master',
+        path: 'pizero/src/esm-examples',
+        platform: 'pizero-esm',
+        commit: 'partslist-and-example-sha',
+      },
+      {
+        sourceId: 'chirimen-drivers-microbit',
+        repository: 'chirimen-oh/chirimen-drivers',
+        branch: 'master',
+        path: 'microbit-examples',
+        platform: 'microbit-driver',
+        commit: 'driver-sha',
+      },
+    ]);
+  });
+});
+
+describe('writeRefreshSourcesReport', () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('keeps the existing file when only generatedAt differs', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'refresh-sources-'));
+    const first = await writeRefreshSourcesReport(tempDir, createSummary());
+
+    expect(first.changed).toBe(true);
+
+    const second = await writeRefreshSourcesReport(
+      tempDir,
+      createSummary({ generatedAt: '2026-07-05T00:00:00.000Z' }),
+    );
+    const content = JSON.parse(await readFile(second.filePath, 'utf8'));
+
+    expect(second.changed).toBe(false);
+    expect(content.generatedAt).toBe('2026-07-04T00:00:00.000Z');
+  });
+});

--- a/tools/scripts/sync-example-upstreams/src/write-refresh-sources-report.ts
+++ b/tools/scripts/sync-example-upstreams/src/write-refresh-sources-report.ts
@@ -1,0 +1,91 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { RefreshSourceReport, SyncSummary } from './types';
+
+const PARTSLIST_SOURCE = {
+  repository: 'chirimen-oh/chirimen.org',
+  branch: 'master',
+  path: '_data/partslist.csv',
+} as const;
+
+function findPartslistCommit(summary: SyncSummary): string | null {
+  return (
+    summary.sources.find(
+      (source) =>
+        source.repo === PARTSLIST_SOURCE.repository &&
+        source.branch === PARTSLIST_SOURCE.branch,
+    )?.commitSha ?? null
+  );
+}
+
+export function buildRefreshSourceReport(
+  summary: SyncSummary,
+  generatedAt = new Date().toISOString(),
+): RefreshSourceReport {
+  return {
+    generatedAt,
+    partslist: {
+      ...PARTSLIST_SOURCE,
+      commit: findPartslistCommit(summary),
+    },
+    examples: summary.sources.map((source) => ({
+      sourceId: source.sourceId,
+      repository: source.repo,
+      branch: source.branch,
+      path: source.path,
+      platform: source.platform,
+      commit: source.commitSha ?? null,
+    })),
+  };
+}
+
+function sourceState(
+  report: RefreshSourceReport,
+): Omit<RefreshSourceReport, 'generatedAt'> {
+  return {
+    partslist: report.partslist,
+    examples: report.examples,
+  };
+}
+
+function hasSameSourceState(
+  current: RefreshSourceReport,
+  next: RefreshSourceReport,
+): boolean {
+  return (
+    JSON.stringify(sourceState(current)) === JSON.stringify(sourceState(next))
+  );
+}
+
+export async function writeRefreshSourcesReport(
+  repoRoot: string,
+  summary: SyncSummary,
+): Promise<{ filePath: string; changed: boolean }> {
+  const filePath = path.join(
+    repoRoot,
+    'generated/reports/refresh-sources.json',
+  );
+  const nextReport = buildRefreshSourceReport(summary, summary.generatedAt);
+
+  try {
+    const existing = JSON.parse(
+      await readFile(filePath, 'utf8'),
+    ) as RefreshSourceReport;
+
+    if (hasSameSourceState(existing, nextReport)) {
+      return { filePath, changed: false };
+    }
+  } catch (err: unknown) {
+    if (
+      !(err instanceof Error) ||
+      !('code' in err) ||
+      (err as NodeJS.ErrnoException).code !== 'ENOENT'
+    ) {
+      throw err;
+    }
+  }
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(nextReport, null, 2)}\n`, 'utf8');
+  return { filePath, changed: true };
+}


### PR DESCRIPTION
## Summary

Issue #225 に対応し、`refresh-devices` workflow 実行時に `partslist.csv` と upstream example repository の取得元 commit hash を追跡できる `generated/reports/refresh-sources.json` を生成するようにしました。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #225

## What changed?

- `sync-example-upstreams` 実行時に `generated/reports/refresh-sources.json` を生成
- `partslist.csv` の取得元として `chirimen-oh/chirimen.org` / `master` の commit hash を記録
- `data/example-upstreams/sources.yaml` の各 upstream source について repository / branch / path / platform / commit hash を記録
- commit hash が変わらない場合は `generatedAt` だけでは report を書き換えないようにし、不要な差分を抑制
- `refresh-devices` workflow の自動 PR 本文に hash report のレビュー観点を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details: なし
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: なし

## How to test

1. `pnpm exec prettier --check tools/scripts/sync-example-upstreams/src/main.ts tools/scripts/sync-example-upstreams/src/write-refresh-sources-report.ts tools/scripts/sync-example-upstreams/src/write-refresh-sources-report.spec.ts tools/scripts/sync-example-upstreams/src/types.ts .github/workflows/refresh-devices.yml`
2. `pnpm nx run sync-example-upstreams:test`
3. `pnpm nx run sync-devices:test`
4. `pnpm nx run generate-platform-examples:test`
5. `pnpm nx run validate-platform-examples:test`

## Environment (if relevant)

- Browser: N/A
- OS: macOS / Linux
- Node version: 24
- pnpm version: 11.8.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)