### PR TITLE
feat(libs-state): support platform keyword device search

### DIFF
--- a/apps/web/src/app/pages/device-list-page/device-list-page.component.html
+++ b/apps/web/src/app/pages/device-list-page/device-list-page.component.html
@@ -8,7 +8,7 @@
         matInput
         [ngModel]="query()"
         (ngModelChange)="onQueryChange($event)"
-        placeholder="名前・タグ・カテゴリ・説明"
+        placeholder="名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）"
       />
     </mat-form-field>
     <mat-button-toggle-group

--- a/libs/devices/state/src/lib/device-list.store.spec.ts
+++ b/libs/devices/state/src/lib/device-list.store.spec.ts
@@ -1,0 +1,157 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  DEVICE_REPOSITORY,
+  type DeviceRepository,
+} from '@chirimen-device-dashboard/libs-data-access';
+import type { DeviceInfo } from '@chirimen-device-dashboard/shared-types';
+import { firstValueFrom, of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DeviceListStore } from './device-list.store';
+
+const devices: DeviceInfo[] = [
+  {
+    id: 'i2c-adt7410',
+    deviceName: 'ADT7410',
+    tag: 'I2C',
+    category: '温度センサ',
+    description: '温度センサ',
+    image: 'https://example.com/adt7410.jpg',
+    product: {
+      url: 'https://example.com/adt7410',
+      example: [
+        {
+          hardware: 'Pi Zero',
+          code: 'https://example.com/pizero/adt7410',
+          platform: 'pizero-esm',
+          deviceId: 'adt7410',
+        },
+      ],
+    },
+  },
+  {
+    id: 'i2c-ads1015',
+    deviceName: 'ADS1015',
+    tag: 'I2C',
+    category: 'ADC',
+    description: 'アナログ電圧測定',
+    image: 'https://example.com/ads1015.jpg',
+    product: {
+      url: 'https://example.com/ads1015',
+      example: [
+        {
+          hardware: 'chirimen',
+          code: 'https://example.com/legacy/ads1015',
+          platform: 'legacy-gc-i2c',
+          deviceId: 'ads1015',
+        },
+      ],
+    },
+  },
+  {
+    id: 'i2c-ads1115',
+    deviceName: 'ADS1115',
+    tag: 'I2C',
+    category: 'ADC',
+    description: 'アナログ電圧測定',
+    image: 'https://example.com/ads1115.jpg',
+    product: {
+      url: 'https://example.com/ads1115',
+      example: [
+        {
+          hardware: 'micro:bit',
+          code: 'https://example.com/microbit/ads1115',
+          platform: 'microbit-driver',
+          deviceId: 'ads1115',
+        },
+      ],
+    },
+  },
+  {
+    id: 'gpio-led',
+    deviceName: 'LED',
+    tag: 'GPIO',
+    category: 'LED',
+    description: 'LED',
+    image: 'https://example.com/led.jpg',
+    product: {
+      url: 'https://example.com/led',
+      example: [
+        {
+          hardware: 'Pi Zero',
+          code: 'https://example.com/pizero/led',
+          platform: 'pizero-esm',
+          deviceId: 'led',
+        },
+      ],
+    },
+  },
+];
+
+const mockRepository: DeviceRepository = {
+  list: () => of(devices),
+  get: () => of(null),
+};
+
+describe('DeviceListStore', () => {
+  let store: DeviceListStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DeviceListStore,
+        { provide: DEVICE_REPOSITORY, useValue: mockRepository },
+      ],
+    });
+
+    store = TestBed.inject(DeviceListStore);
+    store.patchState({ devices });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  async function filteredIds(query: string): Promise<string[]> {
+    store.setQuery(query);
+    const filteredDevices = await firstValueFrom(store.filteredDevices$);
+    return filteredDevices.map((device) => device.id);
+  }
+
+  it('preserves existing single keyword search', async () => {
+    await expect(filteredIds('adt')).resolves.toEqual(['i2c-adt7410']);
+  });
+
+  it('matches microbit and micro:bit platform keywords', async () => {
+    await expect(filteredIds('microbit')).resolves.toEqual(['i2c-ads1115']);
+    await expect(filteredIds('micro:bit')).resolves.toEqual(['i2c-ads1115']);
+  });
+
+  it('matches raspberry platform keywords', async () => {
+    await expect(filteredIds('raspberry')).resolves.toEqual([
+      'i2c-adt7410',
+      'i2c-ads1015',
+      'gpio-led',
+    ]);
+  });
+
+  it('does not treat legacy GC I2C as Pi Zero compatible', async () => {
+    await expect(filteredIds('pi zero')).resolves.toEqual([
+      'i2c-adt7410',
+      'gpio-led',
+    ]);
+  });
+
+  it('filters by multiple keywords with AND semantics', async () => {
+    await expect(filteredIds('i2c raspberry')).resolves.toEqual([
+      'i2c-adt7410',
+      'i2c-ads1015',
+    ]);
+  });
+
+  it('ignores extra whitespace and keyword casing', async () => {
+    await expect(filteredIds('  I2C   RASPBERRY  ')).resolves.toEqual([
+      'i2c-adt7410',
+      'i2c-ads1015',
+    ]);
+  });
+});

