### PR TITLE
fix(generate-platform-examples): skip hard validation for new platforms

### DIFF
--- a/apps/web/public/devices.json
+++ b/apps/web/public/devices.json
@@ -154,6 +154,23 @@
     }
   },
   {
+    "id": "i2c-mcp9808",
+    "deviceName": "MCP9808",
+    "tag": "I2C",
+    "category": "温度センサ",
+    "description": "高精度に温度を測定できるセンサです(分解能を0.0625℃〜0.5℃の4段階で設定可能)",
+    "image": "./no_image.png",
+    "product": {
+      "url": "",
+      "example": [
+        {
+          "hardware": "piZero",
+          "code": "https://chirimen.org/pizero/esm-examples/#I2C_mcp9808"
+        }
+      ]
+    }
+  },
+  {
     "id": "i2c-amg8833",
     "deviceName": "AMG8833",
     "tag": "I2C",
@@ -846,7 +863,7 @@
       "example": [
         {
           "hardware": "piZero",
-          "code": "https://tutorial.chirimen.org/pizero/esm-examples/#I2C_as7341"
+          "code": "https://chirimen.org/pizero/esm-examples/#I2C_as7341"
         }
       ],
       "datasheet": "https://www.mouser.jp/datasheet/3/5912/1/AS7341_DS000504_3_00.pdf"
@@ -993,6 +1010,23 @@
         }
       ],
       "reference": "http://wiki.seeedstudio.com/Grove-3-Axis_Digital_Accelerometer-16g/"
+    }
+  },
+  {
+    "id": "i2c-mma7660",
+    "deviceName": "MMA7660",
+    "tag": "I2C",
+    "category": "3軸加速度センサ",
+    "description": "3軸の加速度を検出できるセンサです",
+    "image": "./no_image.png",
+    "product": {
+      "url": "",
+      "example": [
+        {
+          "hardware": "piZero",
+          "code": "https://chirimen.org/pizero/esm-examples/#I2C_mma7660"
+        }
+      ]
     }
   },
   {
@@ -1835,6 +1869,27 @@
         {
           "hardware": "chirimen",
           "code": "http://chirimen.org/chirimen/gc/top/examples/#I2C-APDS9960"
+        },
+        {
+          "hardware": "piZero",
+          "code": "https://chirimen.org/pizero/esm-examples/#I2C_apds9960"
+        }
+      ]
+    }
+  },
+  {
+    "id": "i2c-apds9930",
+    "deviceName": "APDS9930",
+    "tag": "I2C",
+    "category": "近接・環境光センサー",
+    "description": "近接・環境光を読み取るセンサー",
+    "image": "https://raw.githubusercontent.com/chirimen-oh/chirimen.org/master/partsImgs/APDS9930.jpg",
+    "product": {
+      "url": "",
+      "example": [
+        {
+          "hardware": "piZero",
+          "code": "https://chirimen.org/pizero/esm-examples/#I2C_apds9930"
         }
       ]
     }
@@ -2669,7 +2724,7 @@
           "verified": false
         }
       ],
-      "circuit": "https://tutorial.chirimen.org/pizero/esm-examples/gpio-onchange/index.html#gpio",
+      "circuit": "https://chirimen.org/pizero/esm-examples/gpio-onchange/index.html#gpio",
       "datasheet": "https://files.seeedstudio.com/wiki/Grove-Touch_Sensor/res/TTP223.pdf"
     }
   },
@@ -2938,7 +2993,12 @@
     "image": "https://raw.githubusercontent.com/chirimen-oh/chirimen.org/master/partsImgs/TB6612FNG.jpg",
     "product": {
       "url": "https://www.switch-science.com/catalog/385/",
-      "example": [],
+      "example": [
+        {
+          "hardware": "piZero",
+          "code": "https://chirimen.org/pizero/esm-examples/#GPIO_tb6612fng"
+        }
+      ],
       "datasheet": "http://doc.switch-science.com/datasheets/TB6612FNG_datasheet_ja_20141001.pdf"
     }
   },

