### PR TITLE
fix(web): prevent search placeholder clipping

### DIFF
--- a/apps/web/src/app/pages/device-list-page/device-list-page.component.html
+++ b/apps/web/src/app/pages/device-list-page/device-list-page.component.html
@@ -1,8 +1,8 @@
 <div class="flex flex-col flex-1 min-h-0 overflow-hidden">
   <div
-    class="flex-shrink-0 flex items-center justify-between gap-4 py-2 px-4 border-b border-black/12 dark:border-white/12"
+    class="flex-shrink-0 flex items-start justify-between gap-4 py-2 px-4 border-b border-black/12 dark:border-white/12"
   >
-    <mat-form-field appearance="outline" class="min-w-0 flex-1">
+    <mat-form-field appearance="outline" class="min-w-0 flex-1 max-w-[32rem]">
       <mat-label>検索</mat-label>
       <input
         matInput
@@ -13,7 +13,7 @@
       <mat-hint>名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）</mat-hint>
     </mat-form-field>
     <mat-button-toggle-group
-      class="flex-shrink-0"
+      class="h-14 flex-shrink-0"
       [value]="viewMode()"
       (valueChange)="setViewMode($event)"
       aria-label="表示形式"

--- a/apps/web/src/app/pages/device-list-page/device-list-page.component.html
+++ b/apps/web/src/app/pages/device-list-page/device-list-page.component.html
@@ -2,16 +2,18 @@
   <div
     class="flex-shrink-0 flex items-center justify-between gap-4 py-2 px-4 border-b border-black/12 dark:border-white/12"
   >
-    <mat-form-field appearance="outline" class="flex-1 max-w-96">
+    <mat-form-field appearance="outline" class="min-w-0 flex-1">
       <mat-label>検索</mat-label>
       <input
         matInput
         [ngModel]="query()"
         (ngModelChange)="onQueryChange($event)"
-        placeholder="名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）"
+        placeholder="デバイスを検索"
       />
+      <mat-hint>名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）</mat-hint>
     </mat-form-field>
     <mat-button-toggle-group
+      class="flex-shrink-0"
       [value]="viewMode()"
       (valueChange)="setViewMode($event)"
       aria-label="表示形式"

--- a/apps/web/src/app/pages/device-list-page/device-list-page.component.html
+++ b/apps/web/src/app/pages/device-list-page/device-list-page.component.html
@@ -2,24 +2,24 @@
   <div
     class="flex-shrink-0 flex flex-col items-stretch gap-2 py-2 px-4 border-b border-black/12 dark:border-white/12 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
   >
-    <mat-form-field
-      appearance="outline"
-      class="w-full min-w-0 sm:flex-1 sm:max-w-[32rem]"
-    >
-      <mat-label>検索</mat-label>
-      <input
-        matInput
-        [ngModel]="query()"
-        (ngModelChange)="onQueryChange($event)"
-        placeholder="デバイスを検索"
-      />
-      <mat-hint>
-        <span class="sm:hidden">例: i2c raspberry</span>
-        <span class="hidden sm:inline">
+    <div class="w-full min-w-0 sm:flex-1 sm:max-w-[32rem]">
+      <mat-form-field appearance="outline" class="w-full">
+        <mat-label>検索</mat-label>
+        <input
+          matInput
+          [ngModel]="query()"
+          (ngModelChange)="onQueryChange($event)"
+          placeholder="デバイスを検索"
+        />
+        <mat-hint class="hidden sm:block">
           名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）
-        </span>
-      </mat-hint>
-    </mat-form-field>
+        </mat-hint>
+      </mat-form-field>
+      <p class="-mt-4 mb-0 px-4 text-xs leading-tight text-black/60 dark:text-white/70 sm:hidden">
+        名前・タグ・カテゴリ・説明・対応環境<br />
+        （例: i2c raspberry）
+      </p>
+    </div>
     <mat-button-toggle-group
       class="flex-shrink-0 self-start sm:mt-1"
       [value]="viewMode()"

--- a/apps/web/src/app/pages/device-list-page/device-list-page.component.html
+++ b/apps/web/src/app/pages/device-list-page/device-list-page.component.html
@@ -13,7 +13,7 @@
       <mat-hint>名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）</mat-hint>
     </mat-form-field>
     <mat-button-toggle-group
-      class="h-14 flex-shrink-0"
+      class="mt-1 flex-shrink-0"
       [value]="viewMode()"
       (valueChange)="setViewMode($event)"
       aria-label="表示形式"

--- a/apps/web/src/app/pages/device-list-page/device-list-page.component.html
+++ b/apps/web/src/app/pages/device-list-page/device-list-page.component.html
@@ -1,8 +1,11 @@
 <div class="flex flex-col flex-1 min-h-0 overflow-hidden">
   <div
-    class="flex-shrink-0 flex items-start justify-between gap-4 py-2 px-4 border-b border-black/12 dark:border-white/12"
+    class="flex-shrink-0 flex flex-col items-stretch gap-2 py-2 px-4 border-b border-black/12 dark:border-white/12 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
   >
-    <mat-form-field appearance="outline" class="min-w-0 flex-1 max-w-[32rem]">
+    <mat-form-field
+      appearance="outline"
+      class="w-full min-w-0 sm:flex-1 sm:max-w-[32rem]"
+    >
       <mat-label>検索</mat-label>
       <input
         matInput
@@ -10,10 +13,15 @@
         (ngModelChange)="onQueryChange($event)"
         placeholder="デバイスを検索"
       />
-      <mat-hint>名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）</mat-hint>
+      <mat-hint>
+        <span class="sm:hidden">例: i2c raspberry</span>
+        <span class="hidden sm:inline">
+          名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）
+        </span>
+      </mat-hint>
     </mat-form-field>
     <mat-button-toggle-group
-      class="mt-1 flex-shrink-0"
+      class="flex-shrink-0 self-start sm:mt-1"
       [value]="viewMode()"
       (valueChange)="setViewMode($event)"
       aria-label="表示形式"


### PR DESCRIPTION
## Summary

Safari で検索ボックスにフォーカスしたとき、長い placeholder が入力欄内で見切れないようにしました。あわせてスマホ縦表示でも検索欄・hint・表示切替が崩れないようにしました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #230

## What changed?

- 検索入力の placeholder を短い文言に変更し、検索対象と例は補助テキストとして表示するようにしました。
- 検索フォームの最大幅を設定し、hint を使っても横に広がりすぎないようにしました。
- 検索フォームと表示切替ボタンの上端と高さが揃うように、ヘッダー内の配置とトグル余白を調整しました。
- スマホ縦表示では検索欄と表示切替を縦積みにし、検索対象と例の全文を 2 行の補助テキストとして表示することで横溢れと見切れを防ぎました。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx lint web`
2. `pnpm nx build web`
3. WebKit/Safari 相当のブラウザで検索ボックスにフォーカスし、placeholder が見切れず、検索欄と表示切替ボタンの高さが揃うことを確認
4. iPhone 17 縦表示相当（393px 幅）で「名前・タグ・カテゴリ・説明・対応環境（例: i2c raspberry）」が全文表示され、横溢れしないことを確認

## Environment (if relevant)

- Browser: WebKit / Safari 相当
- OS: macOS
- Node version: v24.16.0
- pnpm version: 11.8.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant