### PR TITLE
ci(ci): GitHub Actions からのプルリクエスト作成を許可する

### DIFF
--- a/.github/workflows/refresh-devices.yml
+++ b/.github/workflows/refresh-devices.yml
@@ -89,6 +89,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           branch: ${{ steps.branch.outputs.name }}
           add-paths: |
             generated/reports

--- a/.github/workflows/sync-devices.yml
+++ b/.github/workflows/sync-devices.yml
@@ -41,6 +41,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           branch: ${{ steps.branch.outputs.name }}
           add-paths: apps/web/public/devices.json
           delete-branch: true
@@ -70,5 +71,6 @@ jobs:
         if: steps.cpr.outputs.pull-request-number != ''
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash

--- a/.github/workflows/sync-example-upstreams.yml
+++ b/.github/workflows/sync-example-upstreams.yml
@@ -69,6 +69,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           branch: ${{ steps.branch.outputs.name }}
           add-paths: |
             generated/reports
@@ -111,5 +112,6 @@ jobs:
         if: steps.cpr.outputs.pull-request-number != ''
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
+          token: ${{ secrets.PAT_TOKEN || github.token }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash

--- a/data/platform-examples/README.md
+++ b/data/platform-examples/README.md
@@ -180,6 +180,8 @@ GitHub Actions から sync / generate / validate / `devices.json` 生成を実�
 
 `sync-devices.yml`（partslist.csv 由来の `devices.json` 更新）は別 workflow です。両方が `devices.json` を更新する場合は merge 時に conflict 解消が必要になることがあります。
 
+自動 PR 作成には、リポジトリ設定で **Allow GitHub Actions to create and approve pull requests** を有効にする必要があります。詳細は [デバイス情報の更新フロー](../../docs/device-data-refresh.md#自動-pr-作成に必要な権限) を参照してください。
+
 ### 自動 PR に含まれるファイル
 
 `sync-example-upstreams` workflow が作成する PR には、おおむね以下が含まれます。

--- a/docs/device-data-refresh.md
+++ b/docs/device-data-refresh.md
@@ -43,10 +43,21 @@ flowchart TD
 | Workflow | ファイル | 役割 |
 | --- | --- | --- |
 | Refresh devices data | [`.github/workflows/refresh-devices.yml`](../.github/workflows/refresh-devices.yml) | `refresh-devices` ラベル付き issue または手動実行から、同期・生成・検証・PR 作成を行う |
+| Sync example upstreams | [`.github/workflows/sync-example-upstreams.yml`](../.github/workflows/sync-example-upstreams.yml) | 毎週または手動で upstream を同期し、差分があれば自動 PR を作成する |
+| Sync devices | [`.github/workflows/sync-devices.yml`](../.github/workflows/sync-devices.yml) | `partslist.csv` から `devices.json` を更新し、差分があれば自動 PR を作成する |
 | Deploy to Firebase Hosting | [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) | `main` への push 後に build / deploy し、対象の反映依頼 issue を close する |
 | Generate devices.json | [`.github/workflows/generate-devices.yml`](../.github/workflows/generate-devices.yml) | PR / `main` で `devices.json` の生成ドリフトを検出する |
 | Generate platform examples | [`.github/workflows/generate-platform-examples.yml`](../.github/workflows/generate-platform-examples.yml) | Platform 別 Example 候補 JSON の生成ドリフトを検出する |
 | Validate platform examples | [`.github/workflows/validate-platform-examples.yml`](../.github/workflows/validate-platform-examples.yml) | 正本データと `devices.json` の整合性を検証する |
+
+### 自動 PR 作成に必要な権限
+
+`refresh-devices` / `sync-example-upstreams` / `sync-devices` は `peter-evans/create-pull-request` で更新 PR を作成します。次の 2 点が揃っていないと、`GitHub Actions is not permitted to create or approve pull requests` で失敗します。
+
+1. 各 workflow の `permissions` に `contents: write` と `pull-requests: write` があること
+2. リポジトリ設定 **Settings → Actions → General → Workflow permissions** で **Allow GitHub Actions to create and approve pull requests** が有効であること
+
+`GITHUB_TOKEN` では PR 作成できない場合、または自動 PR 上で他の workflow を動かしたい場合は、`repo` スコープを持つ Personal Access Token をリポジトリシークレット `PAT_TOKEN` として登録します。未設定時は `GITHUB_TOKEN` にフォールバックします。
 
 ## `refresh-devices` issue で実行される処理
 


### PR DESCRIPTION
## Summary

`sync-example-upstreams` が Create Pull Request ステップで `GitHub Actions is not permitted to create or approve pull requests` により失敗していた問題を修正します。workflow の YAML 権限は既に足りていたため、任意の `PAT_TOKEN` フォールバックを追加し、自動 PR 作成に必要なリポジトリ設定を文書化しました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Related to https://github.com/gurezo/chirimen-device-dashboard/actions/runs/31916856582/job/95090023036
- Part of #187

## What changed?

- `sync-example-upstreams` / `sync-devices` / `refresh-devices` の PR 作成・auto-merge に `token: ${{ secrets.PAT_TOKEN || github.token }}` を追加
- 自動 PR 作成に必要なリポジトリ設定（Allow GitHub Actions to create and approve pull requests）と任意シークレット `PAT_TOKEN` を文書化

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. リポジトリ設定 **Settings → Actions → General → Workflow permissions** で **Allow GitHub Actions to create and approve pull requests** が有効であることを確認する
2. （任意）`repo` スコープの PAT をシークレット `PAT_TOKEN` として登録する。未設定でも `GITHUB_TOKEN` にフォールバックする
3. Actions から `Sync example upstreams` を `workflow_dispatch` で再実行し、Create Pull Request ステップが成功することを確認する

## Environment (if relevant)

- Browser: N/A
- OS: ubuntu-latest
- Node version: 24
- pnpm version: `pnpm/action-setup@v4`

## Checklist

- [ ] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)