### PR TITLE
fix(workspace): resolve tools scripts lint errors

### DIFF
--- a/tools/scripts/generate-platform-examples/tsconfig.app.json
+++ b/tools/scripts/generate-platform-examples/tsconfig.app.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/tools/scripts/generate-platform-examples/tsconfig.app.json
+++ b/tools/scripts/generate-platform-examples/tsconfig.app.json
@@ -1,10 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "node16",
-    "moduleResolution": "node16",
-    "types": ["node"]
+    "outDir": "../../../dist/out-tsc"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/tools/scripts/generate-platform-examples/tsconfig.json
+++ b/tools/scripts/generate-platform-examples/tsconfig.json
@@ -8,6 +8,11 @@
     }
   ],
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "types": ["node"]
   }
 }

--- a/tools/scripts/generate-platform-examples/tsconfig.lib.json
+++ b/tools/scripts/generate-platform-examples/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "outDir": "../../../dist/out-tsc/tools/scripts/generate-platform-examples",
     "declaration": true,
     "declarationMap": true,
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "es2022",
     "lib": ["es2022"],
     "types": ["node"]

--- a/tools/scripts/generate-platform-examples/tsconfig.lib.json
+++ b/tools/scripts/generate-platform-examples/tsconfig.lib.json
@@ -3,12 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc/tools/scripts/generate-platform-examples",
     "declaration": true,
-    "declarationMap": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "es2022",
-    "lib": ["es2022"],
-    "types": ["node"]
+    "declarationMap": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]

--- a/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples.spec.ts
+++ b/tools/scripts/sync-devices/src/bootstrap-legacy-platform-examples.spec.ts
@@ -77,10 +77,14 @@ describe('bootstrapLegacyPlatformExamples', () => {
       }
     );
 
-    expect(entry?.platform).toBe('chirimen');
-    expect(entry?.status).toBe('legacy');
-    expect(entry?.circuitUrl).toBe('https://example.com/circuit.zip');
-    expect(isPlatformSpecificExample(entry!)).toBe(true);
+    expect(entry).toBeDefined();
+    if (!entry) {
+      throw new Error('Expected a legacy platform example entry');
+    }
+    expect(entry.platform).toBe('chirimen');
+    expect(entry.status).toBe('legacy');
+    expect(entry.circuitUrl).toBe('https://example.com/circuit.zip');
+    expect(isPlatformSpecificExample(entry)).toBe(true);
   });
 
   it('bootstraps legacy devices into platform example entries', () => {

--- a/tools/scripts/sync-devices/tsconfig.app.json
+++ b/tools/scripts/sync-devices/tsconfig.app.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/tools/scripts/sync-devices/tsconfig.app.json
+++ b/tools/scripts/sync-devices/tsconfig.app.json
@@ -1,10 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "node16",
-    "moduleResolution": "node16",
-    "types": ["node"]
+    "outDir": "../../../dist/out-tsc"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/tools/scripts/sync-devices/tsconfig.json
+++ b/tools/scripts/sync-devices/tsconfig.json
@@ -8,6 +8,11 @@
     }
   ],
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "types": ["node"]
   }
 }

--- a/tools/scripts/sync-devices/tsconfig.lib.json
+++ b/tools/scripts/sync-devices/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "outDir": "../../../dist/out-tsc/tools/scripts/sync-devices",
     "declaration": true,
     "declarationMap": true,
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],

--- a/tools/scripts/sync-devices/tsconfig.lib.json
+++ b/tools/scripts/sync-devices/tsconfig.lib.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc/tools/scripts/sync-devices",
     "declaration": true,
-    "declarationMap": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "types": ["node"]
+    "declarationMap": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]

--- a/tools/scripts/sync-example-upstreams/tsconfig.app.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.app.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/tools/scripts/sync-example-upstreams/tsconfig.app.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.app.json
@@ -1,10 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "node16",
-    "moduleResolution": "node16",
-    "types": ["node"]
+    "outDir": "../../../dist/out-tsc"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/tools/scripts/sync-example-upstreams/tsconfig.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.json
@@ -8,6 +8,11 @@
     }
   ],
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "types": ["node"]
   }
 }