--- a/data/platform-examples/platform-examples.generated.json
+++ b/data/platform-examples/platform-examples.generated.json
@@ -140,6 +140,26 @@
     ]
   },
   {
+    "dashboardDeviceId": "gpio-tb6612fng",
+    "exampleDeviceId": "tb6612fng",
+    "examples": [
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tb6612fng",
+        "deviceId": "tb6612fng",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/tb6612fng/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/tb6612fng",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/tb6612fng",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/tb6612fng/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-ads1015",
     "exampleDeviceId": "ads1015",
     "examples": [
@@ -316,6 +336,45 @@
     ]
   },
   {
+    "dashboardDeviceId": "i2c-apds9930",
+    "exampleDeviceId": "apds9930",
+    "examples": [
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/apds9930",
+        "deviceId": "apds9930",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/apds9930/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/apds9930",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/apds9930",
+        "status": "primary",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-apds9960",
+    "exampleDeviceId": "apds9960",
+    "examples": [
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/apds9960",
+        "deviceId": "apds9960",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/apds9960/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/apds9960",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/apds9960",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/apds9960/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-as3935",
     "exampleDeviceId": "as3935",
     "examples": [
@@ -474,6 +533,19 @@
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/bme680/imgs/pinbit_bme680.png",
         "verified": false
+      },
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme680",
+        "deviceId": "bme680",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/bme680/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/bme680",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/bme680",
+        "status": "primary",
+        "verified": false
       }
     ]
   },
@@ -561,6 +633,19 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen-drivers/tree/master/microbit-examples/ccs811",
         "status": "legacy",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen-drivers/blob/master/microbit-examples/ccs811/imgs/pinbit_ccs811.png",
+        "verified": false
+      },
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ccs811",
+        "deviceId": "ccs811",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/ccs811/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/ccs811",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/ccs811",
+        "status": "primary",
         "verified": false
       }
     ]
@@ -1028,6 +1113,26 @@
     ]
   },
   {
+    "dashboardDeviceId": "i2c-mcp9808",
+    "exampleDeviceId": "mcp9808",
+    "examples": [
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mcp9808",
+        "deviceId": "mcp9808",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/mcp9808/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/mcp9808",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mcp9808",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mcp9808/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
     "dashboardDeviceId": "i2c-mlx90614",
     "exampleDeviceId": "mlx90614",
     "examples": [
@@ -1057,6 +1162,26 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mlx90614",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mlx90614/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-mma7660",
+    "exampleDeviceId": "mma7660",
+    "examples": [
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mma7660",
+        "deviceId": "mma7660",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/mma7660/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/mma7660",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/mma7660",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/mma7660/schematic.png",
         "verified": false
       }
     ]
@@ -1417,6 +1542,26 @@
         "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/scd40",
         "status": "primary",
         "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/scd40/schematic.png",
+        "verified": false
+      }
+    ]
+  },
+  {
+    "dashboardDeviceId": "i2c-seesaw",
+    "exampleDeviceId": "seesaw",
+    "examples": [
+      {
+        "hardware": "Pi Zero",
+        "code": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/seesaw",
+        "deviceId": "seesaw",
+        "platform": "pizero-esm",
+        "localPath": "examples/devices/seesaw/platforms/pizero-esm",
+        "upstreamRepository": "chirimen-oh/chirimen.org",
+        "upstreamRepositoryUrl": "https://github.com/chirimen-oh/chirimen.org",
+        "upstreamPath": "pizero/src/esm-examples/seesaw",
+        "upstreamPathUrl": "https://github.com/chirimen-oh/chirimen.org/tree/master/pizero/src/esm-examples/seesaw",
+        "status": "primary",
+        "circuitUrl": "https://github.com/chirimen-oh/chirimen.org/blob/master/pizero/src/esm-examples/seesaw/schematic.png",
         "verified": false
       }
     ]

--- a/tools/scripts/generate-platform-examples/src/generate-platform-examples.spec.ts
+++ b/tools/scripts/generate-platform-examples/src/generate-platform-examples.spec.ts
@@ -3,6 +3,7 @@ import type { ExampleInfo } from '@chirimen-device-dashboard/shared-types';
 import {
   buildPlatformExamplesJson,
   generatePlatformExamples,
+  listNewGeneratedPlatforms,
   selectCanonicalGeneratedEntries,
 } from './generate-platform-examples';
 import type { ExampleCandidateEntry, PlatformExampleDeviceEntry } from './types';
@@ -96,6 +97,92 @@ describe('selectCanonicalGeneratedEntries', () => {
     ];
 
     expect(selectCanonicalGeneratedEntries(generated, [])).toEqual([]);
+  });
+
+  it('omits newly discovered platforms that are not in canonical data', () => {
+    const microbit = makeExample('microbit-driver', {
+      hardware: 'micro:bit',
+      status: 'legacy',
+      deviceId: 'bme680',
+    });
+    const canonical: PlatformExampleDeviceEntry[] = [
+      {
+        dashboardDeviceId: 'i2c-bme680',
+        exampleDeviceId: 'bme680',
+        examples: [microbit],
+      },
+    ];
+    const generated: PlatformExampleDeviceEntry[] = [
+      {
+        dashboardDeviceId: 'i2c-bme680',
+        exampleDeviceId: 'bme680',
+        examples: [
+          microbit,
+          makeExample('pizero-esm', {
+            deviceId: 'bme680',
+            circuitUrl: undefined,
+          }),
+        ],
+      },
+    ];
+
+    expect(selectCanonicalGeneratedEntries(generated, canonical)).toEqual([
+      {
+        dashboardDeviceId: 'i2c-bme680',
+        exampleDeviceId: 'bme680',
+        examples: [microbit],
+      },
+    ]);
+  });
+});
+
+describe('listNewGeneratedPlatforms', () => {
+  it('lists platforms that are absent from canonical data', () => {
+    const canonical: PlatformExampleDeviceEntry[] = [
+      {
+        dashboardDeviceId: 'i2c-bme680',
+        exampleDeviceId: 'bme680',
+        examples: [
+          makeExample('microbit-driver', {
+            hardware: 'micro:bit',
+            status: 'legacy',
+            deviceId: 'bme680',
+          }),
+        ],
+      },
+    ];
+    const generated: PlatformExampleDeviceEntry[] = [
+      {
+        dashboardDeviceId: 'i2c-bme680',
+        exampleDeviceId: 'bme680',
+        examples: [
+          makeExample('microbit-driver', {
+            hardware: 'micro:bit',
+            status: 'legacy',
+            deviceId: 'bme680',
+          }),
+          makeExample('pizero-esm', {
+            deviceId: 'bme680',
+            circuitUrl: undefined,
+          }),
+        ],
+      },
+      {
+        dashboardDeviceId: 'i2c-max30102',
+        exampleDeviceId: 'max30102',
+        examples: [
+          makeExample('pizero-esm', {
+            deviceId: 'max30102',
+            circuitUrl: undefined,
+          }),
+        ],
+      },
+    ];
+
+    expect(listNewGeneratedPlatforms(generated, canonical)).toEqual([
+      { dashboardDeviceId: 'i2c-bme680', platform: 'pizero-esm' },
+      { dashboardDeviceId: 'i2c-max30102', platform: 'pizero-esm' },
+    ]);
   });
 });
 

--- a/tools/scripts/generate-platform-examples/src/generate-platform-examples.ts
+++ b/tools/scripts/generate-platform-examples/src/generate-platform-examples.ts
@@ -124,21 +124,96 @@ export async function loadCanonicalPlatformExamples(
   }
 }
 
+/**
+ * Pick generated examples that already exist in the canonical dataset.
+ *
+ * Only device+platform pairs present in `platform-examples.json` are returned.
+ * Newly discovered platforms (review candidates) are omitted so generate can
+ * write incomplete entries to `platform-examples.generated.json` without
+ * failing hard validation.
+ */
 export function selectCanonicalGeneratedEntries(
   entries: PlatformExampleDeviceEntry[],
   canonical: PlatformExampleDeviceEntry[]
 ): PlatformExampleDeviceEntry[] {
-  const canonicalDeviceIds = new Set(
-    canonical.map((entry) => entry.dashboardDeviceId)
+  const canonicalByDevice = new Map(
+    canonical.map((entry) => [entry.dashboardDeviceId, entry])
   );
 
-  if (canonicalDeviceIds.size === 0) {
+  if (canonicalByDevice.size === 0) {
     return [];
   }
 
-  return entries.filter((entry) =>
-    canonicalDeviceIds.has(entry.dashboardDeviceId)
+  const selected: PlatformExampleDeviceEntry[] = [];
+
+  for (const entry of entries) {
+    const canonicalEntry = canonicalByDevice.get(entry.dashboardDeviceId);
+    if (!canonicalEntry) {
+      continue;
+    }
+
+    const canonicalPlatforms = new Set(
+      canonicalEntry.examples
+        .map((example) => example.platform)
+        .filter((platform): platform is string => Boolean(platform))
+    );
+
+    const knownExamples = entry.examples.filter((example) => {
+      const platform = example.platform;
+      return typeof platform === 'string' && canonicalPlatforms.has(platform);
+    });
+
+    if (knownExamples.length === 0) {
+      continue;
+    }
+
+    selected.push({
+      ...entry,
+      examples: knownExamples,
+    });
+  }
+
+  return selected;
+}
+
+/** List generated device+platform pairs that are not in the canonical dataset. */
+export function listNewGeneratedPlatforms(
+  entries: PlatformExampleDeviceEntry[],
+  canonical: PlatformExampleDeviceEntry[]
+): Array<{ dashboardDeviceId: string; platform: string }> {
+  const canonicalPlatformsByDevice = new Map(
+    canonical.map((entry) => [
+      entry.dashboardDeviceId,
+      new Set(
+        entry.examples
+          .map((example) => example.platform)
+          .filter((platform): platform is string => Boolean(platform))
+      ),
+    ])
   );
+
+  const results: Array<{ dashboardDeviceId: string; platform: string }> = [];
+
+  for (const entry of entries) {
+    const canonicalPlatforms = canonicalPlatformsByDevice.get(
+      entry.dashboardDeviceId
+    );
+
+    for (const example of entry.examples) {
+      if (!example.platform) {
+        continue;
+      }
+
+      if (!canonicalPlatforms?.has(example.platform)) {
+        results.push({
+          dashboardDeviceId: entry.dashboardDeviceId,
+          platform: example.platform,
+        });
+      }
+    }
+  }
+
+  return results;
 }
 
 export function generatePlatformExamples(

--- a/tools/scripts/generate-platform-examples/src/main.ts
+++ b/tools/scripts/generate-platform-examples/src/main.ts
@@ -7,6 +7,7 @@ import {
 import { loadUpstreamSources } from './load-upstream-sources';
 import {
   generatePlatformExamples,
+  listNewGeneratedPlatforms,
   loadCanonicalPlatformExamples,
   selectCanonicalGeneratedEntries,
 } from './generate-platform-examples';
@@ -49,6 +50,13 @@ export async function main(): Promise<void> {
   }
 
   const entries = generatePlatformExamples(allCandidates, canonical);
+
+  const newPlatforms = listNewGeneratedPlatforms(entries, canonical);
+  for (const { dashboardDeviceId, platform } of newPlatforms) {
+    console.warn(
+      `Warning: skipping hard validation for new platform candidate ${dashboardDeviceId} [${platform}] (not in canonical platform-examples.json)`
+    );
+  }
 
   const canonicalEntries = selectCanonicalGeneratedEntries(entries, canonical);
   if (canonicalEntries.length > 0) {


### PR DESCRIPTION
> PR タイトルは [Conventional Commits](https://www.conventionalcommits.org/) に準拠してください (例: `feat(web): add device list component`)。
> 利用可能な scope は [CONTRIBUTING.md](../CONTRIBUTING.md#スコープ一覧) と `commitlint.config.js` を参照してください。

## Summary

- `pnpm generate:platform-examples` の厳格 validation 対象を、正本 `platform-examples.json` に既にある device+platform のみに限定しました
- upstream で新規に見つかった platform（例: `i2c-bme680` / `pizero-esm`）は review 用候補として `platform-examples.generated.json` へ出力しつつ、`circuitUrl` 未検出でも generate を失敗させません
- 新規候補は warning ログに出し、正本マージ時の品質ゲート（`validate-platform-examples`）は維持します

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Sync example upstreams CI failure (`circuitUrl is required` on new pizero-esm candidates)

## What changed?

- `selectCanonicalGeneratedEntries` が canonical に存在する platform のみを返すよう変更
- 新規 platform 候補を列挙する `listNewGeneratedPlatforms` を追加し、generate 時に warning を出力
- 新規 platform を validation 対象外にする回帰テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx run generate-platform-examples:test --configuration=ci`
2. `pnpm sync:example-upstreams`（任意）後に `pnpm generate:platform-examples` を実行し、`i2c-bme680` / `i2c-ccs811` の `pizero-esm` で exit code 1 にならないこと
3. warning に `skipping hard validation for new platform candidate ...` が出ることを確認

## Environment (if relevant)

- Browser:
- OS: macOS
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)