--- a/libs/devices/state/src/lib/device-list.store.ts
+++ b/libs/devices/state/src/lib/device-list.store.ts
@@ -28,16 +28,79 @@ const initialState: DeviceListState = {
   filterCategory: undefined,
 };
 
+const PLATFORM_SEARCH_ALIASES: Record<string, readonly string[]> = {
+  'pizero-esm': [
+    'raspberry',
+    'raspberry pi',
+    'raspberry pi 3',
+    'raspberry pi 4',
+    'raspberry pi 5',
+    'raspberry pi zero',
+    'raspberry pi zero 2',
+    'pi zero',
+    'zero 2',
+    'pizero',
+  ],
+  'microbit-driver': ['microbit', 'micro:bit', 'micro bit'],
+  'legacy-gc-i2c': [
+    'raspberry',
+    'raspberry pi',
+    'raspberry pi 3',
+    'raspberry pi 4',
+    'raspberry pi 5',
+  ],
+};
+
+function isSearchableValue(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function getHardwareAliases(hardware: string): string[] {
+  const value = hardware.toLowerCase();
+  const aliases: string[] = [];
+
+  if (value.includes('micro:bit') || value.includes('microbit'))
+    aliases.push('microbit', 'micro:bit', 'micro bit');
+
+  if (value.includes('pi zero') || value.includes('pizero'))
+    aliases.push('raspberry', 'raspberry pi', 'raspberry pi zero', 'pi zero');
+
+  return aliases;
+}
+
+function buildSearchIndex(device: DeviceInfo): string {
+  const deviceTerms = [
+    device.id,
+    device.deviceName,
+    device.tag,
+    device.category,
+    device.description,
+  ];
+
+  const exampleTerms = device.product.example.flatMap((example) => [
+    example.hardware,
+    example.platform,
+    example.deviceId,
+    example.upstreamPath,
+    ...(isSearchableValue(example.platform)
+      ? (PLATFORM_SEARCH_ALIASES[example.platform] ?? [])
+      : []),
+    ...(isSearchableValue(example.hardware)
+      ? getHardwareAliases(example.hardware)
+      : []),
+  ]);
+
+  return [...deviceTerms, ...exampleTerms]
+    .filter(isSearchableValue)
+    .join(' ')
+    .toLowerCase();
+}
+
 function matchesQuery(device: DeviceInfo, query: string): boolean {
   if (!query.trim()) return true;
-  const q = query.trim().toLowerCase();
-  return (
-    device.id.toLowerCase().includes(q) ||
-    device.deviceName.toLowerCase().includes(q) ||
-    device.tag.toLowerCase().includes(q) ||
-    device.category.toLowerCase().includes(q) ||
-    device.description.toLowerCase().includes(q)
-  );
+  const keywords = query.trim().toLowerCase().split(/\s+/);
+  const searchIndex = buildSearchIndex(device);
+  return keywords.every((keyword) => searchIndex.includes(keyword));
 }
 
 export class DeviceListStore extends ComponentStore<DeviceListState> {


### PR DESCRIPTION
## Summary

Issue #213 に対応し、デバイス一覧の検索ボックスで対応環境キーワードと複数キーワード検索を使えるようにしました。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #213

## What changed?

- `product.example` の `hardware` / `platform` を検索対象に追加しました。
- `raspberry`、`pi zero`、`microbit`、`micro:bit` などの対応環境キーワードを platform に紐づけて検索できるようにしました。
- `i2c raspberry` のような空白区切りの複数キーワードを AND 条件で絞り込めるようにしました。
- 検索ボックスの placeholder と、検索ロジックの回帰テストを追加しました。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details: 公開 API のシグネチャ変更はありません。デバイス一覧検索の振る舞いを拡張しています。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx test libs-state --configuration=ci`
2. `pnpm nx lint web`
3. `pnpm nx test web --configuration=ci`

## Environment (if relevant)

- Browser: 未確認
- OS: macOS
- Node version: 未確認
- pnpm version: 11.8.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)