--- a/tools/scripts/sync-example-upstreams/tsconfig.lib.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "outDir": "../../../dist/out-tsc/tools/scripts/sync-example-upstreams",
     "declaration": true,
     "declarationMap": true,
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "es2022",
     "lib": ["es2022"],
     "types": ["node"]

--- a/tools/scripts/sync-example-upstreams/tsconfig.lib.json
+++ b/tools/scripts/sync-example-upstreams/tsconfig.lib.json
@@ -3,12 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc/tools/scripts/sync-example-upstreams",
     "declaration": true,
-    "declarationMap": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "es2022",
-    "lib": ["es2022"],
-    "types": ["node"]
+    "declarationMap": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]

--- a/tools/scripts/validate-platform-examples/tsconfig.app.json
+++ b/tools/scripts/validate-platform-examples/tsconfig.app.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/tools/scripts/validate-platform-examples/tsconfig.app.json
+++ b/tools/scripts/validate-platform-examples/tsconfig.app.json
@@ -1,10 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../../dist/out-tsc",
-    "module": "node16",
-    "moduleResolution": "node16",
-    "types": ["node"]
+    "outDir": "../../../dist/out-tsc"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
 }

--- a/tools/scripts/validate-platform-examples/tsconfig.json
+++ b/tools/scripts/validate-platform-examples/tsconfig.json
@@ -8,6 +8,11 @@
     }
   ],
   "compilerOptions": {
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "types": ["node"]
   }
 }

--- a/tools/scripts/validate-platform-examples/tsconfig.lib.json
+++ b/tools/scripts/validate-platform-examples/tsconfig.lib.json
@@ -4,7 +4,8 @@
     "outDir": "../../../dist/out-tsc/tools/scripts/validate-platform-examples",
     "declaration": true,
     "declarationMap": true,
-    "module": "commonjs",
+    "module": "node16",
+    "moduleResolution": "node16",
     "target": "es2022",
     "lib": ["es2022"],
     "types": ["node"]

--- a/tools/scripts/validate-platform-examples/tsconfig.lib.json
+++ b/tools/scripts/validate-platform-examples/tsconfig.lib.json
@@ -3,12 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc/tools/scripts/validate-platform-examples",
     "declaration": true,
-    "declarationMap": true,
-    "module": "node16",
-    "moduleResolution": "node16",
-    "target": "es2022",
-    "lib": ["es2022"],
-    "types": ["node"]
+    "declarationMap": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]


### PR DESCRIPTION
## Summary

`tools/scripts` 配下の TypeScript / lint 設定を Node v24.x / TypeScript v6.x 前提で整理し、lint error が出ない状態にしました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #227

## What changed?

- `bootstrapLegacyExampleEntry` のテストで non-null assertion (`!`) を使わない assertion に変更しました。
- `tools/scripts/**/tsconfig.json` に `module: preserve` / `moduleResolution: bundler` / `target: ES2024` を集約しました。
- `tools/scripts/**/tsconfig.app.json` は親設定を継承し、spec/test file を app compile から除外する構成に揃えました。
- `tools/scripts/**/tsconfig.lib.json` は出力と declaration 設定だけを持つように整理しました。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details: なし
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: なし

## How to test

1. `for config in tools/scripts/*/tsconfig*.json; do pnpm exec tsc -p "$config" --noEmit || exit 1; done`
2. `pnpm nx run-many --target=build --projects=sync-devices,sync-example-upstreams,generate-platform-examples,validate-platform-examples`
3. `pnpm nx run-many --target=lint --projects=sync-devices,sync-example-upstreams,generate-platform-examples,validate-platform-examples`
4. `pnpm nx run-many --target=test --projects=sync-devices,sync-example-upstreams,generate-platform-examples,validate-platform-examples --configuration=ci`

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: v24.x
- pnpm version: 11.8.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant